### PR TITLE
test(#119): cover SL-3 missing-but-empty-severity branch

### DIFF
--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -576,11 +576,11 @@ $INTEGRATIONS_SEP
 EOF
 assert_exit "SL-2: invalid v2_status token fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl2"
 
-# --- SL-3: severity set but v2_status is not "missing" ---
-mkdir -p "$TEST_DIR/integrations-sl3"
-write_integrations_inventory "$TEST_DIR/integrations-sl3/v1-pages-inventory.md"
-write_good_delta "$TEST_DIR/integrations-sl3/v1-functionality-delta.md"
-cat > "$TEST_DIR/integrations-sl3/v1-integrations-and-exports.md" <<EOF
+# --- SL-3 (set): severity set but v2_status is not "missing" ---
+mkdir -p "$TEST_DIR/integrations-sl3-set"
+write_integrations_inventory "$TEST_DIR/integrations-sl3-set/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/integrations-sl3-set/v1-functionality-delta.md"
+cat > "$TEST_DIR/integrations-sl3-set/v1-integrations-and-exports.md" <<EOF
 # V1 Integrations and Exports
 
 ## Schema
@@ -607,7 +607,40 @@ $INTEGRATIONS_SEP
 
 ## Cross-references
 EOF
-assert_exit "SL-3: severity set when v2_status != missing fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3"
+assert_exit "SL-3: severity set when v2_status != missing fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-set"
+
+# --- SL-3 (empty): severity empty but v2_status is "missing" ---
+mkdir -p "$TEST_DIR/integrations-sl3-empty"
+write_integrations_inventory "$TEST_DIR/integrations-sl3-empty/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/integrations-sl3-empty/v1-functionality-delta.md"
+cat > "$TEST_DIR/integrations-sl3-empty/v1-integrations-and-exports.md" <<EOF
+# V1 Integrations and Exports
+
+## Schema
+
+table.
+
+## External integrations
+
+### Billing and payments
+
+$INTEGRATIONS_HEADER
+$INTEGRATIONS_SEP
+| Bad row | Vendor | Trigger | outbound; sync | [/quickbooks/](v1-pages-inventory.md#quickbooks_integration) | Sees: thing. | missing |  |
+
+### Payroll
+### Accounting
+### Messaging and notifications (third-party)
+### Identity, auth, and SSO (third-party)
+### Other
+
+## Internal notification and email backend
+
+## Customer-facing exports
+
+## Cross-references
+EOF
+assert_exit "SL-3: severity empty when v2_status=missing fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-empty"
 
 # --- SL-4: invalid direction_and_sync token ---
 mkdir -p "$TEST_DIR/integrations-sl4"


### PR DESCRIPTION
## Summary

- Closes #119. Adds the missing fixture for SL-3b (severity required when `v2_status=missing`) in `scripts/tests/test_check_v1_doc_structure.sh`.
- Renames the existing `integrations-sl3` fixture to `integrations-sl3-set` for symmetry with the new `integrations-sl3-empty`.
- Suite: **30 → 31 passing**, 0 failing.

## Coverage gap context

`scripts/check-v1-doc-structure.sh:301-310` has three SL-3 branches:

| Branch | Rule | Fixture before | Fixture after |
|---|---|---|---|
| SL-3a | severity token must be in `{H,M,L,D}` if set | none | none (follow-up issue) |
| SL-3b | severity required when `v2_status=missing` | **none** | **`integrations-sl3-empty`** |
| SL-3c | severity forbidden when `v2_status != missing` | `integrations-sl3` | renamed to `integrations-sl3-set` |

A future regression that flips the SL-3b conditional would now be caught by `make test-v1-docs`.

## Negative-control verification

Transiently commented out the SL-3b branch in `scripts/check-v1-doc-structure.sh` (lines 305-307) and re-ran the suite — the new test failed with `expected exit 1, got 0` as expected. Reverted the script to its committed state and confirmed 31/31 passing. Script diff is empty in this PR; only the test file changed.

## Out-of-scope follow-up

SL-3a (invalid severity token) is also uncovered. Will file a separate issue after this lands — keeping this PR to one branch for clean blame.

## Test plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` → `Results: 31 passed, 0 failed` (was 30/0).
- [x] `make test-v1-docs` output includes `PASS — SL-3: severity empty when v2_status=missing fails (exit 1)`.
- [x] `make scan-v1-docs` exits 0 (real-doc lint unaffected).
- [x] `make check` passes (api lint/test, web lint/typecheck/test/build).
- [x] Negative control: disabling the SL-3b branch in the awk script causes the new test to fail; restoring it makes it pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)