### PR TITLE
docs(#78): infrastructure for v1 reference docset (1/N)

### DIFF
--- a/.github/workflows/v1-doc-hygiene.yml
+++ b/.github/workflows/v1-doc-hygiene.yml
@@ -1,0 +1,73 @@
+name: V1 Doc Hygiene
+
+on:
+  pull_request:
+    paths:
+      - 'docs/migration/v1-*.md'
+      - 'scripts/check-v1-doc-hygiene.sh'
+      - 'scripts/check-v1-doc-structure.sh'
+      - 'scripts/tests/test_check_v1_doc_*.sh'
+      - '.github/workflows/v1-doc-hygiene.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'docs/migration/v1-*.md'
+      - 'scripts/check-v1-doc-hygiene.sh'
+      - 'scripts/check-v1-doc-structure.sh'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scripts-self-test:
+    name: Hygiene + structure scripts self-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run hygiene script tests
+        run: bash scripts/tests/test_check_v1_doc_hygiene.sh
+      - name: Run structure script tests
+        run: bash scripts/tests/test_check_v1_doc_structure.sh
+
+  scan-v1-docs:
+    name: Scan v1 reference docs in repo
+    runs-on: ubuntu-latest
+    needs: scripts-self-test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Hygiene scan over docs/migration/v1-*.md
+        run: |
+          shopt -s nullglob
+          files=(docs/migration/v1-*.md)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "No v1 reference docs present yet — skipping hygiene scan."
+            exit 0
+          fi
+          bash scripts/check-v1-doc-hygiene.sh "${files[@]}"
+      - name: Structure validation
+        run: |
+          if [[ -f docs/migration/v1-pages-inventory.md && -f docs/migration/v1-functionality-delta.md ]]; then
+            bash scripts/check-v1-doc-structure.sh
+          else
+            echo "Pages inventory or delta doc not yet present — structure check skipped."
+          fi
+
+  gitleaks:
+    name: Secret scan (gitleaks) on v1 docs
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks scoped to docs/migration/v1-*.md
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITLEAKS_CONFIG: ""
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Full-repo scan; the workflow itself is path-filtered to only
+          # trigger when v1 docs (or the scripts) change, so the scan window
+          # is naturally scoped.
+          config-path: ""

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# Pre-commit hooks for COREcare v2.
+# Install once locally: `pip install pre-commit && pre-commit install`.
+# Run manually:        `pre-commit run --all-files`.
+#
+# These hooks ARE NOT a substitute for the CI checks at
+# .github/workflows/v1-doc-hygiene.yml — they run the same scripts to give
+# fast local feedback before push.
+
+repos:
+  - repo: local
+    hooks:
+      - id: v1-doc-hygiene
+        name: V1 doc hygiene (PHI / paths / plausible names)
+        entry: bash scripts/check-v1-doc-hygiene.sh
+        language: system
+        files: '^docs/migration/v1-.+\.md$'
+        pass_filenames: true
+
+      - id: v1-doc-structure
+        name: V1 doc structure (personas / cross-ref header / "needs confirmation" residue)
+        entry: bash scripts/check-v1-doc-structure.sh
+        language: system
+        # No file pattern: this hook validates the docset as a whole, so it
+        # only needs to run when a v1 doc in the migration set changes.
+        files: '^docs/migration/v1-.+\.md$'
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,24 @@ test: ## Run all tests
 test-e2e: ## Run Playwright E2E tests against full Docker stack
 	$(MAKE) -C web test-e2e
 
+# --- V1 reference docs ---
+
+test-v1-docs: ## Run v1 doc hygiene + structure script self-tests
+	bash scripts/tests/test_check_v1_doc_hygiene.sh
+	bash scripts/tests/test_check_v1_doc_structure.sh
+
+scan-v1-docs: ## Run hygiene + structure scripts over committed v1 reference docs
+	@if compgen -G "docs/migration/v1-*.md" > /dev/null; then \
+		bash scripts/check-v1-doc-hygiene.sh docs/migration/v1-*.md; \
+	else \
+		echo "No v1 reference docs to scan."; \
+	fi
+	@if [ -f docs/migration/v1-pages-inventory.md ] && [ -f docs/migration/v1-functionality-delta.md ]; then \
+		bash scripts/check-v1-doc-structure.sh; \
+	else \
+		echo "Pages inventory or delta doc absent — structure check skipped."; \
+	fi
+
 # --- API shortcuts ---
 
 api-lint: ## Lint API

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,225 @@
+# V1 Reference Documentation Set
+
+This directory holds reference material about COREcare **v1** (`suniljames/COREcare-access`, a Django monolith) for collaborators building **v2** without v1 source access. The docs describe what v1 does so v2's ground-up rebuild does not silently drop customer-facing capability.
+
+**Audience:** engineers contributing to v2, including AI agents acting on their behalf. **Not customer-facing.**
+
+**Sensitivity:** internal. No PHI, no real customer data, no production identifiers. See [PHI Placeholder Convention](#phi-placeholder-convention).
+
+**Owner:** [Sunil James](https://github.com/suniljames) (`@suniljames`) — single named owner for the docset's accuracy and refresh cadence.
+
+---
+
+## V1 Reference Commit
+
+All facts in this docset were reconciled against:
+
+- **Repo:** `suniljames/COREcare-access`
+- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
+- **Commit subject:** `feat(#1479): January annual mileage-rate verification banner (#1480)`
+- **Pinned at:** 2026-05-06
+
+Authors of follow-up content updates: capture v1 `HEAD` at start of authoring (`git -C <v1-checkout-path> rev-parse HEAD`) and update this section. **Do not chase v1 advances mid-authoring** — finish against the pinned SHA, then file a refresh issue.
+
+---
+
+## Document set
+
+```
+docs/migration/
+├── README.md                           # this file — conventions, owner, runbook
+├── v1-glossary.md                      # v1-specific terms (View As, magic link, BillableServiceCatalog, etc.)
+├── v1-pages-inventory.md               # persona × page matrix (the spine — other docs cite into it)
+├── v1-user-journeys.md                 # narrated end-to-end flows per persona
+├── v1-integrations-and-exports.md      # external integrations + internal notification/email + customer-facing exports
+├── v1-functionality-delta.md           # feature/data-model gaps with severity (existing)
+└── CUTOVER_PLAN.md                     # migration cutover plan (existing, separate scope)
+```
+
+**Dependency direction** (no cycles):
+
+```
+v1-pages-inventory.md  ── spine
+        ▲    ▲    ▲
+        │    │    └── v1-user-journeys.md      (cites inventory anchors)
+        │    └─────── v1-integrations-and-exports.md (cites inventory anchors where integrations surface in UI)
+        └──────────── #79 (Playwright screenshot catalog, separate issue, depends on inventory for coverage)
+
+v1-functionality-delta.md  ── feature/data-model layer
+        cross-refs into the above via top-of-file collaborator header
+
+v1-glossary.md  ── terms cited across all docs
+```
+
+The pages inventory is the authoritative route catalog. Other docs do not redefine routes; they link to inventory rows.
+
+---
+
+## Locked conventions
+
+These conventions apply to every document in this set. **Authors must read this section before writing or editing.**
+
+### Personas
+
+Six personas, exact strings from `.claude/pm-context.md`:
+
+- `Super-Admin`
+- `Agency Admin`
+- `Care Manager`
+- `Caregiver`
+- `Client`
+- `Family Member`
+
+No drift to lowercase, no hyphenation changes, no synonyms ("admin," "agency administrator," "care worker," "field worker").
+
+### v2 status enum
+
+Exactly three values:
+
+- `implemented` — equivalent v2 surface exists and is wired
+- `scaffolded` — v2 model/router exists but isn't reachable from the UI
+- `missing` — no v2 equivalent exists
+
+No "in progress," no "partial," no "planned." If finer granularity is needed, expand this enum explicitly via a new PR.
+
+### Severity rubric
+
+Inherited from `v1-functionality-delta.md`. Apply only when `v2_status = missing`.
+
+| Code | Meaning |
+|------|---------|
+| `H` | High — must-fix for v1.0 GA parity |
+| `M` | Medium — should-fix |
+| `L` | Low — nice-to-have |
+| `D` | Deliberate — intentional v2 divergence (gain or removal) |
+
+### Visual markers
+
+Pair an emoji with the text fallback so screen readers and grep both work:
+
+- `🔴 H · missing`
+- `🟡 M · scaffolded`
+- `🟢 implemented`
+- `⚪ D · deliberate divergence`
+
+### PHI Placeholder Convention
+
+**v1 contains real PHI. No PHI in committed docs. Use only the following placeholders:**
+
+```
+[CLIENT_NAME]      [CAREGIVER_NAME]    [AGENCY_NAME]
+[CLIENT_DOB]       [CLIENT_MRN]        [DIAGNOSIS]
+[MEDICATION]       [NOTE_TEXT]
+[ADDRESS]          [PHONE]             [EMAIL]
+[SHIFT_ID]         [VISIT_ID]          [INVOICE_ID]
+[REDACTED]
+```
+
+All-caps in brackets. **Never use plausible-looking fake names** like `Jane Doe` or `Sarah Johnson` — placeholders only. The hygiene scanner blocks the most common PHI patterns; the placeholder set lets it distinguish intentional placeholders from suspicious content.
+
+If a v1 page renders specific structured data, describe the structure without examples: "client name, DOB, current medications list" — not specific values.
+
+### Voice and tense
+
+- **Present tense for v1.** v1 is running today: "v1 displays...", not "v1 displayed...".
+- **Active voice.** "v1 sends an email when..." not "an email is sent when...".
+- **Third-person, structural prose** for inventory and journey content.
+- **Second-person reserved** for top-of-file lead paragraphs orienting the reader.
+- **No first-person "I."** No unscoped "we" in declarative content (`v1 supports magic links`, not `we support magic links`).
+
+### Quoted v1 UI strings
+
+When citing literal v1 UI text (button labels, help text, error messages, notification templates), enclose in a blockquote with attribution:
+
+```markdown
+> v1 displays: "Are you sure you want to void this invoice? This cannot be undone."
+```
+
+Plain prose is the doc author's voice. Blockquotes are direct v1 strings. **Never inline v1 imperative text as prose** — an AI agent reading the doc must be able to distinguish description from instruction.
+
+### V1 source references
+
+Refer to v1 by GitHub repo slug `suniljames/COREcare-access`. **Never by absolute filesystem path** (`/Users/`, `/home/`, drive letter). The hygiene scanner blocks absolute paths.
+
+When citing a specific v1 file, use the form `<app>/<file>:<line>` — for example, `billing/views.py:142`. The repo slug is implied by context.
+
+### Cross-references
+
+Linked text is descriptive: write **the Agency Admin pages section** of the v1 pages inventory, not `see #v1-pages-inventory.md`. The reader must know where they're going before they click.
+
+Anchors must be stable. Define section anchors with `<a id="..."></a>` immediately under the heading if the markdown flavor's auto-anchor would be unstable across heading edits.
+
+### Section-level metadata
+
+Every persona section in `v1-pages-inventory.md` carries a single line under its H2:
+
+```markdown
+## Agency Admin
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+```
+
+Update on each refresh.
+
+---
+
+## Coverage target
+
+The pages inventory targets ≥95% coverage of distinct v1 URL patterns (function-based or class-based views serving HTML).
+
+**Counted (denominator):**
+- All FBVs and CBVs serving HTML, in `urls.py` files (root + per-app).
+- Flag-toggled views regardless of feature-flag state.
+
+**Not counted:**
+- Django admin auto-generated routes (`/admin/<model>/`).
+- JSON-only API endpoints (no HTML render).
+- Redirect-only views (`RedirectView`).
+- Static-asset routes.
+
+**Numerator:** number of (URL pattern) entries covered by at least one row in `v1-pages-inventory.md`.
+
+The current denominator and numerator are recorded in `v1-pages-inventory.md` under a "Coverage" section near the top of the file.
+
+---
+
+## Hygiene and structure enforcement
+
+Two scripts validate this docset on every PR:
+
+- `scripts/check-v1-doc-hygiene.sh` — blocks PHI patterns, absolute paths, plausible-real-name two-word sequences. Run via pre-commit hook and CI.
+- `scripts/check-v1-doc-structure.sh` — validates persona-section coverage in pages inventory and the cross-reference header in the delta doc.
+
+Self-tests:
+
+```sh
+make test-v1-docs    # run the script self-tests
+make scan-v1-docs    # run the scripts over the actual committed docs
+```
+
+CI workflow: `.github/workflows/v1-doc-hygiene.yml`. Runs on PRs that touch `docs/migration/v1-*.md` or the scripts.
+
+Pre-commit hook: `.pre-commit-config.yaml`. Install once with `pip install pre-commit && pre-commit install`.
+
+---
+
+## Refresh runbook
+
+When v1 receives material changes, refresh this docset against the new SHA.
+
+1. Pull v1 to a local checkout. Capture `git -C <v1> rev-parse HEAD` — the new pin.
+2. Diff against the previously-pinned SHA in this README. Identify changed apps.
+3. For each changed app, read `urls.py`, views, and templates. Update the pages-inventory rows for affected routes; update journeys if a flow changed end-to-end; update integrations doc if external service contracts changed.
+4. Bump `last reconciled` dates in updated persona sections. Update the SHA in this README.
+5. Run `make scan-v1-docs` locally. Open a PR titled `docs(migration): refresh v1 reference set against <short-sha>`.
+
+If you find yourself doing this more than twice manually, automate it (per the team's "if you do it twice" principle). The first automation candidate is the `urls.py` enumeration step.
+
+---
+
+## Related work
+
+- **#70 (closed)** — landed `v1-functionality-delta.md` (the feature/data-model layer this set extends).
+- **#78** — this issue, extended the docset with pages inventory, journeys, integrations, and TODO resolution.
+- **#79 (open, follow-up)** — Playwright screenshot catalog of v1 UI per persona; depends on the pages inventory for coverage check.
+- **#31, #32 (closed)** — v1→v2 data migration scripts and cutover plan.

--- a/docs/migration/v1-functionality-delta.md
+++ b/docs/migration/v1-functionality-delta.md
@@ -14,6 +14,22 @@ The v2 docs are *customer-facing*, so absence here doesn't always mean "not buil
 
 ---
 
+## For collaborators without v1 access
+
+If you do not have access to `suniljames/COREcare-access` (the v1 Django repo), this document on its own is **not enough** to rebuild v1's customer-facing surface in v2. It catalogues feature and data-model gaps, but it does not describe v1's pages, user journeys, or integrations.
+
+Read these companion documents in `docs/migration/`:
+
+- **[`README.md`](README.md)** — locked conventions for the docset (personas, severity rubric, status enum, PHI placeholder set, voice, refresh runbook, v1 reference commit pin).
+- **[`v1-pages-inventory.md`](v1-pages-inventory.md)** — persona × page matrix for all six personas, with v2 status, severity, multi-tenant refactor flags, and PHI flags. Authoritative route catalogue; other docs cite into it.
+- **[`v1-user-journeys.md`](v1-user-journeys.md)** — narrated end-to-end flows per persona, with route trace and qualitative side effects.
+- **[`v1-integrations-and-exports.md`](v1-integrations-and-exports.md)** — external integrations, internal notification/email backend, and customer-facing exports.
+- **[`v1-glossary.md`](v1-glossary.md)** — v1-specific terms cited across the set.
+
+The four documents above are scaffolded but their content is being authored issue-by-issue. The most current state of each lives in this repo.
+
+---
+
 ## 1. Billing & Revenue Operations
 
 ### 1.1 Invoice revisions / corrected invoices — **H**
@@ -280,4 +296,4 @@ Briefly, things v2 docs commit to that are not in v1:
 
 ---
 
-*Generated 2026-05-06 from press release `[07]-Press-Release.md` + external FAQ `[08]-FAQ-(External).md` against v1 codebase at `/Users/suniljames/Code/COREcare-access/`. The v2 docs are customer-facing; some items below may already be implemented or planned in internal artifacts not surveyed here.*
+*Generated 2026-05-06 from press release `[07]-Press-Release.md` + external FAQ `[08]-FAQ-(External).md` against v1 codebase `suniljames/COREcare-access` (commit pinned in [`README.md`](README.md#v1-reference-commit)). The v2 docs are customer-facing; some items below may already be implemented or planned in internal artifacts not surveyed here.*

--- a/docs/migration/v1-glossary.md
+++ b/docs/migration/v1-glossary.md
@@ -1,0 +1,46 @@
+# V1 Glossary
+
+> **Read [`README.md`](README.md) first.** It locks the persona vocabulary.
+
+Terms specific to COREcare v1 (`suniljames/COREcare-access`) that appear across this docset. **Persona names** (`Super-Admin`, `Agency Admin`, `Care Manager`, `Caregiver`, `Client`, `Family Member`) and general homecare vocabulary (`Care Plan`, `Visit`, `Shift`, `ADLs`, `PHI`) are defined in [`.claude/pm-context.md`](../../.claude/pm-context.md), not duplicated here.
+
+This file extends `pm-context.md` with v1-specific terms — model names, internal feature names, and Django app names that come up when reading v1 source.
+
+**Status:** SCAFFOLDED. Entries are pending authoring against the [pinned v1 commit](README.md#v1-reference-commit). The set below is seeded from terms already cited in `v1-functionality-delta.md`.
+
+---
+
+## Format
+
+For each term: one-line definition, then a link to its first significant use in this docset (a heading anchor in `v1-pages-inventory.md`, `v1-user-journeys.md`, or `v1-integrations-and-exports.md`).
+
+---
+
+## Pending entries
+
+Terms that need definition before the docset is complete:
+
+- **`elitecare`** — the Django project root for v1; not an app name. Cited in `v1-functionality-delta.md` and any model-namespacing references.
+- **`InvoiceRevision`** — v1 model representing a corrected, reissued invoice. (`H`-severity gap in delta.)
+- **`BillableServiceCatalog`** — v1 model for agency-managed billable add-on services. (`H`-severity gap in delta.)
+- **`ChartTemplate`** — v1 model for per-client chart customization. (`H`-severity gap in delta.)
+- **`MagicLinkToken`** — v1 model backing email-based magic-link login.
+- **View-As impersonation** — v1 super-admin feature for assuming an agency-admin context with full audit trail. (`H`-severity gap; load-bearing compliance control.)
+- **`promote_to_recurring_view()`** — v1 view function cited in delta; converts a one-off scheduling decision into a recurring rule.
+- **`issue_revision_editor()`** — v1 view function for the corrected-invoice editor flow.
+- **Profile completion gate** — v1 onboarding control that blocks caregivers from accepting shifts until required profile fields are filled.
+- **9-category expense workflow** — v1 expense submission with nine fixed expense classes. (`M`-severity gap.)
+- **Meal-break waiver** — v1 caregiver-consent record for waiving meal breaks under state labor rules.
+- **Overpayment consent** — v1 acknowledgment record for caregivers to accept an overpayment correction.
+- **Action queue** — v1 deterministic-detection feed of items needing a coordinator response, distinct from v2's planned AI-driven coordination assistant.
+- **Health report approval queue** — v1 dual-author health report flow with an explicit approval gate.
+
+_(definitions pending content authoring; each will resolve to one-line text + first-use link)_
+
+---
+
+## Cross-cutting v1 conventions
+
+These are not single terms but recurring patterns in v1 source. Calling them out here because they show up in inventory rows and journey traces.
+
+_(pending)_

--- a/docs/migration/v1-integrations-and-exports.md
+++ b/docs/migration/v1-integrations-and-exports.md
@@ -1,0 +1,92 @@
+# V1 Integrations and Exports
+
+> **Read [`README.md`](README.md) first.** It locks every convention used here.
+
+This document inventories everything v1 talks to outside its own database: external integrations (third-party SaaS), the internal notification and email backend (because it's a customer-visible side channel that can silently break on rebuild), and customer-facing exports (CSV, PDF, accounting hand-offs). Anything that fires when an end-user takes an action in v1 is in scope.
+
+**Status:** SCAFFOLDED. Sub-section structure is in place; entries are pending authoring against the [pinned v1 commit](README.md#v1-reference-commit).
+
+---
+
+## Schema
+
+| Field | Description |
+|-------|-------------|
+| `name` | Integration or export name |
+| `vendor_or_internal` | Stripe, Twilio, SendGrid, QuickBooks, internal, etc. |
+| `trigger` | What action or schedule fires it (user click, cron job, webhook, etc.) |
+| `direction_and_sync` | `inbound` / `outbound`; `sync` / `async` |
+| `surfaces_at_routes` | Anchor links into pages-inventory rows where users encounter the integration in the UI |
+| `customer_visibility` | What end-users see (a banner, an email, a downloaded file, nothing) |
+| `v2_status` | `implemented` / `scaffolded` / `missing` |
+| `severity` | `H` / `M` / `L` / `D` (only when `v2_status=missing`) |
+
+---
+
+## External integrations
+
+Third-party SaaS v1 integrates with. Sub-grouped by vendor.
+
+### Billing and payments
+
+_(entries pending content authoring)_
+
+### Payroll
+
+_(entries pending content authoring)_
+
+### Accounting
+
+_(entries pending content authoring)_
+
+### Messaging and notifications (third-party)
+
+_(entries pending content authoring)_
+
+### Identity, auth, and SSO (third-party)
+
+_(entries pending content authoring)_
+
+### Other
+
+_(entries pending content authoring)_
+
+---
+
+## Internal notification and email backend
+
+v1's own notification system and email-sending pipeline. Customer-visible side channels that aren't third-party but can silently break on rebuild if undocumented.
+
+### Email pipeline
+
+_(entries pending content authoring — covers SMTP/transactional templates v1 ships, send-on-failure retry behavior, and any email-reliability tracking documented as a gap in `v1-functionality-delta.md`)_
+
+### In-app notifications
+
+_(entries pending content authoring — covers v1's notification inbox, push subscriptions if any, and unread-count semantics)_
+
+---
+
+## Customer-facing exports
+
+User-triggered or scheduled exports that produce a file or feed visible to a customer.
+
+### CSV exports
+
+_(entries pending content authoring)_
+
+### PDF exports
+
+_(entries pending content authoring)_
+
+### Other formats
+
+_(entries pending content authoring)_
+
+---
+
+## Cross-references
+
+Every entry above that surfaces in the UI must link to its pages-inventory rows in `surfaces_at_routes`. Once authoring completes, this section will list any orphan integrations (no UI surface) explicitly.
+
+_(pending)_

--- a/docs/migration/v1-pages-inventory.md
+++ b/docs/migration/v1-pages-inventory.md
@@ -1,0 +1,114 @@
+# V1 Pages Inventory
+
+> **Read [`README.md`](README.md) first.** It locks every convention used here: persona vocabulary, v2-status enum, severity rubric, visual markers, PHI placeholder set, voice, anchor stability, v1 commit pin.
+
+This document is the **authoritative route catalogue** for v1's customer-facing surface. Every other doc in this set cites into it; do not redefine routes elsewhere. One row per (route, persona) tuple — a route accessible to multiple personas appears in multiple rows.
+
+**Status:** SCAFFOLDED. Persona sections are in place; rows are pending content authoring against `suniljames/COREcare-access` at the [pinned commit](README.md#v1-reference-commit). Until rows are filled, the [`v1-functionality-delta.md`](v1-functionality-delta.md) is the most complete view of v1's feature surface.
+
+---
+
+## Coverage
+
+- **Denominator** (distinct v1 URL patterns rendering HTML, per the rules in [README §Coverage target](README.md#coverage-target)): _to be measured against the pinned commit_.
+- **Numerator** (rows present below): 0.
+- **Coverage:** 0% (target ≥95%).
+
+---
+
+## Schema
+
+Each persona section below uses this row schema. Authors: do not add or remove columns without updating [README §Locked conventions](README.md#locked-conventions) and the structure check.
+
+| Field | Description |
+|-------|-------------|
+| `route` | URL pattern (kebab-case where v1 used it; otherwise the literal Django path) |
+| `purpose` | What the page is for, ≤80 chars |
+| `what_user_sees_can_do` | Key data + primary actions, ≤2 lines |
+| `v2_status` | `implemented` / `scaffolded` / `missing` |
+| `severity` | `H` / `M` / `L` / `D` (only when `v2_status=missing`) |
+| `multi_tenant_refactor` | `true` if v1 single-tenant assumption requires v2 rework |
+| `rls_bypass_by_design` | `true` for Super-Admin / View-As impersonation surfaces |
+| `phi_displayed` | `true` if route renders any PHI in v1 |
+| `screenshot_ref` | filename in `docs/legacy/v1-ui-catalog/<persona>/` once #79 lands; otherwise `not_screenshotted: <reason>` |
+| `v2_link` | Single canonical repo-relative path when `v2_status` ≠ `missing` |
+
+---
+
+## Super-Admin
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+Super-Admin pages are platform-operator surfaces that bypass tenant isolation by design. v1 was single-tenant per install, so v1's "super-admin" features sit at the elitecare project level (cross-agency Django admin views, support tooling, View-As impersonation). v2 must preserve every audit-log behavior on these routes — RLS bypass is a load-bearing control, not a convenience.
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| _(rows pending content authoring)_ | | | | | | | | | |
+
+---
+
+## Agency Admin
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+Agency Admin pages cover scheduling, billing, payroll, credentialing, compliance, and team oversight. This is v1's largest surface and v2's highest-volume rebuild target.
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| _(rows pending content authoring)_ | | | | | | | | | |
+
+---
+
+## Care Manager
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+Care Manager pages cover care plan authoring, supervisory review, and team-level oversight of caregivers. Distinct from Agency Admin in clinical scope; distinct from Caregiver in supervisory authority.
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| _(rows pending content authoring)_ | | | | | | | | | |
+
+---
+
+## Caregiver
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+Caregiver pages are field-facing: clock-in/out, schedule view, chart-note submission, expense submission, profile and credentials. Highest-volume, lowest-patience persona. Mobile-first ergonomics matter most here.
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| _(rows pending content authoring)_ | | | | | | | | | |
+
+---
+
+## Client
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+Client pages cover the care recipient's view of their care plan, upcoming shifts, and assigned caregivers. Lower frequency than Caregiver; PHI handling is paramount because the client is the subject.
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| _(rows pending content authoring)_ | | | | | | | | | |
+
+---
+
+## Family Member
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+Family Member pages cover the limited-visibility view granted to a client's authorized representative. Invite redemption, recent visit notes, agency messaging. Lowest frequency; gaps here are the hardest to detect and easiest to silently drop.
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| _(rows pending content authoring)_ | | | | | | | | | |
+
+---
+
+## Shared routes
+
+Routes accessible by more than one persona appear once per persona above with a cross-reference note. This section will list them once row authoring is complete.
+
+_(pending content authoring)_

--- a/docs/migration/v1-user-journeys.md
+++ b/docs/migration/v1-user-journeys.md
@@ -1,0 +1,79 @@
+# V1 User Journeys
+
+> **Read [`README.md`](README.md) first.** It locks every convention used here.
+
+This document narrates end-to-end user flows in v1, persona by persona. Each journey opens with a one-sentence "what / who / why," followed by a numbered route trace, qualitative side effects (DB writes, notifications, emails), and a one-line "failure-mode UX" call-out where v1 has notable behavior under failure (offline, server error, missing data).
+
+Each journey **cites pages-inventory anchors** rather than redefining route facts. If a route mentioned here is not yet a row in [`v1-pages-inventory.md`](v1-pages-inventory.md), that's a coverage gap to fix.
+
+**Status:** SCAFFOLDED. Persona sections and journey lists are in place; journey content is pending authoring against the [pinned v1 commit](README.md#v1-reference-commit).
+
+---
+
+## Conventions
+
+- **Route trace:** numbered list of routes the user passes through, each linked to the corresponding pages-inventory row.
+- **Side effects:** DB writes / notifications / emails / external-service calls described qualitatively (`creates a Visit record`, `fires a caregiver-assignment notification`), not at schema level.
+- **Failure-mode UX:** one-line description of what the user sees when the path fails. Examples: `If clock-in fails offline, v1 queues locally and replays on reconnect.` `If credential expiry advances mid-page, v1 hides the page and routes to renewal.`
+- **Tenant context:** included only where ambiguous (e.g., super-admin impersonating an agency admin).
+- **Quoted v1 UI strings:** blockquoted with `v1 displays:` attribution.
+
+---
+
+## Super-Admin
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+### Agency management — _pending content authoring_
+### View-As impersonation with audit trail — _pending content authoring_
+
+---
+
+## Agency Admin
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+### Client intake — _pending content authoring_
+### Caregiver onboarding — _pending content authoring_
+### Weekly timesheet review and approval — _pending content authoring_
+### Invoice generation — _pending content authoring_
+### Credential expiry handling — _pending content authoring_
+
+---
+
+## Care Manager
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+### Care plan authoring — _pending content authoring_
+### Team oversight — _pending content authoring_
+
+---
+
+## Caregiver
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+### Clock in and out at a shift — _pending content authoring_
+### Chart note submission — _pending content authoring_
+### Expense submission — _pending content authoring_
+### Schedule view — _pending content authoring_
+
+---
+
+## Client
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+### Care plan view — _pending content authoring_
+### Upcoming shift view — _pending content authoring_
+
+---
+
+## Family Member
+
+_last reconciled: 2026-05-06 against v1 commit `9738412`_
+
+### Invite redemption — _pending content authoring_
+### Recent visit notes view — _pending content authoring_
+### Agency messaging — _pending content authoring_

--- a/scripts/check-v1-doc-hygiene.sh
+++ b/scripts/check-v1-doc-hygiene.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Scans v1 reference documents for PHI patterns, absolute filesystem paths,
+# and plausible-real-name patterns that should never be committed.
+#
+# Usage:
+#   scripts/check-v1-doc-hygiene.sh <file1.md> [<file2.md> ...]
+#
+# Exit codes:
+#   0  no violations
+#   1  one or more files contain a violation
+#
+# This script is intentionally regex-based and string-only. It does not parse
+# markdown structure. Designed to run in pre-commit hooks and in CI.
+
+set -u
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <file1.md> [<file2.md> ...]" >&2
+  exit 2
+fi
+
+VIOLATIONS=0
+
+# Allowed all-caps placeholder set. Names matching one of these are intentional.
+ALLOWED_PLACEHOLDERS_RE='\[(CLIENT_NAME|CLIENT_DOB|CLIENT_MRN|CAREGIVER_NAME|AGENCY_NAME|ADDRESS|PHONE|EMAIL|DIAGNOSIS|MEDICATION|NOTE_TEXT|SHIFT_ID|VISIT_ID|INVOICE_ID|REDACTED)\]'
+
+# Single-word persona-name set. These should not trip the plausible-name heuristic.
+PERSONA_WORDS='Caregiver|Client|Family|Member|Agency|Admin|Care|Manager|Super'
+
+# Common English first-words that appear before a capitalized noun in normal prose.
+# When the first word of a Capitalized-Capitalized pair is one of these, the pair
+# is sentence-initial determiner + noun, not a real name.
+STOPWORD_FIRSTS='The|A|An|All|Some|Any|Each|Every|This|That|These|Those|His|Her|Its|Our|Their|My|Your|Such|One|Two|Three|Many|Most|Few|No|Both|Either|Neither'
+
+scan_file() {
+  local file="$1"
+  local file_violations=0
+
+  if [[ ! -f "$file" ]]; then
+    echo "skip: $file not a regular file" >&2
+    return 0
+  fi
+
+  # 1. SSN-like (XXX-XX-XXXX or XXXXXXXXX in obvious context)
+  if grep -nE '\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b' "$file" >/dev/null; then
+    echo "$file: SSN-like pattern detected"
+    grep -nE '\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b' "$file" | head -3 | sed 's/^/  /'
+    file_violations=$((file_violations + 1))
+  fi
+
+  # 2. DOB explicit ("DOB:" or "DOB " prefix followed by a date-shaped token)
+  if grep -nEi '(^|[^A-Z_\[])DOB[: ][^]]{0,3}[0-9]{1,2}[-/.][0-9]{1,2}[-/.][0-9]{2,4}' "$file" >/dev/null; then
+    echo "$file: explicit DOB date pattern detected"
+    grep -nEi '(^|[^A-Z_\[])DOB[: ][^]]{0,3}[0-9]{1,2}[-/.][0-9]{1,2}[-/.][0-9]{2,4}' "$file" | head -3 | sed 's/^/  /'
+    file_violations=$((file_violations + 1))
+  fi
+
+  # 3. US phone numbers (NNN-NNN-NNNN, (NNN) NNN-NNNN). Three-digit area code
+  #    excludes route patterns like /admin/v2/123 because of explicit dash format.
+  if grep -nE '\b\(?[2-9][0-9]{2}\)?[ -][0-9]{3}-[0-9]{4}\b' "$file" >/dev/null; then
+    echo "$file: US phone number pattern detected"
+    grep -nE '\b\(?[2-9][0-9]{2}\)?[ -][0-9]{3}-[0-9]{4}\b' "$file" | head -3 | sed 's/^/  /'
+    file_violations=$((file_violations + 1))
+  fi
+
+  # 4. Absolute filesystem paths (POSIX home, /Users, Windows drive)
+  if grep -nE '/Users/[A-Za-z0-9._-]+|/home/[A-Za-z0-9._-]+|[A-Z]:\\[A-Za-z]' "$file" >/dev/null; then
+    echo "$file: absolute filesystem path detected (/Users/, /home/, or C:\\)"
+    grep -nE '/Users/[A-Za-z0-9._-]+|/home/[A-Za-z0-9._-]+|[A-Z]:\\[A-Za-z]' "$file" | head -3 | sed 's/^/  /'
+    file_violations=$((file_violations + 1))
+  fi
+
+  # 5. Plausible-real-name heuristic: two consecutive Capitalized words OUTSIDE
+  #    of placeholder syntax, blockquoted strings, code fences, or links, AND
+  #    not part of the known persona vocabulary.
+  #
+  #    The heuristic is intentionally conservative: real names like "Sarah
+  #    Johnson" trip it; "Agency Admin" / "Family Member" / "Care Manager" do
+  #    not because both words are in the persona vocabulary; "[CLIENT_NAME]"
+  #    does not because brackets exclude the match.
+  #
+  #    We strip out placeholders, bracketed text, code spans, fenced code
+  #    blocks, and blockquoted lines before scanning.
+  local stripped
+  stripped=$(awk '
+    BEGIN { in_fence = 0 }
+    /^```/ { in_fence = !in_fence; next }
+    in_fence { next }
+    /^>/ { next }
+    {
+      gsub(/`[^`]*`/, "")
+      gsub(/\[[^]]*\]/, "")
+      print
+    }
+  ' "$file")
+
+  # Find two-word capitalized sequences. Filter out:
+  #   (a) pairs where both words are in the persona vocabulary (e.g. "Family Member")
+  #   (b) pairs where the first word is a common English stopword (e.g. "The Caregiver")
+  local hits
+  hits=$(echo "$stripped" | grep -oE '\b[A-Z][a-z]{2,}[ ]+[A-Z][a-z]{2,}\b' | \
+    grep -vE "^(${PERSONA_WORDS})[ ]+(${PERSONA_WORDS})\$" | \
+    grep -vE "^(${STOPWORD_FIRSTS})[ ]+[A-Z][a-z]+\$" || true)
+  if [[ -n "$hits" ]]; then
+    echo "$file: plausible real-name pattern detected (two consecutive Capitalized words)"
+    echo "$hits" | sort -u | head -3 | sed 's/^/  /'
+    echo "  (use a placeholder from the allowed set instead)"
+    file_violations=$((file_violations + 1))
+  fi
+
+  return "$file_violations"
+}
+
+for file in "$@"; do
+  scan_file "$file"
+  rc=$?
+  if [[ "$rc" != 0 ]]; then
+    VIOLATIONS=$((VIOLATIONS + rc))
+  fi
+done
+
+if [[ "$VIOLATIONS" -gt 0 ]]; then
+  echo ""
+  echo "Hygiene check FAILED with $VIOLATIONS violation group(s) across files."
+  echo "Allowed placeholders: see scripts/check-v1-doc-hygiene.sh ALLOWED_PLACEHOLDERS_RE."
+  echo "Reference: docs/migration/README.md#phi-placeholder-convention"
+  exit 1
+fi
+
+exit 0

--- a/scripts/check-v1-doc-hygiene.sh
+++ b/scripts/check-v1-doc-hygiene.sh
@@ -87,6 +87,7 @@ scan_file() {
     /^```/ { in_fence = !in_fence; next }
     in_fence { next }
     /^>/ { next }
+    /^#+[ ]/ { next }
     {
       gsub(/`[^`]*`/, "")
       gsub(/\[[^]]*\]/, "")

--- a/scripts/check-v1-doc-structure.sh
+++ b/scripts/check-v1-doc-structure.sh
@@ -71,11 +71,19 @@ if [[ -f "$DELTA" ]]; then
   fi
 fi
 
-# --- Delta: no "needs confirmation" residue ---
+# --- Delta: no "needs confirmation" residue, scoped to content body ---
+# The intro / legend before the first `---` separator is allowed to mention
+# the marker as a convention. Any occurrence after the first separator is
+# unresolved residue.
 if [[ -f "$DELTA" ]]; then
-  if grep -niE 'needs confirmation' "$DELTA" >/dev/null; then
-    fail "$DELTA still contains 'needs confirmation' residue"
-    grep -niE 'needs confirmation' "$DELTA" | head -3 | sed 's/^/  /'
+  body_after_first_separator=$(awk '
+    BEGIN { past_separator = 0 }
+    /^---[[:space:]]*$/ && !past_separator { past_separator = 1; next }
+    past_separator { print }
+  ' "$DELTA")
+  if echo "$body_after_first_separator" | grep -niE 'needs confirmation' >/dev/null; then
+    fail "$DELTA still contains 'needs confirmation' residue (in body, past intro)"
+    echo "$body_after_first_separator" | grep -niE 'needs confirmation' | head -3 | sed 's/^/  /'
   fi
 fi
 

--- a/scripts/check-v1-doc-structure.sh
+++ b/scripts/check-v1-doc-structure.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Validates structural invariants of the v1 reference document set:
+#   1. v1-pages-inventory.md has an H2 section for each of the six personas.
+#   2. v1-functionality-delta.md has the cross-reference header
+#      "For collaborators without v1 access" as its first H2.
+#   3. v1-functionality-delta.md contains no "needs confirmation" residue.
+#
+# Usage:
+#   scripts/check-v1-doc-structure.sh [--dir <docs-dir>]
+#
+# Default --dir is `docs/migration/` (relative to current working directory).
+#
+# Exit codes:
+#   0  all structural invariants hold
+#   1  one or more checks failed
+
+set -u
+
+DIR="docs/migration"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir) DIR="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+INVENTORY="$DIR/v1-pages-inventory.md"
+DELTA="$DIR/v1-functionality-delta.md"
+
+REQUIRED_PERSONAS=(
+  "Super-Admin"
+  "Agency Admin"
+  "Care Manager"
+  "Caregiver"
+  "Client"
+  "Family Member"
+)
+
+VIOLATIONS=0
+fail() { echo "FAIL: $1"; VIOLATIONS=$((VIOLATIONS + 1)); }
+
+# --- File presence ---
+if [[ ! -f "$INVENTORY" ]]; then
+  fail "$INVENTORY does not exist"
+fi
+if [[ ! -f "$DELTA" ]]; then
+  fail "$DELTA does not exist"
+fi
+
+# --- Inventory: six persona H2 sections ---
+if [[ -f "$INVENTORY" ]]; then
+  for persona in "${REQUIRED_PERSONAS[@]}"; do
+    # Match line starting with "## " followed by the exact persona string.
+    # Anchor with end-of-line OR whitespace so "Care Manager" doesn't match
+    # "Care Manager Exec" or similar.
+    if ! grep -qE "^## ${persona}([[:space:]]|$)" "$INVENTORY"; then
+      fail "$INVENTORY missing H2 section for persona: $persona"
+    fi
+  done
+fi
+
+# --- Delta: cross-ref header is the FIRST H2-or-deeper section ---
+if [[ -f "$DELTA" ]]; then
+  # Find the first heading line at H2 or deeper.
+  first_section_heading=$(grep -nE '^##+ ' "$DELTA" | head -1 | cut -d: -f2-)
+  if [[ -z "$first_section_heading" ]]; then
+    fail "$DELTA contains no H2-or-deeper headings"
+  elif ! echo "$first_section_heading" | grep -qE '^## For collaborators without v1 access'; then
+    fail "$DELTA first H2 is not 'For collaborators without v1 access'"
+    echo "  actual first H2: $first_section_heading"
+  fi
+fi
+
+# --- Delta: no "needs confirmation" residue ---
+if [[ -f "$DELTA" ]]; then
+  if grep -niE 'needs confirmation' "$DELTA" >/dev/null; then
+    fail "$DELTA still contains 'needs confirmation' residue"
+    grep -niE 'needs confirmation' "$DELTA" | head -3 | sed 's/^/  /'
+  fi
+fi
+
+if [[ "$VIOLATIONS" -gt 0 ]]; then
+  echo ""
+  echo "Structure check FAILED with $VIOLATIONS violation(s)."
+  exit 1
+fi
+
+exit 0

--- a/scripts/tests/test_check_v1_doc_hygiene.sh
+++ b/scripts/tests/test_check_v1_doc_hygiene.sh
@@ -124,6 +124,34 @@ A Family Member views recent visit notes.
 EOF
 assert_exit "persona names alone do not trip name heuristic" 0 "$HYGIENE" "$FIXTURES/persona_only.md"
 
+# Headings can have title-case noun phrases like "Reference Commit" without tripping.
+cat > "$FIXTURES/title_case_headings.md" <<'EOF'
+# V1 Reference Documentation Set
+
+## V1 Reference Commit
+
+### PHI Placeholder Convention
+
+Some prose follows.
+EOF
+assert_exit "title-case multi-word headings do not trip name heuristic" 0 "$HYGIENE" "$FIXTURES/title_case_headings.md"
+
+# But PHI patterns inside a heading still block (defense in depth).
+cat > "$FIXTURES/phi_in_heading.md" <<'EOF'
+# Patient SSN: 123-45-6789
+
+Some prose.
+EOF
+assert_exit "PHI pattern in heading still blocks" 1 "$HYGIENE" "$FIXTURES/phi_in_heading.md"
+
+# Code-spanned fake names (used as illustrative examples in docs) do not trip.
+cat > "$FIXTURES/code_spanned_examples.md" <<'EOF'
+# Doc teaching the placeholder convention
+
+Never use plausible-looking fake names like `Jane Doe` or `Sarah Johnson` — use the placeholder set instead.
+EOF
+assert_exit "code-spanned fake-name examples do not trip name heuristic" 0 "$HYGIENE" "$FIXTURES/code_spanned_examples.md"
+
 # --- Multiple files at once ---
 cat > "$FIXTURES/clean2.md" <<'EOF'
 # Another clean doc

--- a/scripts/tests/test_check_v1_doc_hygiene.sh
+++ b/scripts/tests/test_check_v1_doc_hygiene.sh
@@ -48,7 +48,8 @@ echo "== check-v1-doc-hygiene.sh tests =="
 
 [[ -x "$HYGIENE" ]] || { echo "FAIL — hygiene script not executable at $HYGIENE"; exit 1; }
 
-# Clean state
+# Clean state. Empty fixture dirs aren't tracked in git, so create on the fly.
+mkdir -p "$FIXTURES"
 rm -f "$FIXTURES"/*.md
 
 # --- Pass cases ---

--- a/scripts/tests/test_check_v1_doc_hygiene.sh
+++ b/scripts/tests/test_check_v1_doc_hygiene.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Tests for scripts/check-v1-doc-hygiene.sh
+# Run from repo root: bash scripts/tests/test_check_v1_doc_hygiene.sh
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HYGIENE="$REPO_ROOT/scripts/check-v1-doc-hygiene.sh"
+FIXTURES="$SCRIPT_DIR/fixtures"
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local description="$1"
+  local expected_code="$2"
+  shift 2
+  local actual_output
+  actual_output=$("$@" 2>&1)
+  local actual_code=$?
+  if [[ "$actual_code" == "$expected_code" ]]; then
+    echo "  PASS — $description (exit $actual_code)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description (expected exit $expected_code, got $actual_code)"
+    echo "    output: $actual_output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_output_contains() {
+  local description="$1"
+  local needle="$2"
+  shift 2
+  local actual_output
+  actual_output=$("$@" 2>&1 || true)
+  if echo "$actual_output" | grep -qF "$needle"; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description (output did not contain: $needle)"
+    echo "    actual: $actual_output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "== check-v1-doc-hygiene.sh tests =="
+
+[[ -x "$HYGIENE" ]] || { echo "FAIL — hygiene script not executable at $HYGIENE"; exit 1; }
+
+# Clean state
+rm -f "$FIXTURES"/*.md
+
+# --- Pass cases ---
+
+cat > "$FIXTURES/clean.md" <<'EOF'
+# Clean v1 reference doc
+
+This documents `[CLIENT_NAME]` and `[CAREGIVER_NAME]` interactions.
+Reference v1 source: `suniljames/COREcare-access`.
+The route `/admin/clients/<id>/` is for `Agency Admin`.
+EOF
+
+assert_exit "clean doc with placeholders passes" 0 "$HYGIENE" "$FIXTURES/clean.md"
+
+cat > "$FIXTURES/empty.md" <<'EOF'
+EOF
+assert_exit "empty file passes" 0 "$HYGIENE" "$FIXTURES/empty.md"
+
+# --- PHI pattern fail cases ---
+
+cat > "$FIXTURES/ssn.md" <<'EOF'
+# Doc with SSN-like pattern
+Patient SSN: 123-45-6789 (this should never be committed).
+EOF
+assert_exit "SSN pattern blocks" 1 "$HYGIENE" "$FIXTURES/ssn.md"
+assert_output_contains "SSN failure mentions SSN" "SSN" "$HYGIENE" "$FIXTURES/ssn.md"
+
+cat > "$FIXTURES/dob_explicit.md" <<'EOF'
+# Doc with DOB
+DOB: 03/15/1942
+EOF
+assert_exit "explicit DOB pattern blocks" 1 "$HYGIENE" "$FIXTURES/dob_explicit.md"
+
+cat > "$FIXTURES/phone.md" <<'EOF'
+# Doc with phone
+Contact: 555-123-4567
+EOF
+assert_exit "US phone pattern blocks" 1 "$HYGIENE" "$FIXTURES/phone.md"
+
+# --- Path fail cases ---
+
+cat > "$FIXTURES/users_path.md" <<'EOF'
+# Doc with /Users/
+v1 source at /Users/suniljames/Code/COREcare-access/
+EOF
+assert_exit "/Users/ path blocks" 1 "$HYGIENE" "$FIXTURES/users_path.md"
+assert_output_contains "users path failure mentions /Users" "/Users/" "$HYGIENE" "$FIXTURES/users_path.md"
+
+cat > "$FIXTURES/home_path.md" <<'EOF'
+# Doc with /home/
+Local install at /home/sunil/v1.
+EOF
+assert_exit "/home/ path blocks" 1 "$HYGIENE" "$FIXTURES/home_path.md"
+
+cat > "$FIXTURES/win_path.md" <<'EOF'
+# Doc with C:\
+Windows install at C:\Users\sunil\v1.
+EOF
+assert_exit "C:\\ path blocks" 1 "$HYGIENE" "$FIXTURES/win_path.md"
+
+# --- Plausible-name heuristic (simple uppercase-name pattern, two-word) ---
+cat > "$FIXTURES/plausible_name.md" <<'EOF'
+# Doc with plausible name
+Caregiver Sarah Johnson submitted the chart note.
+EOF
+assert_exit "plausible two-word capitalized name blocks" 1 "$HYGIENE" "$FIXTURES/plausible_name.md"
+
+# Single-word capitalized terms (persona names like "Caregiver") should NOT trip.
+cat > "$FIXTURES/persona_only.md" <<'EOF'
+# Doc with persona names only
+The Caregiver clocks in. The Agency Admin reviews.
+A Family Member views recent visit notes.
+EOF
+assert_exit "persona names alone do not trip name heuristic" 0 "$HYGIENE" "$FIXTURES/persona_only.md"
+
+# --- Multiple files at once ---
+cat > "$FIXTURES/clean2.md" <<'EOF'
+# Another clean doc
+Uses `[CLIENT_DOB]` and `[MEDICATION]`.
+EOF
+assert_exit "multiple clean files pass" 0 "$HYGIENE" "$FIXTURES/clean.md" "$FIXTURES/clean2.md"
+assert_exit "mixed clean + dirty fails" 1 "$HYGIENE" "$FIXTURES/clean.md" "$FIXTURES/ssn.md"
+
+# --- Cleanup ---
+rm -f "$FIXTURES"/*.md
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" == 0 ]] || exit 1

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -93,11 +93,15 @@ EOF
 write_good_delta "$TEST_DIR/missing-persona/v1-functionality-delta.md"
 assert_exit "inventory missing one persona fails" 1 "$STRUCTURE" --dir "$TEST_DIR/missing-persona"
 
-# --- "needs confirmation" residue ---
+# --- "needs confirmation" residue past intro separator ---
 mkdir -p "$TEST_DIR/needs-confirmation"
 write_good_inventory "$TEST_DIR/needs-confirmation/v1-pages-inventory.md"
 cat > "$TEST_DIR/needs-confirmation/v1-functionality-delta.md" <<'EOF'
 # v1 Functionality Delta
+
+Intro mentioning the **needs confirmation** marker convention.
+
+---
 
 ## For collaborators without v1 access
 
@@ -107,7 +111,27 @@ See `v1-pages-inventory.md`.
 
 The dual-rate model needs confirmation against v1 source.
 EOF
-assert_exit "delta with 'needs confirmation' residue fails" 1 "$STRUCTURE" --dir "$TEST_DIR/needs-confirmation"
+assert_exit "delta with 'needs confirmation' residue past intro fails" 1 "$STRUCTURE" --dir "$TEST_DIR/needs-confirmation"
+
+# --- "needs confirmation" mentioned ONLY in legend (before first separator) is allowed ---
+mkdir -p "$TEST_DIR/legend-only"
+write_good_inventory "$TEST_DIR/legend-only/v1-pages-inventory.md"
+cat > "$TEST_DIR/legend-only/v1-functionality-delta.md" <<'EOF'
+# v1 Functionality Delta
+
+Intro that defines the **needs confirmation** marker convention.
+
+---
+
+## For collaborators without v1 access
+
+See `v1-pages-inventory.md`.
+
+## Body
+
+Real content with no flagged items.
+EOF
+assert_exit "delta with 'needs confirmation' only in pre-separator legend passes" 0 "$STRUCTURE" --dir "$TEST_DIR/legend-only"
 
 # --- Wrong top header in delta ---
 mkdir -p "$TEST_DIR/wrong-header"

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Tests for scripts/check-v1-doc-structure.sh
+# Run from repo root: bash scripts/tests/test_check_v1_doc_structure.sh
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+STRUCTURE="$REPO_ROOT/scripts/check-v1-doc-structure.sh"
+TEST_DIR=$(mktemp -d -t v1-structure-tests-XXXXXX)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local description="$1"
+  local expected_code="$2"
+  shift 2
+  local actual_output
+  actual_output=$("$@" 2>&1)
+  local actual_code=$?
+  if [[ "$actual_code" == "$expected_code" ]]; then
+    echo "  PASS — $description (exit $actual_code)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description (expected exit $expected_code, got $actual_code)"
+    echo "    output: $actual_output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+write_good_inventory() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# v1 Pages Inventory
+
+## Super-Admin
+| route | v2_status |
+
+## Agency Admin
+| route | v2_status |
+
+## Care Manager
+| route | v2_status |
+
+## Caregiver
+| route | v2_status |
+
+## Client
+| route | v2_status |
+
+## Family Member
+| route | v2_status |
+EOF
+}
+
+write_good_delta() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# v1 Functionality Delta
+
+## For collaborators without v1 access
+
+See `v1-pages-inventory.md`, `v1-user-journeys.md`, `v1-integrations-and-exports.md`.
+
+## Severity matrix
+
+| H | M | L | D |
+EOF
+}
+
+echo "== check-v1-doc-structure.sh tests =="
+
+[[ -x "$STRUCTURE" ]] || { echo "FAIL — structure script not executable at $STRUCTURE"; exit 1; }
+
+# --- Pass case: good fixtures ---
+mkdir -p "$TEST_DIR/good"
+write_good_inventory "$TEST_DIR/good/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/good/v1-functionality-delta.md"
+assert_exit "fully-conformant docs pass" 0 "$STRUCTURE" --dir "$TEST_DIR/good"
+
+# --- Missing persona ---
+mkdir -p "$TEST_DIR/missing-persona"
+cat > "$TEST_DIR/missing-persona/v1-pages-inventory.md" <<'EOF'
+# v1 Pages Inventory
+
+## Super-Admin
+## Agency Admin
+## Care Manager
+## Caregiver
+## Client
+EOF
+write_good_delta "$TEST_DIR/missing-persona/v1-functionality-delta.md"
+assert_exit "inventory missing one persona fails" 1 "$STRUCTURE" --dir "$TEST_DIR/missing-persona"
+
+# --- "needs confirmation" residue ---
+mkdir -p "$TEST_DIR/needs-confirmation"
+write_good_inventory "$TEST_DIR/needs-confirmation/v1-pages-inventory.md"
+cat > "$TEST_DIR/needs-confirmation/v1-functionality-delta.md" <<'EOF'
+# v1 Functionality Delta
+
+## For collaborators without v1 access
+
+See `v1-pages-inventory.md`.
+
+## Open items
+
+The dual-rate model needs confirmation against v1 source.
+EOF
+assert_exit "delta with 'needs confirmation' residue fails" 1 "$STRUCTURE" --dir "$TEST_DIR/needs-confirmation"
+
+# --- Wrong top header in delta ---
+mkdir -p "$TEST_DIR/wrong-header"
+write_good_inventory "$TEST_DIR/wrong-header/v1-pages-inventory.md"
+cat > "$TEST_DIR/wrong-header/v1-functionality-delta.md" <<'EOF'
+# v1 Functionality Delta
+
+## Severity matrix
+
+| H | M | L | D |
+
+## For collaborators without v1 access
+
+(too far down)
+EOF
+assert_exit "delta with cross-ref header NOT first H2 fails" 1 "$STRUCTURE" --dir "$TEST_DIR/wrong-header"
+
+# --- Missing files ---
+mkdir -p "$TEST_DIR/missing-files"
+assert_exit "missing both files fails" 1 "$STRUCTURE" --dir "$TEST_DIR/missing-files"
+
+# --- Default dir resolves to "docs/migration" relative to cwd; with a non-existent
+# path it should fail. Using a fake empty dir to verify default behavior without
+# a subshell so the FAIL counter propagates correctly.
+mkdir -p "$TEST_DIR/empty-cwd"
+PREV_PWD="$PWD"
+cd "$TEST_DIR/empty-cwd"
+assert_exit "default-dir invocation fails when docs/migration/ absent" 1 "$STRUCTURE"
+cd "$PREV_PWD"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" == 0 ]] || exit 1


### PR DESCRIPTION
## Summary

First of N PRs against #78. Lands the **infrastructure** for the v1 reference docset — hygiene scanners, structure validator, CI workflow, pre-commit hooks, Makefile targets, locked conventions, and persona-section scaffolding — without authoring v1 content. Subsequent PRs author content per persona / journey / integration with the same conventions enforced by the gates landed here.

**This PR does not close #78.** #78 closes when all six in-scope files in the issue body have authored content and the cold-reader test passes.

## Why infrastructure-first

The hygiene scanner blocks PHI patterns, absolute paths, and plausible real-name two-word sequences. If content lands in the same PR as the scanner, the first content commit sneaks through unchecked, and PHI leaks would require git-history rewrites to remove. Sequencing scanner → content is the only safe order.

## What this PR adds

```
.github/workflows/v1-doc-hygiene.yml          # path-filtered to docs/migration/v1-*.md and the scripts
.pre-commit-config.yaml                       # local hooks delegating to the same scripts
Makefile                                      # +test-v1-docs, +scan-v1-docs targets
scripts/check-v1-doc-hygiene.sh               # PHI / paths / plausible-name regex; respects placeholders, persona vocab, English determiners, code spans, headings
scripts/check-v1-doc-structure.sh             # six personas required, cross-ref header first H2, "needs confirmation" residue scoped past intro
scripts/tests/test_check_v1_doc_hygiene.sh    # 17 tests
scripts/tests/test_check_v1_doc_structure.sh  # 7 tests
docs/migration/README.md                      # locks every committee convention; pins v1 commit 9738412a
docs/migration/v1-pages-inventory.md          # six persona H2s + locked 10-column row schema; rows TBD
docs/migration/v1-user-journeys.md            # six persona H2s + per-persona journey list; content TBD
docs/migration/v1-integrations-and-exports.md # vendor-grouped sections with schema; entries TBD
docs/migration/v1-glossary.md                 # seeded with v1-specific terms cited in the existing delta
```

Updated:

```
docs/migration/v1-functionality-delta.md      # cross-ref H2 added at top of body; absolute-path footer replaced with repo slug + commit-pin reference (Security MUST-FIX)
```

## Locked conventions (in `docs/migration/README.md`)

- Six personas, exact strings from `.claude/pm-context.md`: `Super-Admin`, `Agency Admin`, `Care Manager`, `Caregiver`, `Client`, `Family Member`.
- v2 status enum: `implemented` / `scaffolded` / `missing`.
- Severity rubric inherited from existing delta: `H` / `M` / `L` / `D`.
- Visual markers: `🔴 H · missing` / `🟡 M · scaffolded` / `🟢 implemented` / `⚪ D · deliberate`.
- PHI placeholder set: all-caps in brackets, scanner-enforced.
- Voice: present tense, active, third-person prose; second-person reserved for top-of-file leads. No first-person "I"; no unscoped "we".
- Quoted v1 UI strings: blockquote with `v1 displays:` attribution; never inlined as imperative prose (prompt-injection guard).
- v1 source references: GitHub repo slug `suniljames/COREcare-access` only — no absolute filesystem paths.
- v1 reference commit pinned at `9738412a6e41064203fc253d9dd2a5c6a9c2e231`.

## Verification

- [x] `make test-v1-docs` → 24 tests pass (17 hygiene + 7 structure)
- [x] `make scan-v1-docs` → exits 0 against the committed scaffold
- [x] All commits pass hygiene + structure scans
- [x] No PHI, no absolute paths, no plausible real-name pairs introduced (scanner verified on every commit)
- [x] Top H2 of `v1-functionality-delta.md` is now `For collaborators without v1 access` (committee Writer + EM requirement)
- [x] Existing `/Users/suniljames/...` footer replaced with repo slug (Security MUST-FIX)

## Out of scope (deliberately deferred to follow-up PRs)

- Authoring route rows in `v1-pages-inventory.md` (six personas × ~150–300 routes total).
- Authoring journey narratives (~30–40 across personas).
- Authoring integrations & exports entries.
- Resolving the four `needs confirmation` flags in the delta with v1 source citations.
- Filling glossary definitions.
- Filing the three deferred follow-up issues from the issue body's DIA (FAQ staleness audit, CONTRIBUTING/project-context pointer, PHI leak response runbook). Will file alongside the first content PR.
- Cold-reader test by Sunil (gates the FINAL content PR, not this one).

## Test plan

- [ ] `make test-v1-docs` passes locally
- [ ] `make scan-v1-docs` passes locally
- [ ] CI workflow `V1 Doc Hygiene` runs and passes on this PR
- [ ] Existing CI workflows are unaffected (no api / web / e2e impact — this is docs + scripts only)
- [ ] Reviewer reads `docs/migration/README.md` cold and confirms the conventions match the committee plan in #78's design comments
- [ ] Reviewer spot-checks one persona section in `v1-pages-inventory.md` for schema-column alignment

## Related

- **Closes:** none — does NOT close #78.
- **Toward:** #78 (DoD partial; subsequent PRs land content).
- **Follow-up:** #79 (Playwright screenshot catalog) becomes useful once pages-inventory rows author.