### PR TITLE
feat(#15-17): clinical charting API + credential management

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -10,7 +10,9 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.routers.caregivers import router as caregivers_router
+from app.routers.charts import router as charts_router
 from app.routers.clients import router as clients_router
+from app.routers.credentials import router as credentials_router
 from app.routers.shifts import router as shifts_router
 from app.routers.users import router as users_router
 
@@ -68,6 +70,8 @@ def create_app() -> FastAPI:
     app.include_router(clients_router)
     app.include_router(caregivers_router)
     app.include_router(shifts_router)
+    app.include_router(charts_router)
+    app.include_router(credentials_router)
 
     @app.get("/healthz")
     async def healthz() -> dict[str, str]:

--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -4,7 +4,9 @@ from app.models.agency import Agency
 from app.models.audit import AuditAction, AuditEvent
 from app.models.base import BaseModel, TenantScopedModel
 from app.models.caregiver import CaregiverProfile
+from app.models.chart import Chart, ChartStatus, ChartTemplate
 from app.models.client import Client, ClientStatus, FamilyLink
+from app.models.credential import Credential, CredentialStatus, CredentialType
 from app.models.shift import Shift, ShiftStatus
 from app.models.user import User, UserRole
 from app.models.visit import ShiftOffer, ShiftOfferStatus, Visit
@@ -15,8 +17,14 @@ __all__ = [
     "AuditEvent",
     "BaseModel",
     "CaregiverProfile",
+    "Chart",
+    "ChartStatus",
+    "ChartTemplate",
     "Client",
     "ClientStatus",
+    "Credential",
+    "CredentialStatus",
+    "CredentialType",
     "FamilyLink",
     "Shift",
     "ShiftOffer",

--- a/api/app/models/chart.py
+++ b/api/app/models/chart.py
@@ -1,0 +1,52 @@
+"""Clinical charting models — templates and patient charts."""
+
+import enum
+import uuid
+from datetime import datetime
+
+from sqlmodel import Column, Field, Text
+
+from app.models.base import TenantScopedModel
+
+
+class ChartStatus(enum.StrEnum):
+    DRAFT = "draft"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    SIGNED = "signed"
+    AMENDED = "amended"
+
+
+class ChartTemplate(TenantScopedModel, table=True):
+    """A reusable template defining sections for a chart type."""
+
+    __tablename__ = "chart_templates"
+
+    name: str = Field(max_length=200, index=True)
+    description: str = Field(default="", sa_column=Column(Text))
+    version: int = Field(default=1)
+    is_active: bool = Field(default=True)
+    sections_json: str = Field(
+        default="[]",
+        sa_column=Column(Text),
+    )
+
+
+class Chart(TenantScopedModel, table=True):
+    """A patient chart record based on a template."""
+
+    __tablename__ = "charts"
+
+    template_id: uuid.UUID = Field(foreign_key="chart_templates.id", index=True)
+    client_id: uuid.UUID = Field(foreign_key="clients.id", index=True)
+    caregiver_id: uuid.UUID = Field(foreign_key="users.id", index=True)
+    shift_id: uuid.UUID | None = Field(default=None, foreign_key="shifts.id", index=True)
+    status: ChartStatus = Field(default=ChartStatus.DRAFT, index=True)
+    version: int = Field(default=1)
+    data_json: str = Field(
+        default="{}",
+        sa_column=Column(Text),
+    )
+    signed_at: datetime | None = None
+    signed_by_id: uuid.UUID | None = Field(default=None, foreign_key="users.id")
+    notes: str = Field(default="", sa_column=Column(Text))

--- a/api/app/models/credential.py
+++ b/api/app/models/credential.py
@@ -1,0 +1,46 @@
+"""Caregiver credential management models."""
+
+import enum
+import uuid
+from datetime import date
+
+from sqlmodel import Column, Field, Text
+
+from app.models.base import TenantScopedModel
+
+
+class CredentialStatus(enum.StrEnum):
+    ACTIVE = "active"
+    EXPIRING_SOON = "expiring_soon"
+    EXPIRED = "expired"
+    PENDING_REVIEW = "pending_review"
+
+
+class CredentialType(enum.StrEnum):
+    LICENSE = "license"
+    CERTIFICATION = "certification"
+    TRAINING = "training"
+    BACKGROUND_CHECK = "background_check"
+    HEALTH_SCREENING = "health_screening"
+    OTHER = "other"
+
+
+class Credential(TenantScopedModel, table=True):
+    """A caregiver's credential (license, certification, etc.)."""
+
+    __tablename__ = "credentials"
+
+    caregiver_id: uuid.UUID = Field(foreign_key="users.id", index=True)
+    credential_type: CredentialType = Field(index=True)
+    name: str = Field(max_length=200)
+    issuing_authority: str = Field(default="", max_length=200)
+    credential_number: str = Field(default="", max_length=100)
+    issued_date: date | None = None
+    expiration_date: date | None = None
+    status: CredentialStatus = Field(default=CredentialStatus.ACTIVE, index=True)
+    document_url: str = Field(default="", max_length=500)
+    notes: str = Field(default="", sa_column=Column(Text))
+    alert_sent_90: bool = Field(default=False)
+    alert_sent_60: bool = Field(default=False)
+    alert_sent_30: bool = Field(default=False)
+    alert_sent_7: bool = Field(default=False)

--- a/api/app/routers/charts.py
+++ b/api/app/routers/charts.py
@@ -1,0 +1,176 @@
+"""Charting API endpoints — templates and patient charts."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.models.chart import ChartStatus
+from app.models.user import User, UserRole
+from app.rbac import require_role
+from app.schemas.chart import (
+    ChartCreate,
+    ChartListResponse,
+    ChartResponse,
+    ChartTemplateCreate,
+    ChartTemplateListResponse,
+    ChartTemplateResponse,
+    ChartTemplateUpdate,
+    ChartUpdate,
+)
+from app.services.chart import ChartService
+
+router = APIRouter(prefix="/api", tags=["charts"])
+
+
+# --- Template endpoints ---
+
+
+@router.get("/chart-templates", response_model=ChartTemplateListResponse)
+async def list_templates(
+    page: int = 1,
+    size: int = 20,
+    active_only: bool = True,
+    _user: User = Depends(require_role(UserRole.CAREGIVER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartTemplateListResponse:
+    """List chart templates. Requires caregiver+."""
+    service = ChartService(session)
+    templates, total = await service.list_templates(page=page, size=size, active_only=active_only)
+    items = [ChartTemplateResponse(**service.template_to_response_data(t)) for t in templates]
+    return ChartTemplateListResponse(items=items, total=total, page=page, size=size)
+
+
+@router.get("/chart-templates/{template_id}", response_model=ChartTemplateResponse)
+async def get_template(
+    template_id: uuid.UUID,
+    _user: User = Depends(require_role(UserRole.CAREGIVER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartTemplateResponse:
+    """Get a chart template by ID. Requires caregiver+."""
+    service = ChartService(session)
+    template = await service.get_template(template_id)
+    if template is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return ChartTemplateResponse(**service.template_to_response_data(template))
+
+
+@router.post(
+    "/chart-templates",
+    response_model=ChartTemplateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_template(
+    data: ChartTemplateCreate,
+    admin: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartTemplateResponse:
+    """Create a chart template. Requires care_manager+."""
+    if admin.agency_id is None:
+        raise HTTPException(status_code=400, detail="Super-admin must specify agency")
+    service = ChartService(session)
+    template = await service.create_template(data, agency_id=admin.agency_id)
+    return ChartTemplateResponse(**service.template_to_response_data(template))
+
+
+@router.patch("/chart-templates/{template_id}", response_model=ChartTemplateResponse)
+async def update_template(
+    template_id: uuid.UUID,
+    data: ChartTemplateUpdate,
+    _admin: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartTemplateResponse:
+    """Update a chart template (bumps version on content changes). Requires care_manager+."""
+    service = ChartService(session)
+    template = await service.update_template(template_id, data)
+    if template is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return ChartTemplateResponse(**service.template_to_response_data(template))
+
+
+# --- Chart endpoints ---
+
+
+@router.get("/charts", response_model=ChartListResponse)
+async def list_charts(
+    page: int = 1,
+    size: int = 20,
+    client_id: uuid.UUID | None = None,
+    caregiver_id: uuid.UUID | None = None,
+    chart_status: ChartStatus | None = None,
+    _user: User = Depends(require_role(UserRole.CAREGIVER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartListResponse:
+    """List charts with filtering. Requires caregiver+."""
+    service = ChartService(session)
+    charts, total = await service.list_charts(
+        page=page,
+        size=size,
+        client_id=client_id,
+        caregiver_id=caregiver_id,
+        status=chart_status,
+    )
+    items = [ChartResponse(**service.chart_to_response_data(c)) for c in charts]
+    return ChartListResponse(items=items, total=total, page=page, size=size)
+
+
+@router.get("/charts/{chart_id}", response_model=ChartResponse)
+async def get_chart(
+    chart_id: uuid.UUID,
+    _user: User = Depends(require_role(UserRole.CAREGIVER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartResponse:
+    """Get a chart by ID. Requires caregiver+."""
+    service = ChartService(session)
+    chart = await service.get_chart(chart_id)
+    if chart is None:
+        raise HTTPException(status_code=404, detail="Chart not found")
+    return ChartResponse(**service.chart_to_response_data(chart))
+
+
+@router.post(
+    "/charts",
+    response_model=ChartResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_chart(
+    data: ChartCreate,
+    user: User = Depends(require_role(UserRole.CAREGIVER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartResponse:
+    """Create a new chart. Requires caregiver+."""
+    if user.agency_id is None:
+        raise HTTPException(status_code=400, detail="Super-admin must specify agency")
+    service = ChartService(session)
+    chart = await service.create_chart(data, caregiver_id=user.id, agency_id=user.agency_id)
+    return ChartResponse(**service.chart_to_response_data(chart))
+
+
+@router.patch("/charts/{chart_id}", response_model=ChartResponse)
+async def update_chart(
+    chart_id: uuid.UUID,
+    data: ChartUpdate,
+    _user: User = Depends(require_role(UserRole.CAREGIVER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartResponse:
+    """Update chart data (bumps version on data changes). Requires caregiver+."""
+    service = ChartService(session)
+    chart = await service.update_chart(chart_id, data)
+    if chart is None:
+        raise HTTPException(status_code=404, detail="Chart not found")
+    return ChartResponse(**service.chart_to_response_data(chart))
+
+
+@router.post("/charts/{chart_id}/sign", response_model=ChartResponse)
+async def sign_chart(
+    chart_id: uuid.UUID,
+    user: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> ChartResponse:
+    """Sign a completed chart. Requires care_manager+."""
+    service = ChartService(session)
+    chart = await service.sign_chart(chart_id, signer_id=user.id)
+    if chart is None:
+        raise HTTPException(status_code=404, detail="Chart not found")
+    return ChartResponse(**service.chart_to_response_data(chart))

--- a/api/app/routers/credentials.py
+++ b/api/app/routers/credentials.py
@@ -1,0 +1,125 @@
+"""Credential management API endpoints."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.models.credential import CredentialStatus, CredentialType
+from app.models.user import User, UserRole
+from app.rbac import require_role
+from app.schemas.credential import (
+    CredentialCreate,
+    CredentialListResponse,
+    CredentialResponse,
+    CredentialUpdate,
+    ExpiringCredentialAlert,
+)
+from app.services.credential import CredentialService
+
+router = APIRouter(prefix="/api/credentials", tags=["credentials"])
+
+
+@router.get("", response_model=CredentialListResponse)
+async def list_credentials(
+    page: int = 1,
+    size: int = 20,
+    caregiver_id: uuid.UUID | None = None,
+    credential_type: CredentialType | None = None,
+    credential_status: CredentialStatus | None = None,
+    _user: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> CredentialListResponse:
+    """List credentials with filtering. Requires care_manager+."""
+    service = CredentialService(session)
+    credentials, total = await service.list_credentials(
+        page=page,
+        size=size,
+        caregiver_id=caregiver_id,
+        credential_type=credential_type,
+        status=credential_status,
+    )
+    return CredentialListResponse(
+        items=[CredentialResponse.model_validate(c) for c in credentials],
+        total=total,
+        page=page,
+        size=size,
+    )
+
+
+@router.get("/expiring", response_model=list[ExpiringCredentialAlert])
+async def get_expiring_credentials(
+    _user: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> list[ExpiringCredentialAlert]:
+    """Get credentials expiring within 90 days. Requires care_manager+."""
+    service = CredentialService(session)
+    return await service.check_expiring()
+
+
+@router.get("/{credential_id}", response_model=CredentialResponse)
+async def get_credential(
+    credential_id: uuid.UUID,
+    _user: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> CredentialResponse:
+    """Get a credential by ID. Requires care_manager+."""
+    service = CredentialService(session)
+    credential = await service.get_credential(credential_id)
+    if credential is None:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    return CredentialResponse.model_validate(credential)
+
+
+@router.post("", response_model=CredentialResponse, status_code=status.HTTP_201_CREATED)
+async def create_credential(
+    data: CredentialCreate,
+    admin: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> CredentialResponse:
+    """Create a credential record. Requires care_manager+."""
+    if admin.agency_id is None:
+        raise HTTPException(status_code=400, detail="Super-admin must specify agency")
+    service = CredentialService(session)
+    credential = await service.create_credential(data, agency_id=admin.agency_id)
+    return CredentialResponse.model_validate(credential)
+
+
+@router.patch("/{credential_id}", response_model=CredentialResponse)
+async def update_credential(
+    credential_id: uuid.UUID,
+    data: CredentialUpdate,
+    _admin: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> CredentialResponse:
+    """Update a credential. Requires care_manager+."""
+    service = CredentialService(session)
+    credential = await service.update_credential(credential_id, data)
+    if credential is None:
+        raise HTTPException(status_code=404, detail="Credential not found")
+    return CredentialResponse.model_validate(credential)
+
+
+@router.delete("/{credential_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_credential(
+    credential_id: uuid.UUID,
+    _admin: User = Depends(require_role(UserRole.AGENCY_ADMIN)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> None:
+    """Delete a credential. Requires agency_admin+."""
+    service = CredentialService(session)
+    deleted = await service.delete_credential(credential_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Credential not found")
+
+
+@router.post("/update-statuses")
+async def update_credential_statuses(
+    _admin: User = Depends(require_role(UserRole.CARE_MANAGER)),  # noqa: B008
+    session: AsyncSession = Depends(get_session),  # noqa: B008
+) -> dict[str, int]:
+    """Scan and update credential statuses based on expiration dates. Requires care_manager+."""
+    service = CredentialService(session)
+    updated = await service.update_expiration_statuses()
+    return {"updated_count": updated}

--- a/api/app/schemas/chart.py
+++ b/api/app/schemas/chart.py
@@ -1,0 +1,83 @@
+"""Chart template and chart request/response schemas."""
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+from app.models.chart import ChartStatus
+
+
+class ChartTemplateCreate(BaseModel):
+    name: str
+    description: str = ""
+    sections: list[dict[str, Any]] = []
+
+
+class ChartTemplateUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    sections: list[dict[str, Any]] | None = None
+    is_active: bool | None = None
+
+
+class ChartTemplateResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    version: int
+    is_active: bool
+    sections: list[dict[str, Any]]
+    agency_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ChartTemplateListResponse(BaseModel):
+    items: list[ChartTemplateResponse]
+    total: int
+    page: int
+    size: int
+
+
+class ChartCreate(BaseModel):
+    template_id: uuid.UUID
+    client_id: uuid.UUID
+    shift_id: uuid.UUID | None = None
+    data: dict[str, Any] = {}
+    notes: str = ""
+
+
+class ChartUpdate(BaseModel):
+    data: dict[str, Any] | None = None
+    notes: str | None = None
+    status: ChartStatus | None = None
+
+
+class ChartResponse(BaseModel):
+    id: uuid.UUID
+    template_id: uuid.UUID
+    client_id: uuid.UUID
+    caregiver_id: uuid.UUID
+    shift_id: uuid.UUID | None
+    status: ChartStatus
+    version: int
+    data: dict[str, Any]
+    signed_at: datetime | None
+    signed_by_id: uuid.UUID | None
+    notes: str
+    agency_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ChartListResponse(BaseModel):
+    items: list[ChartResponse]
+    total: int
+    page: int
+    size: int

--- a/api/app/schemas/credential.py
+++ b/api/app/schemas/credential.py
@@ -1,0 +1,70 @@
+"""Credential request/response schemas."""
+
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel
+
+from app.models.credential import CredentialStatus, CredentialType
+
+
+class CredentialCreate(BaseModel):
+    caregiver_id: uuid.UUID
+    credential_type: CredentialType
+    name: str
+    issuing_authority: str = ""
+    credential_number: str = ""
+    issued_date: date | None = None
+    expiration_date: date | None = None
+    document_url: str = ""
+    notes: str = ""
+
+
+class CredentialUpdate(BaseModel):
+    name: str | None = None
+    issuing_authority: str | None = None
+    credential_number: str | None = None
+    issued_date: date | None = None
+    expiration_date: date | None = None
+    status: CredentialStatus | None = None
+    document_url: str | None = None
+    notes: str | None = None
+
+
+class CredentialResponse(BaseModel):
+    id: uuid.UUID
+    caregiver_id: uuid.UUID
+    credential_type: CredentialType
+    name: str
+    issuing_authority: str
+    credential_number: str
+    issued_date: date | None
+    expiration_date: date | None
+    status: CredentialStatus
+    document_url: str
+    notes: str
+    alert_sent_90: bool
+    alert_sent_60: bool
+    alert_sent_30: bool
+    alert_sent_7: bool
+    agency_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class CredentialListResponse(BaseModel):
+    items: list[CredentialResponse]
+    total: int
+    page: int
+    size: int
+
+
+class ExpiringCredentialAlert(BaseModel):
+    credential_id: uuid.UUID
+    caregiver_id: uuid.UUID
+    name: str
+    credential_type: CredentialType
+    expiration_date: date
+    days_until_expiry: int

--- a/api/app/services/chart.py
+++ b/api/app/services/chart.py
@@ -1,0 +1,218 @@
+"""Charting service — templates and patient charts with versioning."""
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chart import Chart, ChartStatus, ChartTemplate
+from app.schemas.chart import ChartCreate, ChartTemplateCreate, ChartTemplateUpdate, ChartUpdate
+
+
+class ChartService:
+    """CRUD for chart templates and patient charts."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    # --- Templates ---
+
+    async def list_templates(
+        self,
+        *,
+        page: int = 1,
+        size: int = 20,
+        active_only: bool = True,
+    ) -> tuple[list[ChartTemplate], int]:
+        query = select(ChartTemplate)
+        if active_only:
+            query = query.where(
+                ChartTemplate.is_active == True  # type: ignore[arg-type]  # noqa: E712
+            )
+
+        count_query = select(func.count()).select_from(query.subquery())
+        total_result = await self.session.execute(count_query)
+        total = total_result.scalar() or 0
+
+        query = (
+            query.offset((page - 1) * size).limit(size).order_by(ChartTemplate.name.asc())  # type: ignore[attr-defined]
+        )
+        result = await self.session.execute(query)
+        return list(result.scalars().all()), total
+
+    async def get_template(self, template_id: uuid.UUID) -> ChartTemplate | None:
+        result = await self.session.execute(
+            select(ChartTemplate).where(
+                ChartTemplate.id == template_id  # type: ignore[arg-type]
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create_template(
+        self, data: ChartTemplateCreate, agency_id: uuid.UUID
+    ) -> ChartTemplate:
+        template = ChartTemplate(
+            name=data.name,
+            description=data.description,
+            sections_json=json.dumps(data.sections),
+            agency_id=agency_id,
+        )
+        self.session.add(template)
+        await self.session.flush()
+        await self.session.refresh(template)
+        return template
+
+    async def update_template(
+        self, template_id: uuid.UUID, data: ChartTemplateUpdate
+    ) -> ChartTemplate | None:
+        template = await self.get_template(template_id)
+        if template is None:
+            return None
+
+        update_data = data.model_dump(exclude_unset=True)
+
+        # Bump version on content changes
+        content_changed = False
+        if "sections" in update_data:
+            template.sections_json = json.dumps(update_data.pop("sections"))
+            content_changed = True
+        if "name" in update_data:
+            content_changed = True
+
+        for field, value in update_data.items():
+            setattr(template, field, value)
+
+        if content_changed:
+            template.version += 1
+
+        self.session.add(template)
+        await self.session.flush()
+        await self.session.refresh(template)
+        return template
+
+    # --- Charts ---
+
+    async def list_charts(
+        self,
+        *,
+        page: int = 1,
+        size: int = 20,
+        client_id: uuid.UUID | None = None,
+        caregiver_id: uuid.UUID | None = None,
+        status: ChartStatus | None = None,
+    ) -> tuple[list[Chart], int]:
+        query = select(Chart)
+
+        if client_id:
+            query = query.where(Chart.client_id == client_id)  # type: ignore[arg-type]
+        if caregiver_id:
+            query = query.where(
+                Chart.caregiver_id == caregiver_id  # type: ignore[arg-type]
+            )
+        if status:
+            query = query.where(Chart.status == status)  # type: ignore[arg-type]
+
+        count_query = select(func.count()).select_from(query.subquery())
+        total_result = await self.session.execute(count_query)
+        total = total_result.scalar() or 0
+
+        query = (
+            query.offset((page - 1) * size).limit(size).order_by(Chart.created_at.desc())  # type: ignore[attr-defined]
+        )
+        result = await self.session.execute(query)
+        return list(result.scalars().all()), total
+
+    async def get_chart(self, chart_id: uuid.UUID) -> Chart | None:
+        result = await self.session.execute(
+            select(Chart).where(Chart.id == chart_id)  # type: ignore[arg-type]
+        )
+        return result.scalar_one_or_none()
+
+    async def create_chart(
+        self, data: ChartCreate, caregiver_id: uuid.UUID, agency_id: uuid.UUID
+    ) -> Chart:
+        chart = Chart(
+            template_id=data.template_id,
+            client_id=data.client_id,
+            caregiver_id=caregiver_id,
+            shift_id=data.shift_id,
+            data_json=json.dumps(data.data),
+            notes=data.notes,
+            agency_id=agency_id,
+        )
+        self.session.add(chart)
+        await self.session.flush()
+        await self.session.refresh(chart)
+        return chart
+
+    async def update_chart(self, chart_id: uuid.UUID, data: ChartUpdate) -> Chart | None:
+        chart = await self.get_chart(chart_id)
+        if chart is None:
+            return None
+
+        update_data = data.model_dump(exclude_unset=True)
+
+        if "data" in update_data:
+            chart.data_json = json.dumps(update_data.pop("data"))
+            chart.version += 1
+
+        for field, value in update_data.items():
+            setattr(chart, field, value)
+
+        self.session.add(chart)
+        await self.session.flush()
+        await self.session.refresh(chart)
+        return chart
+
+    async def sign_chart(self, chart_id: uuid.UUID, signer_id: uuid.UUID) -> Chart | None:
+        chart = await self.get_chart(chart_id)
+        if chart is None:
+            return None
+
+        chart.status = ChartStatus.SIGNED
+        chart.signed_at = datetime.now(UTC)
+        chart.signed_by_id = signer_id
+        self.session.add(chart)
+        await self.session.flush()
+        await self.session.refresh(chart)
+        return chart
+
+    @staticmethod
+    def template_to_response_data(template: ChartTemplate) -> dict[str, Any]:
+        """Convert template model to response-friendly dict with parsed sections."""
+        data = {
+            "id": template.id,
+            "name": template.name,
+            "description": template.description,
+            "version": template.version,
+            "is_active": template.is_active,
+            "sections": json.loads(template.sections_json),
+            "agency_id": template.agency_id,
+            "created_at": template.created_at,
+            "updated_at": template.updated_at,
+        }
+        return data
+
+    @staticmethod
+    def chart_to_response_data(chart: Chart) -> dict[str, Any]:
+        """Convert chart model to response-friendly dict with parsed data."""
+        data = {
+            "id": chart.id,
+            "template_id": chart.template_id,
+            "client_id": chart.client_id,
+            "caregiver_id": chart.caregiver_id,
+            "shift_id": chart.shift_id,
+            "status": chart.status,
+            "version": chart.version,
+            "data": json.loads(chart.data_json),
+            "signed_at": chart.signed_at,
+            "signed_by_id": chart.signed_by_id,
+            "notes": chart.notes,
+            "agency_id": chart.agency_id,
+            "created_at": chart.created_at,
+            "updated_at": chart.updated_at,
+        }
+        return data

--- a/api/app/services/credential.py
+++ b/api/app/services/credential.py
@@ -1,0 +1,187 @@
+"""Credential management service with expiration tracking."""
+
+import uuid
+from datetime import date, timedelta
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.credential import Credential, CredentialStatus, CredentialType
+from app.schemas.credential import CredentialCreate, CredentialUpdate, ExpiringCredentialAlert
+
+
+class CredentialService:
+    """CRUD for caregiver credentials with expiration alerts."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_credentials(
+        self,
+        *,
+        page: int = 1,
+        size: int = 20,
+        caregiver_id: uuid.UUID | None = None,
+        credential_type: CredentialType | None = None,
+        status: CredentialStatus | None = None,
+    ) -> tuple[list[Credential], int]:
+        query = select(Credential)
+
+        if caregiver_id:
+            query = query.where(
+                Credential.caregiver_id == caregiver_id  # type: ignore[arg-type]
+            )
+        if credential_type:
+            query = query.where(
+                Credential.credential_type == credential_type  # type: ignore[arg-type]
+            )
+        if status:
+            query = query.where(
+                Credential.status == status  # type: ignore[arg-type]
+            )
+
+        count_query = select(func.count()).select_from(query.subquery())
+        total_result = await self.session.execute(count_query)
+        total = total_result.scalar() or 0
+
+        query = (
+            query.offset((page - 1) * size)
+            .limit(size)
+            .order_by(
+                Credential.expiration_date.asc()  # type: ignore[union-attr]
+            )
+        )
+        result = await self.session.execute(query)
+        return list(result.scalars().all()), total
+
+    async def get_credential(self, credential_id: uuid.UUID) -> Credential | None:
+        result = await self.session.execute(
+            select(Credential).where(
+                Credential.id == credential_id  # type: ignore[arg-type]
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create_credential(self, data: CredentialCreate, agency_id: uuid.UUID) -> Credential:
+        credential = Credential(
+            caregiver_id=data.caregiver_id,
+            credential_type=data.credential_type,
+            name=data.name,
+            issuing_authority=data.issuing_authority,
+            credential_number=data.credential_number,
+            issued_date=data.issued_date,
+            expiration_date=data.expiration_date,
+            document_url=data.document_url,
+            notes=data.notes,
+            agency_id=agency_id,
+        )
+        self.session.add(credential)
+        await self.session.flush()
+        await self.session.refresh(credential)
+        return credential
+
+    async def update_credential(
+        self, credential_id: uuid.UUID, data: CredentialUpdate
+    ) -> Credential | None:
+        credential = await self.get_credential(credential_id)
+        if credential is None:
+            return None
+
+        update_data = data.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(credential, field, value)
+
+        self.session.add(credential)
+        await self.session.flush()
+        await self.session.refresh(credential)
+        return credential
+
+    async def delete_credential(self, credential_id: uuid.UUID) -> bool:
+        credential = await self.get_credential(credential_id)
+        if credential is None:
+            return False
+        await self.session.delete(credential)
+        await self.session.flush()
+        return True
+
+    async def check_expiring(
+        self,
+        *,
+        reference_date: date | None = None,
+    ) -> list[ExpiringCredentialAlert]:
+        """Find credentials expiring within 90 days and return alerts."""
+        today = reference_date or date.today()
+        threshold = today + timedelta(days=90)
+
+        result = await self.session.execute(
+            select(Credential).where(
+                and_(
+                    Credential.expiration_date != None,  # type: ignore[arg-type]  # noqa: E711
+                    Credential.expiration_date <= threshold,  # type: ignore[arg-type, operator]
+                    Credential.expiration_date >= today,  # type: ignore[arg-type, operator]
+                    Credential.status != CredentialStatus.EXPIRED,  # type: ignore[arg-type]
+                )
+            )
+        )
+        credentials = result.scalars().all()
+
+        alerts: list[ExpiringCredentialAlert] = []
+        for cred in credentials:
+            if cred.expiration_date is None:
+                continue
+            days_left = (cred.expiration_date - today).days
+            alerts.append(
+                ExpiringCredentialAlert(
+                    credential_id=cred.id,
+                    caregiver_id=cred.caregiver_id,
+                    name=cred.name,
+                    credential_type=cred.credential_type,
+                    expiration_date=cred.expiration_date,
+                    days_until_expiry=days_left,
+                )
+            )
+
+        return alerts
+
+    async def update_expiration_statuses(
+        self,
+        *,
+        reference_date: date | None = None,
+    ) -> int:
+        """Scan all credentials and update status based on expiration date.
+
+        Returns the number of credentials updated.
+        """
+        today = reference_date or date.today()
+        updated = 0
+
+        result = await self.session.execute(
+            select(Credential).where(
+                Credential.expiration_date != None  # type: ignore[arg-type]  # noqa: E711
+            )
+        )
+        credentials = result.scalars().all()
+
+        for cred in credentials:
+            if cred.expiration_date is None:
+                continue
+
+            days_left = (cred.expiration_date - today).days
+            new_status = cred.status
+
+            if days_left < 0:
+                new_status = CredentialStatus.EXPIRED
+            elif days_left <= 90:
+                new_status = CredentialStatus.EXPIRING_SOON
+            else:
+                new_status = CredentialStatus.ACTIVE
+
+            if new_status != cred.status:
+                cred.status = new_status
+                self.session.add(cred)
+                updated += 1
+
+        if updated:
+            await self.session.flush()
+
+        return updated

--- a/api/app/tests/test_charts.py
+++ b/api/app/tests/test_charts.py
@@ -1,0 +1,277 @@
+"""Tests for charting — templates and patient charts."""
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+from app.models import Agency, Chart, ChartTemplate, Client, Shift, User, Visit  # noqa: F401
+from app.models.chart import ChartStatus
+from app.models.shift import ShiftStatus
+from app.models.user import UserRole
+from app.schemas.chart import (
+    ChartCreate,
+    ChartTemplateCreate,
+    ChartTemplateUpdate,
+    ChartUpdate,
+)
+from app.services.chart import ChartService
+
+TEST_DB_URL = "sqlite+aiosqlite:///./test_charts.db"
+AGENCY_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+NOW = datetime.now(UTC).replace(microsecond=0)
+
+
+@pytest.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine(TEST_DB_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        agency = Agency(id=AGENCY_ID, name="Test Agency", slug="test-agency")
+        s.add(agency)
+        await s.commit()
+        yield s
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await engine.dispose()
+
+
+async def _setup(session: AsyncSession) -> tuple[Client, User, Shift]:
+    """Create test client, caregiver, and shift."""
+    client = Client(first_name="Test", last_name="Client", agency_id=AGENCY_ID)
+    cg = User(
+        email="cg@test.com",
+        first_name="CG",
+        last_name="Test",
+        role=UserRole.CAREGIVER,
+        agency_id=AGENCY_ID,
+    )
+    session.add_all([client, cg])
+    await session.commit()
+    await session.refresh(client)
+    await session.refresh(cg)
+
+    shift = Shift(
+        client_id=client.id,
+        start_time=NOW,
+        end_time=NOW + timedelta(hours=4),
+        status=ShiftStatus.OPEN,
+        agency_id=AGENCY_ID,
+    )
+    session.add(shift)
+    await session.commit()
+    await session.refresh(shift)
+    return client, cg, shift
+
+
+SAMPLE_SECTIONS = [
+    {
+        "title": "Vitals",
+        "fields": [
+            {"name": "bp", "type": "text"},
+            {"name": "temp", "type": "number"},
+        ],
+    },
+    {
+        "title": "Notes",
+        "fields": [{"name": "observation", "type": "textarea"}],
+    },
+]
+
+
+# --- Template tests ---
+
+
+@pytest.mark.asyncio
+async def test_create_template(session: AsyncSession) -> None:
+    """ChartService.create_template creates a v1 template."""
+    service = ChartService(session)
+    template = await service.create_template(
+        ChartTemplateCreate(name="Daily Visit", sections=SAMPLE_SECTIONS),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    assert template.name == "Daily Visit"
+    assert template.version == 1
+    assert template.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_update_template_bumps_version(session: AsyncSession) -> None:
+    """Updating template content bumps the version number."""
+    service = ChartService(session)
+    template = await service.create_template(
+        ChartTemplateCreate(name="Initial", sections=SAMPLE_SECTIONS),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    updated = await service.update_template(
+        template.id,
+        ChartTemplateUpdate(name="Updated Name"),
+    )
+    await session.commit()
+
+    assert updated is not None
+    assert updated.version == 2
+    assert updated.name == "Updated Name"
+
+
+@pytest.mark.asyncio
+async def test_deactivate_template(session: AsyncSession) -> None:
+    """Deactivating a template excludes it from active listings."""
+    service = ChartService(session)
+    template = await service.create_template(
+        ChartTemplateCreate(name="Old Template", sections=[]),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    await service.update_template(
+        template.id,
+        ChartTemplateUpdate(is_active=False),
+    )
+    await session.commit()
+
+    templates, total = await service.list_templates(active_only=True)
+    assert total == 0
+
+
+@pytest.mark.asyncio
+async def test_list_templates_includes_inactive(session: AsyncSession) -> None:
+    """Listing with active_only=False includes deactivated templates."""
+    service = ChartService(session)
+    template = await service.create_template(
+        ChartTemplateCreate(name="Template A", sections=[]),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    await service.update_template(
+        template.id,
+        ChartTemplateUpdate(is_active=False),
+    )
+    await session.commit()
+
+    templates, total = await service.list_templates(active_only=False)
+    assert total == 1
+
+
+# --- Chart tests ---
+
+
+@pytest.mark.asyncio
+async def test_create_chart(session: AsyncSession) -> None:
+    """Creating a chart links to template, client, and caregiver."""
+    client, cg, shift = await _setup(session)
+    service = ChartService(session)
+
+    template = await service.create_template(
+        ChartTemplateCreate(name="Visit Note", sections=SAMPLE_SECTIONS),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    chart = await service.create_chart(
+        ChartCreate(
+            template_id=template.id,
+            client_id=client.id,
+            shift_id=shift.id,
+            data={"bp": "120/80", "temp": 98.6},
+        ),
+        caregiver_id=cg.id,
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    assert chart.status == ChartStatus.DRAFT
+    assert chart.version == 1
+    assert chart.template_id == template.id
+
+
+@pytest.mark.asyncio
+async def test_update_chart_bumps_version(session: AsyncSession) -> None:
+    """Updating chart data bumps version."""
+    client, cg, _ = await _setup(session)
+    service = ChartService(session)
+
+    template = await service.create_template(
+        ChartTemplateCreate(name="Template", sections=[]),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    chart = await service.create_chart(
+        ChartCreate(template_id=template.id, client_id=client.id, data={"v": 1}),
+        caregiver_id=cg.id,
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    updated = await service.update_chart(chart.id, ChartUpdate(data={"v": 2, "new_field": "val"}))
+    await session.commit()
+
+    assert updated is not None
+    assert updated.version == 2
+
+
+@pytest.mark.asyncio
+async def test_sign_chart(session: AsyncSession) -> None:
+    """Signing a chart sets status, timestamp, and signer."""
+    client, cg, _ = await _setup(session)
+    service = ChartService(session)
+
+    template = await service.create_template(
+        ChartTemplateCreate(name="Template", sections=[]),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    chart = await service.create_chart(
+        ChartCreate(template_id=template.id, client_id=client.id),
+        caregiver_id=cg.id,
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    signed = await service.sign_chart(chart.id, signer_id=cg.id)
+    await session.commit()
+
+    assert signed is not None
+    assert signed.status == ChartStatus.SIGNED
+    assert signed.signed_at is not None
+    assert signed.signed_by_id == cg.id
+
+
+@pytest.mark.asyncio
+async def test_list_charts_filter_by_client(session: AsyncSession) -> None:
+    """Filtering charts by client_id returns only that client's charts."""
+    client, cg, _ = await _setup(session)
+    service = ChartService(session)
+
+    template = await service.create_template(
+        ChartTemplateCreate(name="Template", sections=[]),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    await service.create_chart(
+        ChartCreate(template_id=template.id, client_id=client.id),
+        caregiver_id=cg.id,
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    charts, total = await service.list_charts(client_id=client.id)
+    assert total == 1
+    assert charts[0].client_id == client.id
+
+    # No results for random client
+    other_charts, other_total = await service.list_charts(client_id=uuid.uuid4())
+    assert other_total == 0

--- a/api/app/tests/test_credentials.py
+++ b/api/app/tests/test_credentials.py
@@ -1,0 +1,263 @@
+"""Tests for credential management with expiration tracking."""
+
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+from app.models import Agency, Client, Credential, Shift, User, Visit  # noqa: F401
+from app.models.credential import CredentialStatus, CredentialType
+from app.models.user import UserRole
+from app.schemas.credential import CredentialCreate, CredentialUpdate
+from app.services.credential import CredentialService
+
+TEST_DB_URL = "sqlite+aiosqlite:///./test_credentials.db"
+AGENCY_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+TODAY = date.today()
+
+
+@pytest.fixture
+async def session() -> AsyncGenerator[AsyncSession, None]:
+    engine = create_async_engine(TEST_DB_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as s:
+        agency = Agency(id=AGENCY_ID, name="Test Agency", slug="test-agency")
+        s.add(agency)
+        await s.commit()
+        yield s
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.drop_all)
+    await engine.dispose()
+
+
+async def _create_caregiver(session: AsyncSession) -> User:
+    cg = User(
+        email="cg@test.com",
+        first_name="CG",
+        last_name="Test",
+        role=UserRole.CAREGIVER,
+        agency_id=AGENCY_ID,
+    )
+    session.add(cg)
+    await session.commit()
+    await session.refresh(cg)
+    return cg
+
+
+@pytest.mark.asyncio
+async def test_create_credential(session: AsyncSession) -> None:
+    """Creating a credential stores all fields."""
+    cg = await _create_caregiver(session)
+    service = CredentialService(session)
+
+    cred = await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.LICENSE,
+            name="RN License",
+            issuing_authority="State Board of Nursing",
+            credential_number="RN-12345",
+            issued_date=TODAY - timedelta(days=365),
+            expiration_date=TODAY + timedelta(days=180),
+        ),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    assert cred.name == "RN License"
+    assert cred.credential_type == CredentialType.LICENSE
+    assert cred.status == CredentialStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_update_credential(session: AsyncSession) -> None:
+    """Updating a credential changes the specified fields."""
+    cg = await _create_caregiver(session)
+    service = CredentialService(session)
+
+    cred = await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.CERTIFICATION,
+            name="CPR Cert",
+        ),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    updated = await service.update_credential(
+        cred.id,
+        CredentialUpdate(name="CPR/AED Certification", issuing_authority="AHA"),
+    )
+    await session.commit()
+
+    assert updated is not None
+    assert updated.name == "CPR/AED Certification"
+    assert updated.issuing_authority == "AHA"
+
+
+@pytest.mark.asyncio
+async def test_delete_credential(session: AsyncSession) -> None:
+    """Deleting a credential removes it from the database."""
+    cg = await _create_caregiver(session)
+    service = CredentialService(session)
+
+    cred = await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.TRAINING,
+            name="HIPAA Training",
+        ),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    deleted = await service.delete_credential(cred.id)
+    await session.commit()
+    assert deleted is True
+
+    # Verify it's gone
+    result = await service.get_credential(cred.id)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_check_expiring_finds_credentials(session: AsyncSession) -> None:
+    """check_expiring returns credentials expiring within 90 days."""
+    cg = await _create_caregiver(session)
+    service = CredentialService(session)
+
+    # Expiring in 30 days - should appear
+    await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.LICENSE,
+            name="Expiring License",
+            expiration_date=TODAY + timedelta(days=30),
+        ),
+        agency_id=AGENCY_ID,
+    )
+    # Expiring in 180 days - should NOT appear
+    await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.CERTIFICATION,
+            name="Far Out Cert",
+            expiration_date=TODAY + timedelta(days=180),
+        ),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    alerts = await service.check_expiring(reference_date=TODAY)
+    assert len(alerts) == 1
+    assert alerts[0].name == "Expiring License"
+    assert alerts[0].days_until_expiry == 30
+
+
+@pytest.mark.asyncio
+async def test_check_expiring_excludes_past(session: AsyncSession) -> None:
+    """check_expiring excludes already-expired credentials."""
+    cg = await _create_caregiver(session)
+    service = CredentialService(session)
+
+    await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.LICENSE,
+            name="Already Expired",
+            expiration_date=TODAY - timedelta(days=10),
+        ),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    alerts = await service.check_expiring(reference_date=TODAY)
+    assert len(alerts) == 0
+
+
+@pytest.mark.asyncio
+async def test_update_expiration_statuses(session: AsyncSession) -> None:
+    """update_expiration_statuses transitions credentials to correct status."""
+    cg = await _create_caregiver(session)
+    service = CredentialService(session)
+
+    # Create credentials at different stages
+    expired_cred = await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.LICENSE,
+            name="Expired",
+            expiration_date=TODAY - timedelta(days=5),
+        ),
+        agency_id=AGENCY_ID,
+    )
+    expiring_cred = await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.CERTIFICATION,
+            name="Expiring Soon",
+            expiration_date=TODAY + timedelta(days=45),
+        ),
+        agency_id=AGENCY_ID,
+    )
+    active_cred = await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.TRAINING,
+            name="Still Active",
+            expiration_date=TODAY + timedelta(days=200),
+        ),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    updated_count = await service.update_expiration_statuses(reference_date=TODAY)
+    await session.commit()
+
+    # Refresh to get updated statuses
+    expired_refreshed = await service.get_credential(expired_cred.id)
+    expiring_refreshed = await service.get_credential(expiring_cred.id)
+    active_refreshed = await service.get_credential(active_cred.id)
+
+    assert expired_refreshed is not None
+    assert expired_refreshed.status == CredentialStatus.EXPIRED
+    assert expiring_refreshed is not None
+    assert expiring_refreshed.status == CredentialStatus.EXPIRING_SOON
+    assert active_refreshed is not None
+    assert active_refreshed.status == CredentialStatus.ACTIVE
+    assert updated_count == 2  # expired + expiring_soon changed
+
+
+@pytest.mark.asyncio
+async def test_list_credentials_filter_by_type(session: AsyncSession) -> None:
+    """Filtering credentials by type returns correct subset."""
+    cg = await _create_caregiver(session)
+    service = CredentialService(session)
+
+    await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.LICENSE,
+            name="License",
+        ),
+        agency_id=AGENCY_ID,
+    )
+    await service.create_credential(
+        CredentialCreate(
+            caregiver_id=cg.id,
+            credential_type=CredentialType.TRAINING,
+            name="Training",
+        ),
+        agency_id=AGENCY_ID,
+    )
+    await session.commit()
+
+    creds, total = await service.list_credentials(credential_type=CredentialType.LICENSE)
+    assert total == 1
+    assert creds[0].name == "License"


### PR DESCRIPTION
## Summary
- **Charting API (#15, #16):** ChartTemplate model with versioned JSON sections, Chart model with template-based patient records, data versioning, and signing workflow (draft → signed)
- **Credential Management (#17):** Credential model with type classification (license, certification, training, etc.), expiration tracking with 90/60/30/7-day alert flags, bulk status updates (active → expiring_soon → expired)
- REST endpoints for templates, charts, credentials with role-based access (caregiver+ for charts, care_manager+ for credentials)

## Test plan
- [x] 8 charting tests: template CRUD, version bumping, deactivation, chart creation, data versioning, signing, client filtering
- [x] 7 credential tests: CRUD, delete, expiring alerts (within/outside window), bulk status updates, type filtering
- [x] Full suite: 87 passed, 3 skipped (PostgreSQL-only)
- [x] ruff check + ruff format + mypy clean

Closes #15, closes #16, closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)