### PR TITLE
fix(#76): scaffold Playwright config + smoke test, wait for web in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
       - run: docker compose up -d
       - run: |
           timeout 60 bash -c 'until curl -sf http://localhost:8000/healthz; do sleep 2; done'
+      - run: |
+          timeout 120 bash -c 'until curl -sf http://localhost:3000/ > /dev/null; do sleep 2; done'
       - run: cd web && pnpm test:e2e
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "@playwright/test";
+
+test("home page renders the COREcare heading", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByRole("heading", { name: "COREcare v2" })).toBeVisible();
+});

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? "http://localhost:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

After #74 fixed the docker startup, E2E Tests still failed because Playwright was sweeping up the vitest tests in `web/src/__tests__/`:

```
Error: Vitest cannot be imported in a CommonJS module using require(). Please use "import" instead.
   at src/__tests__/middleware.test.ts:1
```

Closes #76.

## Root cause

Two gaps:

1. **No `playwright.config.*` in `web/`** — Playwright defaulted to scanning the whole project for `*.test.*` / `*.spec.*` and picked up the vitest tests.
2. **No actual Playwright tests existed** — `web/e2e/` was missing. The npm script, CI step, and `@playwright/test` dep were all wired, but the test directory had never been scaffolded.

## Fix

- `web/playwright.config.ts`: `testDir: './e2e'`, `baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000'`, single chromium project, retries on CI, screenshot on failure.
- `web/e2e/smoke.spec.ts`: one smoke test — visits `/`, asserts the `COREcare v2` heading renders.
- `.github/workflows/ci.yml` E2E job: add a `until curl -sf http://localhost:3000/` wait alongside the existing `/healthz` wait, so Playwright doesn't race the web container.

## Verification

Reproduced locally on the Mini:

```
$ docker compose up -d
$ pnpm exec playwright test
Running 1 test using 1 worker
  ✓  1 [chromium] › e2e/smoke.spec.ts:3:5 › home page renders the COREcare heading (786ms)
  1 passed (1.9s)
```

E2E Tests is gated to `refs/heads/main` so it won't run on this PR — final verification has to happen post-merge on `main`.

## Test plan

- [ ] After merge: E2E Tests green on `main`'s post-push CI run
- [ ] Future Playwright tests added to `web/e2e/` get picked up without further config

🤖 Generated with [Claude Code](https://claude.com/claude-code)