### PR TITLE
docs(#53): genericize Claude-centric AI agent language

### DIFF
--- a/.claude/commands/ramd.md
+++ b/.claude/commands/ramd.md
@@ -40,7 +40,7 @@ Closes #<issue-number>
 - [ ] CI passes
 - [ ] Docker health check passes
 EOF
-)" --label "ai:claude-code"
+)" --label "ai:autonomous"
 ```
 
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ htmlcov/
 coverage/
 *.lcov
 
-# Claude Code
+# AI Agent
 .claude/worktrees/
 .claude/memory/progress/*.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Test accounts (seeded by `make api-seed`):
 - Git commits use `suniljames <suniljames@users.noreply.github.com>`.
 
 ### Fully Autonomous Workflow
-- **No human review gates.** Claude Code fills every role: PM, UX Designer, Software Engineer, System Architect, Data Engineer, AI/ML Engineer, Security Engineer, QA Engineer, SRE, Tech Writer, and the Engineering Manager.
+- **No human review gates.** The AI agent fills every role: PM, UX Designer, Software Engineer, System Architect, Data Engineer, AI/ML Engineer, Security Engineer, QA Engineer, SRE, Tech Writer, and the Engineering Manager.
 - Product questions are resolved by the PM persona inline.
 - Engineering questions are resolved by the Engineering Manager (convening the committee if needed).
 - The full `/pm` -> `/design` -> `/implement` -> `/ramd` pipeline runs without stopping.


### PR DESCRIPTION
## Summary
- Replace "Claude Code fills every role" → "The AI agent fills every role" in `CLAUDE.md`
- Change PR label from `ai:claude-code` → `ai:autonomous` in `.claude/commands/ramd.md`
- Update `.gitignore` section comment from `# Claude Code` → `# AI Agent`

Prepares shared docs for multi-agent support (Gemini CLI). All Claude API product references and `.claude/` paths are intentionally kept.

Closes #53

## Test plan
- [x] `grep -ri "claude code" .` returns zero matches outside `.claude/` tool-specific files
- [x] `git diff` confirms only 3 lines changed
- [x] All remaining "Claude" references are Claude API product refs or `.claude/` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)