### PR TITLE
fix(#72): unblock Web Build by setting Clerk publishable key in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,13 @@ jobs:
     defaults:
       run:
         working-directory: web
+    # Build-time-only dummy Clerk publishable key. ClerkProvider lives in the
+    # root layout, so every prerendered route validates the key at build time.
+    # The key below is a publicly-known dummy in Clerk's own examples — it
+    # passes Clerk's format check but cannot authenticate. Real production keys
+    # live in deployment env (Vercel etc.), not CI.
+    env:
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_Y2xlcmsuaW5jbHVkZWQua2F0eWRpZC05Mi5sY2wuZGV2JA
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

ClerkProvider lives in the root layout (`web/src/app/layout.tsx`), so every prerendered route validates the publishable key at build time. CI had no key set → `throwMissingPublishableKeyError` → Web Build red on main since 2026-04-15.

This PR sets `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` in the `web-build` job to a publicly-known dummy from Clerk's own examples. The dummy passes Clerk's format check but cannot authenticate. Real production keys live in deployment env (Vercel etc.), not CI — by design.

Closes #72.

## Why this approach over the others

The issue laid out three options. I picked option 1 (env var in CI) but with a hardcoded public dummy instead of a GitHub secret, because:

- Option 2 (force-dynamic on `/`) gives up static optimization for a page that genuinely is static — and doesn't fix the underlying problem (every layout-using route would still need to be marked dynamic).
- Option 3 (move Clerk evaluation out of module scope) requires invasive layout changes, and the standard Clerk + Next.js pattern explicitly recommends the provider in the root layout.
- Option 1 with a real Clerk test instance + GitHub secret was the heaviest. The hardcoded dummy is publicly known (used in Clerk's own example apps), satisfies the build-time format validation, and requires zero ops setup.

## Verification

Built locally with the dummy key:

```
NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_Y2xlcmsuaW5jbHVkZWQua2F0eWRpZC05Mi5sY2wuZGV2JA pnpm build
```

```
Route (app)                                 Size  First Load JS
┌ ○ /                                      121 B         102 kB
├ ○ /_not-found                            993 B         103 kB
├ ƒ /sign-in/[[...sign-in]]                392 B         141 kB
└ ƒ /sign-up/[[...sign-up]]                392 B         141 kB
```

All 4 pages render clean. `/sign-in` and `/sign-up` are correctly marked dynamic (`ƒ`) so they don't prerender — the original blocker was purely the root-layout ClerkProvider, not the auth pages themselves.

## Test plan

- [ ] Web Build green on this PR
- [ ] After merge: Web Build green on `main`
- [ ] No production Clerk key in source or CI logs (dummy is build-only, no auth capability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)