### PR TITLE
fix: reconcile stale references and hardcoded numbering

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -43,13 +43,13 @@ If purely backend/API/infra, skip mockups.
 
 ## Conduct the committee review
 
-Follow `docs/developer/ENGINEERING_COMMITTEE.md`:
+Follow the [committee process](https://github.com/suniljames/directives/blob/main/teams/engineering/process/committee-process.md):
 
 1. **If UI/UX change:** UX Designer documents Design Direction and generates SVG mockups
    - Create `docs/mockups/<issue-number>/` directory
    - Generate high-fidelity SVGs consistent with `docs/design-system/`
    - Commit and push the SVGs
-2. Each committee member posts their review **in order** (1-9), reading ALL prior comments
+2. Each committee member posts their review **in review order** (per manifest), reading ALL prior comments
    - Post each review as a separate GitHub issue comment
    - **Committee is primed for FastAPI + Next.js 15 + shadcn/ui + PostgreSQL RLS + Clerk**
 3. The Engineering Manager synthesizes all feedback into a final unified plan

--- a/.claude/commands/pm.md
+++ b/.claude/commands/pm.md
@@ -61,7 +61,7 @@ gh issue view <number> --repo "$REPO" --comments
 
 ## Step 4: Write the PRD
 
-Read the PRD template from `docs/developer/prd-template.md`.
+Read the [PRD template](https://github.com/suniljames/directives/blob/main/teams/engineering/process/prd-template.md).
 
 Compose the PRD using that template with the persona context from
 `.claude/pm-context.md`. Every section is **required** — use "N/A" with a

--- a/.claude/commands/ramd.md
+++ b/.claude/commands/ramd.md
@@ -79,7 +79,7 @@ gh pr diff <number> --repo "$REPO"
 ### B.2: Each committee member reviews through their code-review lens
 
 Read `docs/developer/code-review-lenses.md` for role definitions.
-Each of the 9 members reviews the diff, categorizing findings as MUST-FIX, SHOULD-FIX, or NIT.
+Each committee member (per manifest review order) reviews the diff, categorizing findings as MUST-FIX, SHOULD-FIX, or NIT.
 Post each review as a PR comment.
 
 ### B.3: Engineering Manager synthesizes

--- a/.claude/commands/references/prd-template.md
+++ b/.claude/commands/references/prd-template.md
@@ -1,5 +1,3 @@
 # PRD Template
 
-Moved to `docs/developer/prd-template.md`. This file is kept as a redirect.
-
-See [docs/developer/prd-template.md](../../../docs/developer/prd-template.md) for the current version.
+See the [PRD template in directives](https://github.com/suniljames/directives/blob/main/teams/engineering/process/prd-template.md) for the current version.

--- a/docs/adr/009-multi-agent-engineering-split.md
+++ b/docs/adr/009-multi-agent-engineering-split.md
@@ -10,7 +10,7 @@ A single AI model acting as both builder and validator creates correlated failur
 
 ## Decision
 
-Split engineering agent roles across two LLM backends: **Claude Code** (builder/executor) and **Google Gemini** (validator/risk manager).
+Split engineering agent roles across two LLM backends: **Claude Code** (builder) and **Google Gemini** (validator).
 
 The full rationale, role assignments, coordination protocol, and guiding principles are documented in the [engineering directives](https://github.com/suniljames/directives/blob/main/process/agent-architecture.md).
 

--- a/docs/developer/code-review-lenses.md
+++ b/docs/developer/code-review-lenses.md
@@ -16,7 +16,7 @@ lens during `/ramd` Phase B.
 
 ---
 
-## 1. UX Designer
+## UX Designer
 
 **Skip if:** No frontend files (tsx, css, components) in the diff.
 
@@ -29,7 +29,7 @@ lens during `/ramd` Phase B.
 
 ---
 
-## 2. Senior Software Engineer
+## Software Engineer
 
 **What to look for:**
 - Code quality: DRY, dead code, complexity
@@ -40,7 +40,7 @@ lens during `/ramd` Phase B.
 
 ---
 
-## 3. System Architect
+## System Architect
 
 **What to look for:**
 - Service layer separation (routers -> services -> models)
@@ -50,7 +50,7 @@ lens during `/ramd` Phase B.
 
 ---
 
-## 4. Principal Data Engineer
+## Data Engineer
 
 **What to look for:**
 - Alembic migration safety: reversible, separate data from schema migrations
@@ -60,7 +60,7 @@ lens during `/ramd` Phase B.
 
 ---
 
-## 5. Principal AI/ML Engineer
+## AI/ML Engineer
 
 **Skip if:** No AI/ML code (no Claude API calls, no prompt construction).
 
@@ -72,7 +72,7 @@ lens during `/ramd` Phase B.
 
 ---
 
-## 6. Principal Security Engineer
+## Security Engineer
 
 **What to look for:**
 - Injection vectors (SQL via raw queries, XSS, template injection)
@@ -84,17 +84,17 @@ lens during `/ramd` Phase B.
 
 ---
 
-## 7. Principal QA Engineer
+## QA Engineer
 
 **What to look for:**
 - Test coverage for changed/added code
 - Edge cases, assertion quality, fixture adequacy
 - Test isolation, mock boundaries
-- Correct test layer per TEST_BUDGET.md (service > integration > E2E)
+- Correct test layer per [test-budget.md](https://github.com/suniljames/directives/blob/main/teams/engineering/process/test-budget.md) (service > integration > E2E)
 
 ---
 
-## 8. Senior SRE
+## SRE
 
 **What to look for:**
 - Error handling: graceful degradation for external services
@@ -104,7 +104,7 @@ lens during `/ramd` Phase B.
 
 ---
 
-## 9. Principal Writer
+## Writer
 
 **What to look for:**
 - User-facing copy: helpful errors, clear labels

--- a/docs/developer/project-context.md
+++ b/docs/developer/project-context.md
@@ -13,7 +13,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 
 ## Persona: Project-Specific Knowledge
 
-### 1. UX Designer
+### UX Designer
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -24,7 +24,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Component reuse | Shared component library across admin, caregiver, and family portals |
 | Multi-tenant UI | Agency branding, tenant-scoped navigation, super-admin views |
 
-### 2. Software Engineer
+### Software Engineer
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -35,7 +35,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Code quality | `make check` gate: linters, type checking, tests, build |
 | Auth integration | Clerk JWT validation in FastAPI dependencies |
 
-### 3. System Architect
+### System Architect
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -46,7 +46,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Deployment | Docker Compose on local Mac Mini, single-node simplicity |
 | Event patterns | Domain events for audit logging, notification triggers |
 
-### 4. Data Engineer
+### Data Engineer
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -57,7 +57,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Audit trails | Temporal tracking for care plans, medication changes, visit logs |
 | Data integrity | Foreign keys, check constraints, unique constraints for business rules |
 
-### 5. AI/ML Engineer
+### AI/ML Engineer
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -68,7 +68,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Cost management | Token tracking, model selection (Haiku vs Sonnet vs Opus), caching |
 | Audit trail | Logging all AI interactions for HIPAA compliance and quality review |
 
-### 6. Security Engineer
+### Security Engineer
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -79,18 +79,18 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Logging | PHI exclusion from logs, structured audit logging for compliance |
 | Secrets | Environment variable management, no secrets in code or Docker images |
 
-### 7. QA Engineer
+### QA Engineer
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
-| Test layers | pytest (service/endpoint), vitest (components), Playwright (E2E) per `TEST_BUDGET.md` |
+| Test layers | pytest (service/endpoint), vitest (components), Playwright (E2E) per [test-budget.md](https://github.com/suniljames/directives/blob/main/teams/engineering/process/test-budget.md) |
 | Test format | Given/When/Then specs for all test layers |
 | Quality gates | `make check` must pass: linters + tests + typecheck + build |
 | CI | GitHub Actions against PostgreSQL 16 |
 | Multi-tenant testing | Tenant isolation verification in service tests for every data-access endpoint |
 | Test markers | `@smoke`, `@security` for Playwright; unmarked for standard tests |
 
-### 8. SRE
+### SRE
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -101,7 +101,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Resource management | PostgreSQL connection pooling, Redis connection management |
 | Monitoring | Health check verification, container resource usage tracking |
 
-### 9. Writer
+### Writer
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -112,7 +112,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Documentation | Developer docs, ADRs, design system documentation |
 | Accessibility | Alt text, ARIA labels, meaningful link text, screen reader support |
 
-### 10. Engineering Manager
+### Engineering Manager
 
 | Expertise | COREcare Application |
 |-----------|---------------------|
@@ -123,7 +123,7 @@ Project-specific persona knowledge and engineering compromises. This extends the
 | Tech debt tracking | Identifying shortcuts that need to be repaid and when |
 | Operational health | Ensuring shipped features are operable, not just functional |
 
-### 11. PM
+### PM
 
 | Expertise | COREcare Application |
 |-----------|---------------------|


### PR DESCRIPTION
Follows up on #63

## Summary
- ADR-009: updated stale "builder/executor" and "validator/risk manager" → "builder" and "validator"
- code-review-lenses.md: dropped numbered sections (1-9) and Senior/Principal prefixes to match manifest names
- project-context.md: dropped numbered persona headers (1-11)
- design.md: fixed reference to nonexistent `ENGINEERING_COMMITTEE.md` → directives committee-process link
- pm.md: fixed reference to nonexistent `docs/developer/prd-template.md` → directives link
- ramd.md: replaced hardcoded "9 members" with manifest reference
- Fixed `TEST_BUDGET.md` references → directives test-budget.md link
- Updated prd-template redirect to point to directives repo

## Test plan
- [x] All stale file references now point to valid locations
- [x] Role names match manifest canonical names
- [x] No hardcoded member counts remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)