### PR TITLE
feat(#68): wire project with shared Claude Code magic from dotfiles

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,78 @@
+{
+  "_comment": "Hooks are sourced from suniljames/dotfiles via ~/.claude/hooks/. Each command guards with [ -x ... ] so missing hooks gracefully no-op rather than erroring. Install dotfiles to activate hooks.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -x $HOME/.claude/hooks/check-gh-token-drift.sh ] && $HOME/.claude/hooks/check-gh-token-drift.sh || exit 0"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -x $HOME/.claude/hooks/gh-auth-switch.sh ] && $HOME/.claude/hooks/gh-auth-switch.sh || exit 0"
+          },
+          {
+            "type": "command",
+            "command": "[ -x $HOME/.claude/hooks/safety-check.sh ] && exec $HOME/.claude/hooks/safety-check.sh || exit 0"
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -x $HOME/.claude/hooks/simplify-gate.sh ] && exec $HOME/.claude/hooks/simplify-gate.sh || exit 0"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -x $HOME/.claude/hooks/post-tool-check.sh ] && $HOME/.claude/hooks/post-tool-check.sh || exit 0"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -x $HOME/.claude/hooks/worklog-reminder.sh ] && $HOME/.claude/hooks/worklog-reminder.sh || exit 0"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(gh *)",
+      "Bash(git *)",
+      "Bash(docker *)",
+      "Bash(docker compose *)",
+      "Bash(make *)",
+      "Bash(pnpm *)",
+      "Bash(npm *)",
+      "Bash(uv *)",
+      "Bash(uvx *)",
+      "Bash(pytest *)",
+      "Bash(alembic *)",
+      "Bash(curl *)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:docs.anthropic.com)"
+    ]
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,20 @@ Project-specific docs:
 - [`docs/developer/SAFETY.md`](docs/developer/SAFETY.md) — project-specific safety rules
 - [`docs/developer/code-review-lenses.md`](docs/developer/code-review-lenses.md) — tech-specific review checklists
 - [`docs/developer/project-context.md`](docs/developer/project-context.md) — project-specific persona knowledge
+
+## Shared Claude Code magic
+
+This project inherits shared hooks and scripts from [`suniljames/dotfiles`](https://github.com/suniljames/dotfiles). `.claude/settings.json` references hooks at `$HOME/.claude/hooks/*` with graceful no-op fallback if dotfiles isn't installed on the machine.
+
+To activate hooks locally:
+
+```bash
+git clone https://github.com/suniljames/dotfiles.git ~/Code/dotfiles
+cd ~/Code/dotfiles && ./install.sh
+```
+
+Worktree cleanup runs from the dotfiles-provided script (no local copy needed):
+
+```bash
+~/Code/dotfiles/scripts/cleanup_worktrees.py --repo-root "$(git rev-parse --show-toplevel)"
+```


### PR DESCRIPTION
Closes #68.

## Summary

- Adds `.claude/settings.json` wiring shared hooks from `suniljames/dotfiles` (via `\$HOME/.claude/hooks/`).
- Adds `.mcp.json` with the GitHub MCP server.
- Documents the shared-magic inheritance pattern in `CLAUDE.md`.

## How the hook inheritance works

Hooks live once in `suniljames/dotfiles/.claude/hooks/` and are symlinked into `~/.claude/hooks/` by dotfiles' `install.sh`. This project references them via `\$HOME` expansion:

\`\`\`json
"command": "[ -x \$HOME/.claude/hooks/safety-check.sh ] && exec \$HOME/.claude/hooks/safety-check.sh || exit 0"
\`\`\`

The `[ -x … ] && … || exit 0` guard means: if dotfiles isn't installed on a machine (e.g. a fresh clone, CI, or a new teammate's first run), the hook silently no-ops. The project works normally. When dotfiles is installed, every hook activates.

## Hooks wired

| Trigger | Hook | Purpose |
|---|---|---|
| SessionStart | `check-gh-token-drift.sh` | Warn if `.env` PAT drifted from `gh auth token` |
| PreToolUse (Bash) | `gh-auth-switch.sh` | Ensure `gh` is on `suniljames` before gh cmds |
| PreToolUse (Bash) | `safety-check.sh` | Block `rm -rf`, force-push, `DROP TABLE`, etc. |
| PreToolUse (Skill) | `simplify-gate.sh` | Require `/simplify` pass before `/ship` |
| PostToolUse (Write\\|Edit) | `post-tool-check.sh` | Auto-format + lint on save |
| Stop | `worklog-reminder.sh` | Nudge WORKLOG.md on multi-agent handoff |

## Dependency

Blocked on [suniljames/dotfiles#2](https://github.com/suniljames/dotfiles/pull/2) for the hooks to actually exist at the referenced paths. Until that merges and `install.sh` runs on the machine, this PR is inert (hooks no-op gracefully, but no harm). Safe to merge in any order.

## Not in this PR

- `scripts/devserver.sh` — `docker compose` already covers the dev-server surface. Worktree-level port isolation for Docker Compose is its own design problem (needs `COMPOSE_PROJECT_NAME` per worktree + port overrides) and is out of scope here.
- `scripts/cleanup_worktrees.py` — no need to duplicate. Call the dotfiles version directly: `~/Code/dotfiles/scripts/cleanup_worktrees.py --repo-root \"\$(git rev-parse --show-toplevel)\"`.
- launchd plists — installed on the Mac Mini via dotfiles `install-launchd.sh`, not per-project.

## Test plan

- [ ] After dotfiles#2 merges + `~/Code/dotfiles/install.sh` runs on the Mini, opening a Bash tool call blocks `rm -rf ~/Code/test` (safety-check)
- [ ] Editing a `.ts` file triggers `[hook] file.ts: formatted` in output
- [ ] `gh auth switch` happens automatically before any `gh` command when the active account isn't `suniljames`
- [ ] On a machine without dotfiles installed, all hooks silently no-op and the project still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)