### PR TITLE
feat(#9): User management CRUD API

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.routers.users import router as users_router
 
 logger = structlog.get_logger()
 
@@ -59,6 +60,8 @@ def create_app() -> FastAPI:
             duration_ms=round(elapsed * 1000, 2),
         )
         return response
+
+    app.include_router(users_router)
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -1,0 +1,114 @@
+"""User management API endpoints."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.db import get_session
+from app.models.user import User, UserRole
+from app.rbac import require_role
+from app.schemas.user import UserCreate, UserListResponse, UserResponse, UserUpdate
+from app.services.user import UserService
+
+router = APIRouter(prefix="/api/users", tags=["users"])
+
+
+@router.get("/me", response_model=UserResponse)
+async def get_me(
+    user: User = Depends(get_current_user),  # noqa: B008
+) -> User:
+    """Get the current authenticated user's profile."""
+    return user
+
+
+@router.patch("/me", response_model=UserResponse)
+async def update_me(
+    data: UserUpdate,
+    user: User = Depends(get_current_user),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> User:
+    """Update the current user's own profile (limited fields)."""
+    # Self-update: only allow name changes, not role or active status
+    safe_data = UserUpdate(first_name=data.first_name, last_name=data.last_name)
+    service = UserService(session)
+    updated = await service.update_user(user.id, safe_data)
+    if updated is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return updated
+
+
+@router.get("", response_model=UserListResponse)
+async def list_users(
+    page: int = 1,
+    size: int = 20,
+    role: UserRole | None = None,
+    search: str | None = None,
+    _admin: User = Depends(require_role(UserRole.AGENCY_ADMIN)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> UserListResponse:
+    """List users (agency-scoped via RLS). Requires agency_admin+."""
+    service = UserService(session)
+    users, total = await service.list_users(page=page, size=size, role=role, search=search)
+    return UserListResponse(
+        items=[UserResponse.model_validate(u) for u in users],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+@router.get("/{user_id}", response_model=UserResponse)
+async def get_user(
+    user_id: uuid.UUID,
+    _admin: User = Depends(require_role(UserRole.AGENCY_ADMIN)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> User:
+    """Get a user by ID. Requires agency_admin+."""
+    service = UserService(session)
+    user = await service.get_user(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.post("", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+async def create_user(
+    data: UserCreate,
+    admin: User = Depends(require_role(UserRole.AGENCY_ADMIN)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> User:
+    """Create a new user. Requires agency_admin+."""
+    service = UserService(session)
+    user = await service.create_user(data, default_agency_id=admin.agency_id)
+    return user
+
+
+@router.patch("/{user_id}", response_model=UserResponse)
+async def update_user(
+    user_id: uuid.UUID,
+    data: UserUpdate,
+    _admin: User = Depends(require_role(UserRole.AGENCY_ADMIN)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> User:
+    """Update a user. Requires agency_admin+."""
+    service = UserService(session)
+    user = await service.update_user(user_id, data)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@router.delete("/{user_id}", response_model=UserResponse)
+async def deactivate_user(
+    user_id: uuid.UUID,
+    _admin: User = Depends(require_role(UserRole.AGENCY_ADMIN)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> User:
+    """Deactivate (soft-delete) a user. Requires agency_admin+."""
+    service = UserService(session)
+    user = await service.deactivate_user(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user

--- a/api/app/schemas/user.py
+++ b/api/app/schemas/user.py
@@ -1,0 +1,52 @@
+"""User request/response schemas."""
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr
+
+from app.models.user import UserRole
+
+
+class UserCreate(BaseModel):
+    """Schema for creating a new user."""
+
+    email: EmailStr
+    first_name: str
+    last_name: str
+    role: UserRole = UserRole.CAREGIVER
+    agency_id: uuid.UUID | None = None
+
+
+class UserUpdate(BaseModel):
+    """Schema for updating a user. All fields optional."""
+
+    first_name: str | None = None
+    last_name: str | None = None
+    role: UserRole | None = None
+    is_active: bool | None = None
+
+
+class UserResponse(BaseModel):
+    """Schema for user API responses."""
+
+    id: uuid.UUID
+    email: str
+    first_name: str
+    last_name: str
+    role: UserRole
+    is_active: bool
+    agency_id: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class UserListResponse(BaseModel):
+    """Paginated list of users."""
+
+    items: list[UserResponse]
+    total: int
+    page: int
+    size: int

--- a/api/app/services/user.py
+++ b/api/app/services/user.py
@@ -1,0 +1,101 @@
+"""User management service."""
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User, UserRole
+from app.schemas.user import UserCreate, UserUpdate
+
+
+class UserService:
+    """CRUD operations for users, tenant-scoped via RLS."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_users(
+        self,
+        *,
+        page: int = 1,
+        size: int = 20,
+        role: UserRole | None = None,
+        search: str | None = None,
+    ) -> tuple[list[User], int]:
+        """List users with optional filtering. RLS handles tenant scoping."""
+        query = select(User)
+
+        if role:
+            query = query.where(User.role == role)  # type: ignore[arg-type]
+        if search:
+            pattern = f"%{search}%"
+            query = query.where(
+                User.email.like(pattern)  # type: ignore[attr-defined]
+                | User.first_name.like(pattern)  # type: ignore[attr-defined]
+                | User.last_name.like(pattern)  # type: ignore[attr-defined]
+            )
+
+        # Count total before pagination
+        count_query = select(func.count()).select_from(query.subquery())
+        total_result = await self.session.execute(count_query)
+        total = total_result.scalar() or 0
+
+        # Apply pagination
+        query = query.offset((page - 1) * size).limit(size).order_by(
+            User.created_at.desc()  # type: ignore[attr-defined]
+        )
+        result = await self.session.execute(query)
+        users = list(result.scalars().all())
+
+        return users, total
+
+    async def get_user(self, user_id: uuid.UUID) -> User | None:
+        """Get a single user by ID."""
+        result = await self.session.execute(
+            select(User).where(User.id == user_id)  # type: ignore[arg-type]
+        )
+        return result.scalar_one_or_none()
+
+    async def create_user(
+        self, data: UserCreate, default_agency_id: uuid.UUID | None = None
+    ) -> User:
+        """Create a new user."""
+        user = User(
+            email=data.email,
+            first_name=data.first_name,
+            last_name=data.last_name,
+            role=data.role,
+            agency_id=data.agency_id or default_agency_id,
+        )
+        self.session.add(user)
+        await self.session.flush()
+        await self.session.refresh(user)
+        return user
+
+    async def update_user(self, user_id: uuid.UUID, data: UserUpdate) -> User | None:
+        """Update an existing user. Returns None if not found."""
+        user = await self.get_user(user_id)
+        if user is None:
+            return None
+
+        update_data = data.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(user, field, value)
+
+        self.session.add(user)
+        await self.session.flush()
+        await self.session.refresh(user)
+        return user
+
+    async def deactivate_user(self, user_id: uuid.UUID) -> User | None:
+        """Soft-delete a user by setting is_active=False."""
+        user = await self.get_user(user_id)
+        if user is None:
+            return None
+
+        user.is_active = False
+        self.session.add(user)
+        await self.session.flush()
+        await self.session.refresh(user)
+        return user

--- a/api/app/tests/test_users.py
+++ b/api/app/tests/test_users.py
@@ -1,0 +1,217 @@
+"""Tests for user management CRUD."""
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+from app.models import Agency, AuditEvent, User  # noqa: F401 — register models
+from app.models.user import UserRole
+from app.schemas.user import UserCreate, UserListResponse, UserResponse, UserUpdate
+from app.services.user import UserService
+
+TEST_DB_URL = "sqlite+aiosqlite:///./test_users.db"
+
+AGENCY_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    """Create a fresh test database session."""
+    engine = create_async_engine(TEST_DB_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        # Create a test agency
+        agency = Agency(id=AGENCY_ID, name="Test Agency", slug="test-agency")
+        s.add(agency)
+        await s.commit()
+        yield s
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await engine.dispose()
+
+
+# --- Schema tests ---
+
+
+@pytest.mark.asyncio
+async def test_user_create_schema_valid() -> None:
+    """UserCreate schema accepts valid data."""
+    data = UserCreate(
+        email="test@example.com",
+        first_name="Test",
+        last_name="User",
+        role=UserRole.CAREGIVER,
+    )
+    assert data.email == "test@example.com"
+    assert data.role == UserRole.CAREGIVER
+
+
+@pytest.mark.asyncio
+async def test_user_create_schema_invalid_email() -> None:
+    """UserCreate schema rejects invalid email."""
+    with pytest.raises(ValueError):
+        UserCreate(email="not-an-email", first_name="Test", last_name="User")
+
+
+@pytest.mark.asyncio
+async def test_user_update_schema_partial() -> None:
+    """UserUpdate schema allows partial updates."""
+    data = UserUpdate(first_name="NewName")
+    assert data.first_name == "NewName"
+    assert data.last_name is None
+    assert data.role is None
+
+
+@pytest.mark.asyncio
+async def test_user_response_from_attributes() -> None:
+    """UserResponse can be created from a User model."""
+    user = User(
+        email="test@example.com",
+        first_name="Test",
+        last_name="User",
+        role=UserRole.CAREGIVER,
+        agency_id=AGENCY_ID,
+    )
+    resp = UserResponse.model_validate(user)
+    assert resp.email == "test@example.com"
+
+
+@pytest.mark.asyncio
+async def test_user_list_response_structure() -> None:
+    """UserListResponse has correct structure."""
+    resp = UserListResponse(items=[], total=0, page=1, size=20)
+    assert resp.total == 0
+    assert resp.page == 1
+
+
+# --- Service tests ---
+
+
+@pytest.mark.asyncio
+async def test_service_create_user(session: AsyncSession) -> None:
+    """UserService.create_user persists a new user."""
+    service = UserService(session)
+    data = UserCreate(
+        email="new@example.com",
+        first_name="New",
+        last_name="User",
+        role=UserRole.CAREGIVER,
+    )
+    user = await service.create_user(data, default_agency_id=AGENCY_ID)
+    await session.commit()
+
+    assert user.id is not None
+    assert user.email == "new@example.com"
+    assert user.agency_id == AGENCY_ID
+
+
+@pytest.mark.asyncio
+async def test_service_list_users(session: AsyncSession) -> None:
+    """UserService.list_users returns paginated results."""
+    service = UserService(session)
+    for i in range(5):
+        await service.create_user(
+            UserCreate(
+                email=f"user{i}@example.com",
+                first_name=f"User{i}",
+                last_name="Test",
+            ),
+            default_agency_id=AGENCY_ID,
+        )
+    await session.commit()
+
+    users, total = await service.list_users(page=1, size=3)
+    assert total == 5
+    assert len(users) == 3
+
+
+@pytest.mark.asyncio
+async def test_service_list_users_filter_role(session: AsyncSession) -> None:
+    """UserService.list_users filters by role."""
+    service = UserService(session)
+    await service.create_user(
+        UserCreate(
+            email="admin@example.com",
+            first_name="Admin",
+            last_name="User",
+            role=UserRole.AGENCY_ADMIN,
+        ),
+        default_agency_id=AGENCY_ID,
+    )
+    await service.create_user(
+        UserCreate(
+            email="cg@example.com",
+            first_name="CG",
+            last_name="User",
+            role=UserRole.CAREGIVER,
+        ),
+        default_agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    users, total = await service.list_users(role=UserRole.AGENCY_ADMIN)
+    assert total == 1
+    assert users[0].role == UserRole.AGENCY_ADMIN
+
+
+@pytest.mark.asyncio
+async def test_service_update_user(session: AsyncSession) -> None:
+    """UserService.update_user modifies fields."""
+    service = UserService(session)
+    user = await service.create_user(
+        UserCreate(email="update@example.com", first_name="Old", last_name="Name"),
+        default_agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    updated = await service.update_user(user.id, UserUpdate(first_name="New"))
+    await session.commit()
+
+    assert updated is not None
+    assert updated.first_name == "New"
+    assert updated.last_name == "Name"
+
+
+@pytest.mark.asyncio
+async def test_service_deactivate_user(session: AsyncSession) -> None:
+    """UserService.deactivate_user sets is_active=False."""
+    service = UserService(session)
+    user = await service.create_user(
+        UserCreate(email="deactivate@example.com", first_name="To", last_name="Deactivate"),
+        default_agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    deactivated = await service.deactivate_user(user.id)
+    await session.commit()
+
+    assert deactivated is not None
+    assert deactivated.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_service_get_user(session: AsyncSession) -> None:
+    """UserService.get_user returns a user by ID."""
+    service = UserService(session)
+    user = await service.create_user(
+        UserCreate(email="get@example.com", first_name="Get", last_name="User"),
+        default_agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    found = await service.get_user(user.id)
+    assert found is not None
+    assert found.email == "get@example.com"
+
+
+@pytest.mark.asyncio
+async def test_service_get_user_not_found(session: AsyncSession) -> None:
+    """UserService.get_user returns None for non-existent user."""
+    service = UserService(session)
+    result = await service.get_user(uuid.uuid4())
+    assert result is None

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "python-jose[cryptography]>=3.3",
     "passlib[bcrypt]>=1.7",
     "python-multipart>=0.0.18",
+    "email-validator>=2.0",
 ]
 
 [dependency-groups]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -205,6 +205,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
+    { name = "email-validator" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "passlib", extra = ["bcrypt"] },
@@ -236,6 +237,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.14" },
     { name = "asyncpg", specifier = ">=0.30" },
+    { name = "email-validator", specifier = ">=2.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7" },
@@ -357,6 +359,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -366,6 +377,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/1f/924e3caae75f471eae4b26bd13b698f6af2c44279f67af317439c2f4c46a/ecdsa-0.19.1.tar.gz", hash = "sha256:478cba7b62555866fcb3bb3fe985e06decbdb68ef55713c4e5ab98c57d508e61", size = 201793, upload-time = "2025-03-13T11:52:43.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a3/460c57f094a4a165c84a1341c373b0a4f5ec6ac244b998d5021aade89b77/ecdsa-0.19.1-py2.py3-none-any.whl", hash = "sha256:30638e27cf77b7e15c4c4cc1973720149e1033827cfd00661ca5c8cc0cdb24c3", size = 150607, upload-time = "2025-03-13T11:52:41.757Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- User schemas (create, update, response, paginated list)
- UserService with full CRUD + search/filter/pagination
- Users router with role-protected endpoints + /me self-service
- 12 new tests (43 total passed, 3 skipped)

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)