### PR TITLE
feat(#6): HIPAA-grade audit logging

### DIFF
--- a/api/alembic/env.py
+++ b/api/alembic/env.py
@@ -9,7 +9,7 @@ from sqlmodel import SQLModel
 
 from alembic import context
 from app.config import settings
-from app.models import Agency, User  # noqa: F401 — register models for autogenerate
+from app.models import Agency, AuditEvent, User  # noqa: F401 — register models for autogenerate
 
 config = context.config
 if config.config_file_name is not None:

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -1,7 +1,16 @@
 """Database models."""
 
 from app.models.agency import Agency
+from app.models.audit import AuditAction, AuditEvent
 from app.models.base import BaseModel, TenantScopedModel
 from app.models.user import User, UserRole
 
-__all__ = ["Agency", "BaseModel", "TenantScopedModel", "User", "UserRole"]
+__all__ = [
+    "Agency",
+    "AuditAction",
+    "AuditEvent",
+    "BaseModel",
+    "TenantScopedModel",
+    "User",
+    "UserRole",
+]

--- a/api/app/models/audit.py
+++ b/api/app/models/audit.py
@@ -1,0 +1,43 @@
+"""Audit event model for HIPAA-grade logging."""
+
+import enum
+import uuid
+from typing import Any
+
+from sqlalchemy import JSON
+from sqlmodel import Column, Field
+
+from app.models.base import BaseModel
+
+
+class AuditAction(enum.StrEnum):
+    """Actions that can be audited."""
+
+    CREATE = "create"
+    READ = "read"
+    UPDATE = "update"
+    DELETE = "delete"
+    LOGIN = "login"
+    LOGOUT = "logout"
+    EXPORT = "export"
+
+
+class AuditEvent(BaseModel, table=True):
+    """Immutable audit log entry. Append-only — never update or delete.
+
+    Not tenant-scoped via RLS because super-admin actions span tenants.
+    Filtering by agency_id is done at query time.
+    """
+
+    __tablename__ = "audit_events"
+
+    user_id: uuid.UUID | None = Field(default=None, index=True)
+    agency_id: uuid.UUID | None = Field(default=None, foreign_key="agencies.id", index=True)
+    action: AuditAction = Field(index=True)
+    resource_type: str = Field(index=True)
+    resource_id: str = Field(default="")
+    is_phi_access: bool = Field(default=False, index=True)
+    ip_address: str = Field(default="")
+    user_agent: str = Field(default="")
+    details: str = Field(default="")
+    changes: dict[str, Any] | None = Field(default=None, sa_column=Column(JSON, nullable=True))

--- a/api/app/services/__init__.py
+++ b/api/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer."""

--- a/api/app/services/audit.py
+++ b/api/app/services/audit.py
@@ -1,0 +1,57 @@
+"""Audit logging service for HIPAA compliance."""
+
+import uuid
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AuditAction, AuditEvent
+
+logger = structlog.get_logger()
+
+
+class AuditService:
+    """Append-only audit event writer."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def log(
+        self,
+        *,
+        action: AuditAction,
+        resource_type: str,
+        resource_id: str = "",
+        user_id: uuid.UUID | None = None,
+        agency_id: uuid.UUID | None = None,
+        is_phi_access: bool = False,
+        ip_address: str = "",
+        user_agent: str = "",
+        details: str = "",
+        changes: dict[str, Any] | None = None,
+    ) -> AuditEvent:
+        """Create an audit event. All parameters are keyword-only for clarity."""
+        event = AuditEvent(
+            user_id=user_id,
+            agency_id=agency_id,
+            action=action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            is_phi_access=is_phi_access,
+            ip_address=ip_address,
+            user_agent=user_agent,
+            details=details,
+            changes=changes,
+        )
+        self.session.add(event)
+        await self.session.flush()
+        await logger.ainfo(
+            "audit_event",
+            action=action.value,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            user_id=str(user_id) if user_id else None,
+            is_phi=is_phi_access,
+        )
+        return event

--- a/api/app/tests/test_audit.py
+++ b/api/app/tests/test_audit.py
@@ -1,0 +1,142 @@
+"""Tests for HIPAA-grade audit logging."""
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+from app.models import Agency, User  # noqa: F401 — register models for metadata
+from app.models.audit import AuditAction, AuditEvent
+from app.services.audit import AuditService
+
+TEST_DB_URL = "sqlite+aiosqlite:///./test_audit.db"
+
+
+@pytest.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    """Create a fresh test database session (SQLite)."""
+    engine = create_async_engine(TEST_DB_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await engine.dispose()
+
+
+# --- Model structure tests ---
+
+
+@pytest.mark.asyncio
+async def test_audit_event_has_required_fields() -> None:
+    """AuditEvent model declares all required audit fields."""
+    fields = AuditEvent.model_fields
+    assert "user_id" in fields
+    assert "agency_id" in fields
+    assert "action" in fields
+    assert "resource_type" in fields
+    assert "resource_id" in fields
+    assert "is_phi_access" in fields
+    assert "ip_address" in fields
+    assert "changes" in fields
+
+
+@pytest.mark.asyncio
+async def test_audit_action_enum_values() -> None:
+    """AuditAction enum has all expected action types."""
+    actions = {a.value for a in AuditAction}
+    assert actions == {"create", "read", "update", "delete", "login", "logout", "export"}
+
+
+@pytest.mark.asyncio
+async def test_audit_event_agency_id_nullable() -> None:
+    """AuditEvent.agency_id is optional (for super-admin platform-level actions)."""
+    event = AuditEvent(action=AuditAction.LOGIN, resource_type="session", agency_id=None)
+    assert event.agency_id is None
+
+
+# --- Service tests ---
+
+
+@pytest.mark.asyncio
+async def test_audit_service_creates_event(session: AsyncSession) -> None:
+    """AuditService.log() creates an audit event in the database."""
+    service = AuditService(session)
+    agency_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    event = await service.log(
+        action=AuditAction.CREATE,
+        resource_type="user",
+        resource_id="user-123",
+        user_id=user_id,
+        agency_id=agency_id,
+        details="Created new user",
+    )
+    await session.commit()
+
+    assert event.id is not None
+    assert event.action == AuditAction.CREATE
+    assert event.resource_type == "user"
+    assert event.resource_id == "user-123"
+    assert event.user_id == user_id
+    assert event.agency_id == agency_id
+    assert event.details == "Created new user"
+    assert event.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_audit_service_phi_flag(session: AsyncSession) -> None:
+    """AuditService.log() correctly sets the is_phi_access flag."""
+    service = AuditService(session)
+
+    event = await service.log(
+        action=AuditAction.READ,
+        resource_type="client_chart",
+        resource_id="chart-456",
+        is_phi_access=True,
+    )
+    await session.commit()
+
+    assert event.is_phi_access is True
+
+
+@pytest.mark.asyncio
+async def test_audit_service_stores_changes(session: AsyncSession) -> None:
+    """AuditService.log() stores before/after change details as JSON."""
+    service = AuditService(session)
+
+    changes = {"before": {"status": "active"}, "after": {"status": "inactive"}}
+    event = await service.log(
+        action=AuditAction.UPDATE,
+        resource_type="user",
+        resource_id="user-789",
+        changes=changes,
+    )
+    await session.commit()
+    await session.refresh(event)
+
+    assert event.changes == changes
+
+
+@pytest.mark.asyncio
+async def test_audit_events_queryable(session: AsyncSession) -> None:
+    """Multiple audit events can be queried from the database."""
+    service = AuditService(session)
+
+    for i in range(3):
+        await service.log(
+            action=AuditAction.READ,
+            resource_type="client",
+            resource_id=f"client-{i}",
+        )
+    await session.commit()
+
+    result = await session.execute(text("SELECT COUNT(*) FROM audit_events"))
+    count = result.scalar()
+    assert count == 3


### PR DESCRIPTION
## Summary

- Adds `AuditEvent` model with full audit trail fields (who, what, when, where, tenant, PHI flag)
- Adds `AuditAction` enum (create/read/update/delete/login/logout/export)
- Creates `AuditService` with async `log()` method for append-only event creation
- 7 new tests, all pass. Total: 19 passed, 3 skipped.

## Test plan

- [x] AuditEvent has all required fields
- [x] AuditAction enum has correct values
- [x] agency_id nullable for platform-level actions
- [x] AuditService.log() creates events in DB
- [x] PHI flag set correctly
- [x] JSON changes stored and retrievable
- [x] Multiple events queryable

Closes #6

Generated with [Claude Code](https://claude.com/claude-code)