### PR TITLE
docs(#100): pages-inventory rows for Care Manager persona

### DIFF
--- a/docs/migration/v1-pages-inventory.md
+++ b/docs/migration/v1-pages-inventory.md
@@ -54,6 +54,20 @@ _Enumeration in progress (#81). Per-Django-app denominators below._
 
 **Status note (2026-05-07).** Issue #81 covers Agency Admin row authoring; sub-issues #83–#89 split the work per Django app. All ten Django-app sub-sections are now complete: top-level admin routes, `billing`, `billing_catalogs`, `charting` (per #85), `clients` (per #84), `compliance` (per #88), `dashboard` (per this PR #83), `employees` (per #87), `quickbooks_integration` (per #86), and `auth_service` (per #88). Only the dual-role / shared routes remain (#89) — those land in the file's `## Shared routes` section, not under `## Agency Admin`. Coverage at this commit is **91 / 96 ≈ 95%**, meeting the section's ≥95% target; the remaining 5 dual-role routes are the headroom.
 
+### Care Manager
+
+| app | denominator | numerator | notes |
+|-----|-------------|-----------|-------|
+| care_manager | 6 | 6 | dedicated CM portal — caseload, client focus, three CM-expense screens, receipt download; complete |
+| charting | 1 (proxy_chart_view, gated `is_staff or is_care_manager`) | 0 | row authored under [Agency Admin → charting](#charting); cross-ref only — no duplicate row in this section |
+| **total (Care Manager)** | **7** | **6 (≈86% — see note)** | the single charting row is intentionally not duplicated; coverage of *authored-here* rows is 6/6 = 100%. The 7-route total is the persona's full reachable surface; cross-ref discharges authoring obligation per the #82 convention |
+
+**Excluded charting routes (not Care-Manager-reachable in v1).** Chart-comment review queue, health-report approval queue, all per-client clinical trend / summary / order views, and report-template administration are gated `@staff_member_required` in `charting/views.py` at v1 commit `9738412a`. `CareManagerProfile.is_staff = False`, so CMs do not reach them. ~25 routes total; not enumerated here.
+
+**Excluded redirect-only routes (not counted in denominator).** `/care-manager/dashboard/`, `/care-manager/clients/`, `/care-manager/schedule/`, `/care-manager/requests/` are `RedirectView` permanent redirects to `/care-manager/`; excluded per the README coverage rule.
+
+**Status note (2026-05-07).** Issue #100 closes this section. The cross-ref to `proxy_chart_view` discharges the charting authoring obligation per the row-not-duplicated convention. Excluded routes (per the lead paragraph) total ~25 in `charting/` and are not Care-Manager-reachable in v1.
+
 ### Client
 
 _v1 has no Client-as-actor surface — see [the Client section absence note](#client-section) below._
@@ -261,13 +275,21 @@ _password-reset flow (4 routes) + magic-link login (1 route); mounted at root pr
 
 ## Care Manager
 
-_last reconciled: 2026-05-06 against v1 commit `9738412`_
+_last reconciled: 2026-05-07 against v1 commit `9738412`_
 
-Care Manager pages cover care plan authoring, supervisory review, and team-level oversight of caregivers. Distinct from Agency Admin in clinical scope; distinct from Caregiver in supervisory authority.
+Care Manager is a dedicated role profile (`CareManagerProfile`, OneToOne with User, `is_staff=False`) — a caseload-first portal of six pages where a CM sees their assigned clients and submits the small expenses they incur in the field. v1's chart-comment review queue, health-report approval queue, per-client clinical trend and order views, and report-template administration are gated `@staff_member_required` in `charting/views.py` at v1 commit `9738412a`; CMs do not reach them, and v2 must not collapse this gate by granting CMs `is_staff`. Audit-log behavior in the CM portal is uneven — `ExpenseService` logs status transitions on submit/edit/resubmit, but `cm_serve_receipt` does not log downloads, and clinical-tab access inside `cm_client_focus` inherits whatever logging the underlying `charting` services emit; each row's `purpose` cell calls out where v1 audit-logs and where v2 must add coverage. The `proxy_chart_view` row lives under [Agency Admin → charting](#charting); see the [cross-reference index](#cross-reference-index) for dual-role portal switching, password reset, magic-link login, and the receipt-route Agency Admin oversight path.
+
+### care_manager
+_six HTML routes mounted at `/care-manager/` per `elitecare/urls.py` line 179: caseload, per-client focus, CM expense list, expense submit, expense edit, expense receipt download; four legacy `RedirectView` URLs (`/dashboard/`, `/clients/`, `/schedule/`, `/requests/`) are excluded per the README coverage rule_
 
 | route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
 |-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
-| _(rows pending content authoring)_ | | | | | | | | | |
+| `/care-manager/` | 🔒 PHI · `My Caseload` — priority-sorted list of every client assigned to this CM, with attention queue and all-clear groups; scope enforced by `CareManagerService.get_assigned_client_ids`; v1 does not audit-log this surface. | Sees: assigned clients with severity-colored attention badges, action queue with caregiver and client context, all-clear group, daily summary. Can: drill to a client's focus page, dismiss or annotate actions via the inline notify links. | missing | H | true | false | true | not_screenshotted: pending #79 |  |
+| `/care-manager/client/<int:pk>/` | 🔒 PHI · `Client Focus` — full per-client context for one assigned client across schedule, charting, vitals, and care-request tabs; unassigned-client access raises Http404; clinical-tab audit logging inherits whatever the underlying `charting` services emit (verify per-tab in v2 design). | Sees: client demographics with diagnosis and DNR badge, alert-badge strip, care-team caregiver cards with phone and email, family-member contacts, tab-specific data (schedule grid, charting rollup, vitals trend, request list) with notification dots per tab. Can: switch tabs via querystring, drill to caregivers and family members, take per-tab actions surfaced by the action queue. | missing | H | true | false | true | not_screenshotted: pending #79 |  |
+| `/care-manager/expenses/` | 🔒 PHI · CM expense list grouped per assigned client, with budget status; status transitions on the linked expenses are audit-logged via `ExpenseService` workflow events but the list view itself is not. | Sees: per-client expense groupings with status, amount, expense type, submission date; budget status banner; receipt thumbnails. Can: drill to a single expense to edit or resubmit, navigate to the submission form, open a receipt. | missing | M | true | false | true | not_screenshotted: pending #79 |  |
+| `/care-manager/expenses/submit/` | 🔒 PHI · CM expense submission form scoped to assigned clients; submission audit-logged via `ExpenseService.create_expense` workflow events. | Sees: budget status, expense-type picker, amount, description, expense date, client picker (assigned clients only), payment-method radio, receipt upload. Can: submit an expense with a single attached receipt; success returns to the expense list with a flash message. | missing | M | true | false | true | not_screenshotted: pending #79 |  |
+| `/care-manager/expenses/<int:expense_id>/edit/` | 🔒 PHI · CM expense edit / resubmit form; submitter-only ownership enforced; resubmits on REJECTED expenses route through `ExpenseService.resubmit_expense`, edits route through `ExpenseService.edit_expense` — both audit-logged via workflow events. | Sees: pre-filled form mirroring the submit page with the linked client locked, current status, and an optional receipt upload. Can: update fields and save, attach a new receipt (replaces the previous one), or resubmit a rejected expense. | missing | M | true | false | true | not_screenshotted: pending #79 |  |
+| `/care-manager/expenses/<int:expense_id>/receipt/<int:receipt_id>/` | 🔒 PHI · Auth-gated download of an expense receipt; access boundary is the submitter, the linked caregiver, or `is_staff` short-circuit at `care_manager/views.py:733` (Agency Admin oversight path); receipt is verified-bound to its parent expense via `get_object_or_404(ExpenseReceipt, pk=receipt_id, expense=expense)` to prevent cross-receipt IDOR; **v1 has no audit on this route — v2 design must add**. | Sees: file download initiated by the browser with `Content-Disposition: attachment` and a sanitized filename. Can: open or save the receipt blob. | missing | H | true | false | true | not_screenshotted: pending #79 |  |
 
 ---
 
@@ -345,6 +367,7 @@ Routes whose canonical row lives in a persona section.
 | `/password-reset/<uuid:token>/` | Agency Admin | all other personas | [Agency Admin → auth_service](#auth_service) |
 | `/password-reset/complete/` | Agency Admin | all other personas | [Agency Admin → auth_service](#auth_service) |
 | `/magic-login/<uuid:token>/` | Caregiver | Client, Family Member (admin users `is_staff`/`is_superuser` blocked at the view layer; URL reachable but bounces to invalid-token) | (pending Caregiver section; Agency Admin row in `### auth_service` documents the v1 block-for-admins behavior) |
+| `/care-manager/expenses/<int:expense_id>/receipt/<int:receipt_id>/` | Care Manager | Agency Admin (oversight via `is_staff` short-circuit at `care_manager/views.py:733` in v1) | [Care Manager → care_manager](#care_manager) |
 
 ### Routes authored here (no primary-persona section)
 

--- a/scripts/tests/test_issue_100_care_manager.sh
+++ b/scripts/tests/test_issue_100_care_manager.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# Acceptance test for issue #100: pages-inventory rows for Care Manager
+# persona. Asserts the Definition of Done from the issue body:
+#   1. ## Care Manager has exactly one ### care_manager H3 (no ### charting).
+#   2. ### care_manager has 6 populated route rows.
+#   3. All 6 rows are PHI-prefixed (🔒 PHI · ).
+#   4. Lead paragraph carries the four required tokens (CareManagerProfile,
+#      is_staff=False, @staff_member_required, proxy_chart_view).
+#   5. Lead paragraph cross-refs the Agency Admin charting anchor.
+#   6. Receipt row's purpose includes the audit-gap phrase + IDOR boundary.
+#   7. Coverage subsection has a ### Care Manager block.
+#   8. Cross-reference index has the new receipt-route entry.
+#   9. _last reconciled:_ line is updated to 2026-05-07 + commit 9738412.
+#  10. No "supervising nurse" / "supervising-nurse" leakage in section prose.
+#  11. Hygiene + structure scanners pass.
+#
+# Run from repo root: bash scripts/tests/test_issue_100_care_manager.sh
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INVENTORY="$REPO_ROOT/docs/migration/v1-pages-inventory.md"
+HYGIENE="$REPO_ROOT/scripts/check-v1-doc-hygiene.sh"
+STRUCTURE="$REPO_ROOT/scripts/check-v1-doc-structure.sh"
+
+PASS=0
+FAIL=0
+
+assert() {
+  local description="$1"; shift
+  if "$@"; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Print lines between (exclusive) two H2 headings — used to scope checks
+# to the Care Manager section.
+care_manager_section() {
+  awk '
+    /^## Care Manager$/ { in_section = 1; next }
+    in_section && /^## / { in_section = 0 }
+    in_section { print }
+  ' "$INVENTORY"
+}
+
+# Print lines under ### care_manager (exclusive of the H3 line itself,
+# stopping at next H3 or H2).
+care_manager_h3_block() {
+  awk '
+    /^### care_manager$/ { in_block = 1; next }
+    in_block && /^### / { exit }
+    in_block && /^## / { exit }
+    in_block { print }
+  ' "$INVENTORY"
+}
+
+# Print lines under ### Care Manager (Coverage block) — exclusive of the
+# H3 line itself, stopping at next H3 or H2.
+coverage_care_manager_block() {
+  awk '
+    /^### Care Manager$/ { in_block = 1; next }
+    in_block && /^### / { exit }
+    in_block && /^## / { exit }
+    in_block { print }
+  ' "$INVENTORY"
+}
+
+# 1. ## Care Manager has exactly one ### care_manager H3.
+care_manager_has_one_h3_care_manager() {
+  local count
+  count=$(care_manager_section | grep -cE '^### care_manager$' || true)
+  [[ "$count" -eq 1 ]]
+}
+
+# 2. ## Care Manager does NOT have a ### charting H3 (anchor-stability rule).
+care_manager_has_no_h3_charting() {
+  ! care_manager_section | grep -qE '^### charting$'
+}
+
+# 3. ### care_manager has exactly 6 route rows (lines starting with `| `).
+care_manager_h3_has_six_rows() {
+  local count
+  count=$(care_manager_h3_block | grep -cE '^\| `/care-manager/' || true)
+  [[ "$count" -eq 6 ]]
+}
+
+# 4. Every route row in ### care_manager has 🔒 PHI · prefix in purpose.
+care_manager_rows_phi_prefixed() {
+  # All 6 rows expected; if fewer rows have the prefix, fail.
+  local prefixed
+  prefixed=$(care_manager_h3_block | grep -cE '^\| `/care-manager/.*\| 🔒 PHI · ' || true)
+  [[ "$prefixed" -eq 6 ]]
+}
+
+# 5a. Lead paragraph contains CareManagerProfile token.
+lead_has_caremanagerprofile() {
+  care_manager_section | grep -qE 'CareManagerProfile'
+}
+
+# 5b. Lead paragraph contains is_staff=False token.
+lead_has_is_staff_false() {
+  care_manager_section | grep -qE 'is_staff=False'
+}
+
+# 5c. Lead paragraph contains @staff_member_required token.
+lead_has_staff_member_required() {
+  care_manager_section | grep -qE '@staff_member_required'
+}
+
+# 5d. Lead paragraph references proxy_chart_view.
+lead_has_proxy_chart_view() {
+  care_manager_section | grep -qE 'proxy_chart_view'
+}
+
+# 6. Lead paragraph contains a markdown link to Agency Admin charting anchor.
+lead_links_to_charting_anchor() {
+  care_manager_section | grep -qE '\(#charting\)'
+}
+
+# 7a. Receipt row contains the verbatim audit-gap phrase.
+receipt_row_has_audit_gap_phrase() {
+  care_manager_h3_block \
+    | grep -E '^\| `/care-manager/expenses/<int:expense_id>/receipt/' \
+    | grep -q 'v1 has no audit on this route'
+}
+
+# 7b. Receipt row mentions IDOR boundary.
+receipt_row_mentions_idor() {
+  care_manager_h3_block \
+    | grep -E '^\| `/care-manager/expenses/<int:expense_id>/receipt/' \
+    | grep -qE 'IDOR'
+}
+
+# 7c. Receipt row notes the is_staff short-circuit boundary.
+receipt_row_notes_is_staff_boundary() {
+  care_manager_h3_block \
+    | grep -E '^\| `/care-manager/expenses/<int:expense_id>/receipt/' \
+    | grep -qE 'is_staff'
+}
+
+# 8. Coverage subsection has a ### Care Manager block.
+coverage_has_care_manager_block() {
+  awk '
+    /^## Coverage/ { in_section = 1; next }
+    in_section && /^## / { exit }
+    in_section && /^### Care Manager$/ { found = 1; exit }
+    END { exit (found ? 0 : 1) }
+  ' "$INVENTORY"
+}
+
+# 8b. Coverage Care Manager block has care_manager row with 6/6 numerator.
+coverage_care_manager_row_complete() {
+  coverage_care_manager_block | grep -qE '^\| care_manager \| 6 \| 6 \|'
+}
+
+# 9. Cross-reference index has the new receipt-route entry.
+xref_index_has_receipt_route() {
+  awk '
+    /^### Cross-reference index/ { in_section = 1; next }
+    in_section && /^### / { exit }
+    in_section && /^## / { exit }
+    in_section && /\/care-manager\/expenses\/<int:expense_id>\/receipt\/<int:receipt_id>\// { found = 1 }
+    END { exit (found ? 0 : 1) }
+  ' "$INVENTORY"
+}
+
+# 9b. The new entry's primary persona is Care Manager and also-reachable mentions Agency Admin via is_staff.
+xref_index_receipt_route_attributes() {
+  awk '
+    /^### Cross-reference index/ { in_section = 1; next }
+    in_section && /^### / { exit }
+    in_section && /^## / { exit }
+    in_section && /\/care-manager\/expenses\/<int:expense_id>\/receipt\/<int:receipt_id>\// {
+      if ($0 ~ /Care Manager/ && $0 ~ /Agency Admin/ && $0 ~ /is_staff/) { found = 1 }
+      exit
+    }
+    END { exit (found ? 0 : 1) }
+  ' "$INVENTORY"
+}
+
+# 10. _last reconciled:_ line under ## Care Manager has 2026-05-07 + 9738412.
+care_manager_last_reconciled_updated() {
+  care_manager_section | head -3 | grep -qE '_last reconciled: 2026-05-07 against v1 commit `9738412`_'
+}
+
+# 11. No "supervising nurse" leakage in the section's prose.
+no_supervising_nurse_leak() {
+  ! care_manager_section | grep -qiE 'supervising[ -]?nurse'
+}
+
+# 12. Hygiene scanner passes over the inventory.
+hygiene_passes() {
+  bash "$HYGIENE" "$INVENTORY" >/dev/null 2>&1
+}
+
+# 13. Structure scanner passes over docs/migration/.
+structure_passes() {
+  bash "$STRUCTURE" --dir "$REPO_ROOT/docs/migration" >/dev/null 2>&1
+}
+
+echo "== Issue #100 acceptance tests =="
+
+assert "## Care Manager has exactly one ### care_manager H3" care_manager_has_one_h3_care_manager
+assert "## Care Manager has NO ### charting H3 (anchor-stability)" care_manager_has_no_h3_charting
+assert "### care_manager has 6 route rows" care_manager_h3_has_six_rows
+assert "all 6 ### care_manager rows are 🔒 PHI · prefixed" care_manager_rows_phi_prefixed
+assert "lead paragraph cites CareManagerProfile" lead_has_caremanagerprofile
+assert "lead paragraph cites is_staff=False" lead_has_is_staff_false
+assert "lead paragraph cites @staff_member_required" lead_has_staff_member_required
+assert "lead paragraph references proxy_chart_view" lead_has_proxy_chart_view
+assert "lead paragraph links to (#charting)" lead_links_to_charting_anchor
+assert "receipt row contains audit-gap phrase verbatim" receipt_row_has_audit_gap_phrase
+assert "receipt row mentions IDOR boundary" receipt_row_mentions_idor
+assert "receipt row notes is_staff short-circuit" receipt_row_notes_is_staff_boundary
+assert "Coverage subsection has ### Care Manager block" coverage_has_care_manager_block
+assert "Coverage care_manager row shows 6/6" coverage_care_manager_row_complete
+assert "Cross-reference index has the new receipt-route entry" xref_index_has_receipt_route
+assert "Cross-ref index entry: Care Manager primary, Agency Admin via is_staff" xref_index_receipt_route_attributes
+assert "_last reconciled:_ updated to 2026-05-07 + 9738412" care_manager_last_reconciled_updated
+assert "no 'supervising nurse' / 'supervising-nurse' leak in section" no_supervising_nurse_leak
+assert "hygiene scanner passes over inventory" hygiene_passes
+assert "structure scanner passes over docs/migration/" structure_passes
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" == 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Authors the `## Care Manager` section of `docs/migration/v1-pages-inventory.md` against v1 commit `9738412a`. Six routes in `### care_manager`, one cross-ref to `proxy_chart_view` (already authored under Agency Admin per #85), one new row in `## Shared routes → ### Cross-reference index` for the receipt-route oversight path. Closes #100; toward #78.

## What landed

- **Lead paragraph (4 sentences)** — role+portal definition (`CareManagerProfile`, OneToOne, `is_staff=False`), excluded-routes citation with `@staff_member_required` decorator citation, audit-log unevenness story, cross-ref obligations.
- **`### care_manager` H3 + 6 PHI-prefixed rows:**
  - `/care-manager/` — `My Caseload` (H, scope-enforced via `CareManagerService.get_assigned_client_ids`)
  - `/care-manager/client/<int:pk>/` — `Client Focus` four-tab per-client surface (H)
  - `/care-manager/expenses/` — per-client grouped expense list (M)
  - `/care-manager/expenses/submit/` — CM expense submit form (M)
  - `/care-manager/expenses/<int:expense_id>/edit/` — CM expense edit/resubmit (M)
  - `/care-manager/expenses/<int:expense_id>/receipt/<int:receipt_id>/` — auth-gated receipt download with IDOR boundary + audit-gap call-out (H)
- **No `### charting` H3 under Care Manager** — anchor stability with the existing Agency Admin `#charting`. Cross-ref inlined in the lead.
- **Coverage subsection**: new `### Care Manager` block (`care_manager: 6/6`, `charting: 1/0`, status note explaining the row-not-duplicated convention; ~25 `@staff_member_required` charting routes explicitly excluded; redirect-only legacy URLs called out).
- **Cross-reference index entry**: receipt-route gets one new row (primary `Care Manager`, also reachable by `Agency Admin (oversight via is_staff short-circuit at care_manager/views.py:733 in v1)`).
- **Acceptance test**: `scripts/tests/test_issue_100_care_manager.sh` — 20 assertions covering every DoD bullet, mirrors the `#88` pattern.

## Authoring metrics

| sub-section | rows | minutes | notes |
|---|---|---|---|
| `### care_manager` (caseload, client focus, expense list/submit/edit, receipt) | 6 | ~25 | 4 of 6 reuse the same `ExpenseService` audit convention; receipt row took longer (IDOR boundary + audit-gap phrasing) |
| Coverage `### Care Manager` block | n/a | ~5 | mirrored Agency Admin format |
| Cross-ref index entry | n/a | ~3 | one new row added |
| Lead paragraph (4 sentences) | n/a | ~7 | tokens specified verbatim by EM synthesis |
| **content total** | **6 rows** | **~40** | well under the 2-hour timebox |
| acceptance test | 20 assertions | ~20 | mirrored `test_issue_88_compliance_auth_service.sh` |

## Cold-reader self-test

All five Test-Spec E2E questions answerable from the section + cross-refs in <60s each:

1. **What screens does a Care Manager see in v1?** ✓ — six rows under `### care_manager`.
2. **Where does a CM review a chart on behalf of a caregiver?** ✓ — lead sentence 4 → linked Agency Admin `proxy_chart_view` row.
3. **Can a CM approve chart comments / sign off on health-report requests?** ✓ — lead sentence 2 (excluded-routes citation, `@staff_member_required`).
4. **Difference between a CM and an Agency Admin?** ✓ — lead sentence 1 (role asymmetry, `is_staff=False`).
5. **What should v2 not silently change?** ✓ — lead sentences 1, 3, 4 + receipt-row `purpose`.

## Verification

- [x] `bash scripts/tests/test_issue_100_care_manager.sh` — 20/20 PASS
- [x] `make scan-v1-docs` — exits 0
- [x] `make test-v1-docs` — 17 hygiene + 11 structure = 28 self-tests PASS
- [x] `make -C api lint` — ruff + mypy clean
- [x] `make -C api test` — 124 passed, 3 skipped
- [x] `make -C web lint typecheck test` — clean
- [ ] `make -C web build` — fails on `next build` for missing `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (environmental — same failure mode in the main checkout; no committed `.env.local`). Not caused by this PR. CI's `V1 Doc Hygiene` workflow is the canonical gate per the issue's DoD.

## Test plan

- [ ] CI workflow `V1 Doc Hygiene` passes on this PR
- [ ] Reviewer reads the new `## Care Manager` section + Coverage block + cross-ref index entry; confirms format-alignment with `## Agency Admin`
- [ ] Reviewer spot-checks the 6 rows against `~/Code/COREcare-access/care_manager/{urls,views}.py` at v1 commit `9738412a`
- [ ] **Sunil signs off on PHI hygiene of the diff before merge — manual review.** No automation substitutes.

## Related

- **Closes:** #100
- **Toward:** #78 (umbrella) — Care Manager section is the second persona to land after Agency Admin (#81 closed, sub-issues #82–#92 merged)
- **Inherits:** #80 (conventions + scanner), #82 (row prose conventions), #85 (`proxy_chart_view` row that this section cross-refs), #88 (test pattern that `test_issue_100_care_manager.sh` mirrors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
