### PR TITLE
fix(#74): unblock E2E by aligning compose api command + populating .venv in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,13 @@ jobs:
           node-version: 20
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      # docker-compose.yml bind-mounts ./api over /app, which overlays the
+      # Dockerfile-installed .venv. Populate ./api/.venv on the runner so
+      # `uv run uvicorn` resolves inside the container.
+      - run: cd api && uv sync --frozen
       - run: cd web && pnpm install --frozen-lockfile
       - run: cd web && pnpm exec playwright install --with-deps chromium
       - run: docker compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
   web:
     build:


### PR DESCRIPTION
## Summary

E2E Tests has been broken since at least 2026-04-15 but was masked behind the Web Build failure (#72) — the job's `needs: [api-test, web-build]` gate prevented it from running. After #72 was fixed (PR #73, merged this session), E2E ran for the first time and failed:

```
Error response from daemon: failed to create task for container:
OCI runtime create failed: ... exec: "uvicorn": executable file not found in $PATH
```

Closes #74.

## Root cause

Two compounding bugs in `docker-compose.yml`:

1. **`command: uvicorn ...`** uses bare `uvicorn`, but the Dockerfile installs uvicorn into `/app/.venv/bin/` via `uv`. The Dockerfile `CMD` correctly uses `uv run uvicorn`; the compose file overrides that with bare `uvicorn`, which isn't on the container's system PATH.
2. **`volumes: - ./api:/app`** bind-mounts the host's `./api` over `/app`, overlaying the Dockerfile-built `.venv` with whatever the host has — or doesn't have. Local devs work because they run `uv sync` on the host first; CI doesn't.

## Fix

- `docker-compose.yml`: api command → `uv run uvicorn ...` (matches Dockerfile `CMD`; resilient regardless of system PATH state).
- `.github/workflows/ci.yml` E2E job: add `cd api && uv sync --frozen` step before `docker compose up -d` so the bind-mounted host `.venv` is populated.

Total diff: 2 files, +8/-1 lines.

## Verification

Reproduced locally on the Mac Mini (Darwin/arm64, OrbStack-backed Docker):

```
$ cd api && uv sync --frozen
$ docker compose up -d
$ docker compose logs api | tail
api-1  | INFO:     Uvicorn running on http://0.0.0.0:8000
api-1  | INFO:     Started reloader process [49] using WatchFiles
api-1  | INFO:     Started server process [51]
api-1  | INFO:     Application startup complete.
```

Cross-platform note: I ran `uv sync` on Darwin/arm64 and bind-mounted into a Linux container, which usually mismatches binaries — `uv` re-synced inside the container at runtime (visible in logs as `Installed 64 packages in 1.22s`). On CI's `ubuntu-latest` runner, the host venv is already Linux-native, so this re-sync won't happen and the container will start faster.

## Test plan

- [ ] E2E Tests green on this PR (note: E2E job is gated to `refs/heads/main`, so it won't actually run against this PR — verification will happen post-merge on `main`)
- [ ] After merge: E2E Tests green on `main`'s post-push CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)