### PR TITLE
refactor: update directives references for manifest-driven architecture

### DIFF
--- a/.claude/commands/pm.md
+++ b/.claude/commands/pm.md
@@ -13,7 +13,7 @@ Use `--repo "$REPO"` on every `gh` command.
 
 ## Persona
 
-Read `docs/organization/engineering/personas/11-pm.md` for the PM persona.
+Read the [PM persona](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/pm.md).
 
 Read `.claude/pm-context.md` for domain context (in-home medical care, HIPAA,
 multi-tenant SaaS, care workflows, compliance requirements, stakeholder personas).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ Multi-tenant SaaS platform for home care coordination. Ground-up rebuild with Fa
 
 This project follows the [engineering directives](https://github.com/suniljames/directives) (includes [healthcare overlay](https://github.com/suniljames/directives/blob/main/overlays/healthcare/)).
 
+<!-- team: engineering -->
 <!-- pipeline-mode: autonomous -->
 
 ## Tech Stack

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # COREcare v2 — Gemini Agent Config
 
-You are the **validator/risk manager** agent. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first, then the [engineering directives](https://github.com/suniljames/directives).
+You are the **validator** agent. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first, then the [engineering directives](https://github.com/suniljames/directives).
 
 Project-specific docs:
 - [`docs/developer/ARCHITECTURE.md`](docs/developer/ARCHITECTURE.md) — codebase patterns
@@ -13,26 +13,21 @@ Project-specific docs:
 
 ## Your Roles
 
-You own 4 of the 11 engineering committee personas (see [directives](https://github.com/suniljames/directives/blob/main/process/committee-process.md)):
+You are the **validator** agent. Your roles are defined in the [engineering team manifest](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) — all roles where `agent: validator`.
 
-| # | Role | Persona |
-|---|------|---------|
-| 6 | Security Engineer | [directives](https://github.com/suniljames/directives/blob/main/personas/06-security-engineer.md) |
-| 7 | QA Engineer | [directives](https://github.com/suniljames/directives/blob/main/personas/07-qa-engineer.md) |
-| 9 | Tech Writer | [directives](https://github.com/suniljames/directives/blob/main/personas/09-writer.md) |
-| 11 | PM | [directives](https://github.com/suniljames/directives/blob/main/personas/11-pm.md) |
+Read each persona file to understand your responsibilities:
+- [Security Engineer](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/security-engineer.md)
+- [QA Engineer](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/qa-engineer.md)
+- [Writer](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/writer.md)
+- [PM](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/pm.md)
 
-Roles you do NOT own (Claude Code's): Engineering Manager, Software Engineer, System Architect, Data Engineer, AI/ML Engineer, UX Designer, SRE. File findings; don't fix.
+Roles you do NOT own (builder agent's): all roles where `agent: builder` in the manifest. File findings; don't fix.
 
 ## What You Produce
 
-**Stage 1 — Product Review (PM):** Write a PRD comment ([template](https://github.com/suniljames/directives/blob/main/process/prd-template.md) + [healthcare addendum](https://github.com/suniljames/directives/blob/main/overlays/healthcare/prd-addendum.md)), add `pm-reviewed` label.
+See the [pipeline stages](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) for your responsibilities at each stage. Use severity levels from the manifest's `vocabularies.severity_levels` when posting review findings.
 
-**Stage 2 — Design Review (Security + QA):** Post Security + QA findings, write a test specification ([format](https://github.com/suniljames/directives/blob/main/process/committee-process.md)).
-
-**Stage 4 — Code Review (Security + QA):** `gh pr diff <number>`, post findings as `MUST-FIX` / `SHOULD-FIX` / `NIT`.
-
-**Stage 6 — Summarize (Tech Writer):** Plain-language summary of what changed, why, who it affects.
+For PRDs, use the [template](https://github.com/suniljames/directives/blob/main/teams/engineering/process/prd-template.md) + [healthcare addendum](https://github.com/suniljames/directives/blob/main/overlays/healthcare/prd-addendum.md).
 
 ## What NOT to Do
 

--- a/docs/developer/code-review-lenses.md
+++ b/docs/developer/code-review-lenses.md
@@ -1,6 +1,6 @@
 # Code Review Lenses
 
-> Persona backgrounds and generic review lenses are in the [engineering directives](https://github.com/suniljames/directives/blob/main/process/code-review-framework.md).
+> Persona backgrounds and generic review lenses are in the [engineering directives](https://github.com/suniljames/directives/blob/main/teams/engineering/process/code-review-framework.md).
 > Below are the **COREcare-specific** technology checklists for each role.
 
 Each engineering committee member reviews the PR diff through a **code-review-specific**


### PR DESCRIPTION
## Summary

- Add `<!-- team: engineering -->` declaration to CONTRIBUTING.md
- Update GEMINI.md to reference manifest instead of hardcoding role numbers and persona paths
- Fix stale persona path in `.claude/commands/pm.md`
- Fix stale code-review-framework path in `docs/developer/code-review-lenses.md`

Cascades changes from suniljames/directives#2.

## Test plan

- [ ] Verify all GitHub links in GEMINI.md resolve after directives PR merges
- [ ] Verify pm.md persona link resolves

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)