### PR TITLE
docs(#102): pages-inventory Client persona — absence note

### DIFF
--- a/docs/migration/v1-pages-inventory.md
+++ b/docs/migration/v1-pages-inventory.md
@@ -54,6 +54,15 @@ _Enumeration in progress (#81). Per-Django-app denominators below._
 
 **Status note (2026-05-07).** Issue #81 covers Agency Admin row authoring; sub-issues #83–#89 split the work per Django app. All ten Django-app sub-sections are now complete: top-level admin routes, `billing`, `billing_catalogs`, `charting` (per #85), `clients` (per #84), `compliance` (per #88), `dashboard` (per this PR #83), `employees` (per #87), `quickbooks_integration` (per #86), and `auth_service` (per #88). Only the dual-role / shared routes remain (#89) — those land in the file's `## Shared routes` section, not under `## Agency Admin`. Coverage at this commit is **91 / 96 ≈ 95%**, meeting the section's ≥95% target; the remaining 5 dual-role routes are the headroom.
 
+### Client
+
+_v1 has no Client-as-actor surface — see [the Client section absence note](#client) below._
+
+| app | denominator | numerator | notes |
+|-----|-------------|-----------|-------|
+| _(no Django app reachable by Client persona)_ | 0 | 0 | Client is a model record (`clients.models.Client`), not an authenticator. No URL patterns reachable by a logged-in client. |
+| **total (Client)** | **0** | **0** | N/A — section is an absence note, not a row table. |
+
 ---
 
 ---
@@ -276,13 +285,17 @@ Caregiver pages are field-facing: clock-in/out, schedule view, chart-note submis
 
 ## Client
 
-_last reconciled: 2026-05-06 against v1 commit `9738412`_
+_last reconciled: 2026-05-07 against v1 commit `9738412`_
 
-Client pages cover the care recipient's view of their care plan, upcoming shifts, and assigned caregivers. Lower frequency than Caregiver; PHI handling is paramount because the client is the subject.
+**v1 has no Client-as-actor surface.** Clients are subjects of care, not authenticators. `clients/models.py:15` defines `class Client(models.Model)` with no `User` linkage; the only `User` linkage in the `clients/` app is `class ClientFamilyMember` at `clients/models.py:392`, whose `user = ForeignKey(settings.AUTH_USER_MODEL)` field at `clients/models.py:400` binds a Family Member account to a Client record. Every `<int:client_id>`-parameterized URL pattern in v1 is reached by staff (Agency Admin, Care Manager, Caregiver) under `@staff_member_required` / role decorators, or by a linked Family Member under the `ClientFamilyMember` relationship — never by a logged-in client. v1 carries zero `@client_required`-style decorators (verified by source grep at the pinned commit). The `.claude/pm-context.md` `Stakeholders` table aligns with this reality: it lists Super-Admin, Agency Admin, Care Manager, Caregiver, and Family Member as personas; Client appears in the `Domain Vocabulary` table as a subject term, not in `Stakeholders` as an actor.
 
-| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
-|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
-| _(rows pending content authoring)_ | | | | | | | | | |
+**Where client-data visibility actually lives in v1.** Inventory rows that render a client's PHI live under other persona sections:
+
+- the [Family Member section](#family-member) of this inventory — the Family Member persona reaches client-linked dashboards, billing PDFs, health-report downloads, and event calendars under the `ClientFamilyMember` linkage (rows authored under #103).
+- [Agency Admin → clients](#clients) — staff reach the per-client unified calendar, custom event creation, attachments, and schedule PDF/preview (rows authored under #84).
+- [Agency Admin → charting](#charting) — staff reach the per-client charting tab, trend views, medication orders, chart-comment review, health-report generation and approval, and proxy charting (rows authored under #85).
+
+**v2 product question.** Whether v2 adds an authenticated Client portal as a deliberate divergence from v1 — and the implied new Clerk role plus per-client RLS policy — is tracked separately in [#109](https://github.com/suniljames/COREcare-v2/issues/109) (`needs-pm-input`). This inventory section is faithful to v1 and is intentionally empty of rows.
 
 ---
 

--- a/docs/migration/v1-pages-inventory.md
+++ b/docs/migration/v1-pages-inventory.md
@@ -56,7 +56,7 @@ _Enumeration in progress (#81). Per-Django-app denominators below._
 
 ### Client
 
-_v1 has no Client-as-actor surface — see [the Client section absence note](#client) below._
+_v1 has no Client-as-actor surface — see [the Client section absence note](#client-section) below._
 
 | app | denominator | numerator | notes |
 |-----|-------------|-----------|-------|
@@ -284,6 +284,8 @@ Caregiver pages are field-facing: clock-in/out, schedule view, chart-note submis
 ---
 
 ## Client
+
+<a id="client-section"></a>
 
 _last reconciled: 2026-05-07 against v1 commit `9738412`_
 


### PR DESCRIPTION
Closes #102.

## Summary

Authors the `## Client` H2 section of `docs/migration/v1-pages-inventory.md` as an **absence note** rather than a row table. v1 has no Client-as-actor surface — `clients/models.py:15` defines `class Client(models.Model)` with no `User` linkage, and the only `User` binding in the `clients/` app is `ClientFamilyMember` at `clients/models.py:392`. Every `<int:client_id>`-parameterized v1 URL is reached by staff or by a Family Member; never by a logged-in client.

This finding emerged during `/design` on #102 and reshaped the issue scope. See the committee thread on #102 for the full rationale.

## What changed

- **`## Client` section** (`docs/migration/v1-pages-inventory.md`): replaced the `_(rows pending content authoring)_` placeholder with a structured absence note citing the v1 source (`clients/models.py:15` and `clients/models.py:392`), plus three descriptive cross-references to where client-data visibility actually lives in v1: the [Family Member section](docs/migration/v1-pages-inventory.md#family-member) (rows pending under #103), [Agency Admin → clients](docs/migration/v1-pages-inventory.md#clients) (authored under #84), and [Agency Admin → charting](docs/migration/v1-pages-inventory.md#charting) (authored under #85). Bumped `_last reconciled:_` to `2026-05-07`.
- **`## Coverage` subsection** (same file): added a `### Client` block with `0 / 0` per-app entry and section total, mirroring the layout of the existing `### Agency Admin` block so per-persona comparisons grep cleanly.
- **Filed #109** — `feat(v2): evaluate Client-as-user persona — Clerk role + RLS policy` — labeled `documentation` + `needs-pm-input`. Linked from the absence note.
- **Commented on #105** — requested a v1-glossary entry for "Client" that distinguishes the v1 model record from the v2-hypothetical persona.

## Why this is the right shape

The committee on #102 (Software Engineer, System Architect, Data Engineer, Security Engineer, QA Engineer, Writer; UX, AI/ML, SRE deferred) was unanimous: a row table for an absent surface mis-trains the cold reader. The structure validator at `scripts/check-v1-doc-structure.sh:53-60` only requires the `## Client` H2 to be present, not populated — the absence note satisfies the validator and documents the v1 truth.

## Hygiene gates

```sh
$ make scan-v1-docs
... OK: catalog coverage holds (exit 0)

$ make test-v1-docs
Total: 18  PASS: 18  FAIL: 0 (exit 0)
```

## Sunil PHI sign-off (request)

The original DoD's "every row's `phi_displayed=true`" check no longer applies because there are no rows. The remaining PHI gate is on the absence-note prose itself: it names no clients, prescribers, or specific records. PHI-safe to merge once Sunil signs off.

## Related

- **Closes:** #102.
- **Filed:** #109 (v2 Client-portal product question).
- **Commented on:** #105 (glossary entry hook).
- **Cross-references in the absence note:** #103 (Family Member, pending), #84 (Agency Admin clients, merged), #85 (Agency Admin charting, merged).
- **Inheritance:** #80 (infrastructure), #82 (row prose conventions).

## Test plan

- [x] `make scan-v1-docs` exits 0 locally.
- [x] `make test-v1-docs` exits 0 locally (18/18).
- [x] `## Client` H2 present (structure validator).
- [x] No `_(rows pending content authoring)_` placeholder in `## Client`.
- [x] `_last reconciled: 2026-05-07 against v1 commit `9738412`_` line directly under H2.
- [x] Absence note explicitly cites `clients/models.py:15` and `clients/models.py:392`.
- [x] Cross-reference list contains three descriptive links to Family Member section, Agency Admin → clients, Agency Admin → charting.
- [x] Coverage subsection has `### Client` block with `0/0`.
- [x] Trailing sentence links #109.
- [x] Follow-up #109 filed with `documentation` + `needs-pm-input` labels.
- [x] One-line comment posted on #105 requesting glossary entry.
- [ ] Sunil PHI sign-off on absence-note prose.
- [ ] CI hygiene workflow green.