### PR TITLE
feat(#107): Phase 1 — TS Playwright crawler scaffold + unit tests + CI

### DIFF
--- a/.github/workflows/v1-catalog-coverage.yml
+++ b/.github/workflows/v1-catalog-coverage.yml
@@ -6,7 +6,10 @@ on:
       - 'docs/migration/v1-pages-inventory.md'
       - 'docs/legacy/v1-ui-catalog/**'
       - 'scripts/check-v1-catalog-coverage.sh'
+      - 'scripts/extract-inventory-routes.sh'
       - 'scripts/tests/test_check_v1_catalog_coverage.sh'
+      - 'scripts/tests/test_extract_inventory_routes.sh'
+      - 'tools/v1-screenshot-catalog/**'
       - '.github/workflows/v1-catalog-coverage.yml'
   push:
     branches: [main]
@@ -14,6 +17,8 @@ on:
       - 'docs/migration/v1-pages-inventory.md'
       - 'docs/legacy/v1-ui-catalog/**'
       - 'scripts/check-v1-catalog-coverage.sh'
+      - 'scripts/extract-inventory-routes.sh'
+      - 'tools/v1-screenshot-catalog/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -21,14 +26,15 @@ concurrency:
 
 jobs:
   script-self-test:
-    name: Coverage script self-test
+    name: Bash script self-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          # The script does not read LFS-tracked binaries; skip smudge to keep
-          # the job lean per ADR-010.
+          # The scripts do not read LFS-tracked binaries; skip smudge per ADR-010.
           lfs: false
+      - name: Run inventory-routes extractor tests
+        run: bash scripts/tests/test_extract_inventory_routes.sh
       - name: Run coverage script tests
         run: bash scripts/tests/test_check_v1_catalog_coverage.sh
 
@@ -42,3 +48,29 @@ jobs:
           lfs: false
       - name: Run coverage check against repo state
         run: bash scripts/check-v1-catalog-coverage.sh
+
+  crawler-tests:
+    name: Crawler unit tests
+    runs-on: ubuntu-latest
+    needs: script-self-test
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: 'tools/v1-screenshot-catalog/pnpm-lock.yaml'
+      - name: Install crawler deps
+        run: pnpm install
+        working-directory: tools/v1-screenshot-catalog
+      - name: Typecheck
+        run: pnpm typecheck
+        working-directory: tools/v1-screenshot-catalog
+      - name: Unit tests
+        run: pnpm test
+        working-directory: tools/v1-screenshot-catalog

--- a/.github/workflows/v1-doc-hygiene.yml
+++ b/.github/workflows/v1-doc-hygiene.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'docs/migration/v1-*.md'
+      - 'tools/v1-screenshot-catalog/*.md'
       - 'scripts/check-v1-doc-hygiene.sh'
       - 'scripts/check-v1-doc-structure.sh'
       - 'scripts/tests/test_check_v1_doc_*.sh'
@@ -12,6 +13,7 @@ on:
     branches: [main]
     paths:
       - 'docs/migration/v1-*.md'
+      - 'tools/v1-screenshot-catalog/*.md'
       - 'scripts/check-v1-doc-hygiene.sh'
       - 'scripts/check-v1-doc-structure.sh'
 
@@ -36,10 +38,10 @@ jobs:
     needs: scripts-self-test
     steps:
       - uses: actions/checkout@v4
-      - name: Hygiene scan over docs/migration/v1-*.md
+      - name: Hygiene scan over v1 reference docs
         run: |
           shopt -s nullglob
-          files=(docs/migration/v1-*.md)
+          files=(docs/migration/v1-*.md tools/v1-screenshot-catalog/*.md)
           if [[ ${#files[@]} -eq 0 ]]; then
             echo "No v1 reference docs present yet — skipping hygiene scan."
             exit 0

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,11 @@ test-e2e: ## Run Playwright E2E tests against full Docker stack
 
 # --- V1 reference docs ---
 
-test-v1-docs: ## Run v1 doc hygiene + structure + catalog-coverage script self-tests
+test-v1-docs: ## Run v1 doc hygiene + structure + catalog scripts self-tests
 	bash scripts/tests/test_check_v1_doc_hygiene.sh
 	bash scripts/tests/test_check_v1_doc_structure.sh
 	bash scripts/tests/test_check_v1_catalog_coverage.sh
+	bash scripts/tests/test_extract_inventory_routes.sh
 
 scan-v1-docs: ## Run hygiene + structure + catalog-coverage scripts over committed docs
 	@if compgen -G "docs/migration/v1-*.md" > /dev/null; then \

--- a/scripts/check-catalog-reproducibility.sh
+++ b/scripts/check-catalog-reproducibility.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Compares two v1-UI-catalog directories and emits a per-image pixel-diff
+# report. Used to verify T2 of #107: byte-identical (AA-jitter only) re-run.
+#
+# Approach: convert WebPs to PNG via `sharp`, then run `pixelmatch` from npx.
+# Any image with >0.5% pixel diff fails the run.
+#
+# Usage:
+#   scripts/check-catalog-reproducibility.sh <baseline-dir> <rerun-dir>
+#     [--threshold-pct N]   default 0.5 (percent of pixels allowed to differ)
+#     [--output-dir <path>] default <rerun-dir>/reproducibility-report
+#
+# Exit codes:
+#   0  every image is within threshold
+#   1  one or more images exceed threshold
+#   2  bad invocation
+
+set -u
+
+THRESHOLD_PCT="0.5"
+OUTPUT_DIR=""
+BASELINE=""
+RERUN=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threshold-pct) THRESHOLD_PCT="$2"; shift 2 ;;
+    --output-dir)    OUTPUT_DIR="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    --*)
+      echo "unknown flag: $1" >&2
+      exit 2 ;;
+    *)
+      if [[ -z "$BASELINE" ]]; then BASELINE="$1"
+      elif [[ -z "$RERUN" ]]; then RERUN="$1"
+      else echo "unexpected positional arg: $1" >&2; exit 2
+      fi
+      shift ;;
+  esac
+done
+
+if [[ -z "$BASELINE" || -z "$RERUN" ]]; then
+  echo "error: must pass two positional args: <baseline-dir> <rerun-dir>" >&2
+  exit 2
+fi
+if [[ ! -d "$BASELINE" ]]; then echo "error: baseline dir not found: $BASELINE" >&2; exit 2; fi
+if [[ ! -d "$RERUN" ]]; then echo "error: rerun dir not found: $RERUN" >&2; exit 2; fi
+if [[ -z "$OUTPUT_DIR" ]]; then OUTPUT_DIR="$RERUN/reproducibility-report"; fi
+mkdir -p "$OUTPUT_DIR"
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "error: npx not found; install Node 20+" >&2
+  exit 2
+fi
+
+# Find every WebP under the baseline that has a sibling in the rerun.
+# Outputs report to <OUTPUT_DIR>/report.md and per-image diffs as PNGs.
+REPORT="$OUTPUT_DIR/report.md"
+echo "# Catalog reproducibility report" > "$REPORT"
+echo "" >> "$REPORT"
+echo "**Baseline:** $BASELINE" >> "$REPORT"
+echo "**Rerun:** $RERUN" >> "$REPORT"
+echo "**Threshold:** ${THRESHOLD_PCT}% per-image pixel diff" >> "$REPORT"
+echo "" >> "$REPORT"
+echo "| canonical_id | viewport | diff% | status |" >> "$REPORT"
+echo "|--------------|----------|------:|--------|" >> "$REPORT"
+
+EXCEEDED=0
+TOTAL=0
+
+while IFS= read -r -d '' baseline_file; do
+  rel="${baseline_file#$BASELINE/}"
+  rerun_file="$RERUN/$rel"
+  if [[ ! -f "$rerun_file" ]]; then
+    continue   # rerun is missing this image — caught by the coverage script, not here
+  fi
+  TOTAL=$((TOTAL + 1))
+
+  # canonical_id is the path minus the .{desktop,mobile}.webp suffix
+  canonical_id="${rel%.desktop.webp}"
+  canonical_id="${canonical_id%.mobile.webp}"
+  if [[ "$rel" == *".desktop.webp" ]]; then viewport="desktop"
+  elif [[ "$rel" == *".mobile.webp" ]]; then viewport="mobile"
+  else continue
+  fi
+
+  # Convert both to PNG via sharp (npx). pixelmatch requires PNG.
+  baseline_png=$(mktemp -t catrepro-base.XXXXXX.png)
+  rerun_png=$(mktemp -t catrepro-rerun.XXXXXX.png)
+  diff_png="$OUTPUT_DIR/${canonical_id//\//_}.${viewport}.diff.png"
+  mkdir -p "$(dirname "$diff_png")" 2>/dev/null
+
+  npx --yes sharp-cli "$baseline_file" -o "$baseline_png" -f png >/dev/null 2>&1 || true
+  npx --yes sharp-cli "$rerun_file"    -o "$rerun_png"    -f png >/dev/null 2>&1 || true
+
+  if [[ ! -s "$baseline_png" || ! -s "$rerun_png" ]]; then
+    echo "| $canonical_id | $viewport | n/a | conversion-failed |" >> "$REPORT"
+    EXCEEDED=$((EXCEEDED + 1))
+    rm -f "$baseline_png" "$rerun_png"
+    continue
+  fi
+
+  # pixelmatch via npx. Output: number of differing pixels.
+  diff_output=$(npx --yes pixelmatch "$baseline_png" "$rerun_png" "$diff_png" 0.1 2>/dev/null || true)
+  diff_pixels=$(echo "$diff_output" | grep -oE '[0-9]+' | head -1)
+  diff_pixels="${diff_pixels:-0}"
+
+  # Compute total pixels of the baseline (width × height).
+  total_pixels=$(npx --yes sharp-cli metadata "$baseline_png" 2>/dev/null | python3 -c "import sys, json; m = json.load(sys.stdin); print(m.get('width', 0) * m.get('height', 0))" 2>/dev/null || echo 1)
+  total_pixels="${total_pixels:-1}"
+  if [[ "$total_pixels" -le 0 ]]; then total_pixels=1; fi
+
+  diff_pct=$(awk -v d="$diff_pixels" -v t="$total_pixels" 'BEGIN { printf "%.4f", (d * 100.0) / t }')
+  ok=$(awk -v d="$diff_pct" -v t="$THRESHOLD_PCT" 'BEGIN { print (d <= t) ? 1 : 0 }')
+
+  if [[ "$ok" == "1" ]]; then
+    echo "| $canonical_id | $viewport | ${diff_pct}% | ok |" >> "$REPORT"
+  else
+    echo "| $canonical_id | $viewport | ${diff_pct}% | EXCEEDED |" >> "$REPORT"
+    EXCEEDED=$((EXCEEDED + 1))
+  fi
+
+  rm -f "$baseline_png" "$rerun_png"
+done < <(find "$BASELINE" -name '*.webp' -type f -print0 2>/dev/null)
+
+echo "" >> "$REPORT"
+echo "## Summary" >> "$REPORT"
+echo "" >> "$REPORT"
+echo "- Total compared: $TOTAL" >> "$REPORT"
+echo "- Within threshold: $((TOTAL - EXCEEDED))" >> "$REPORT"
+echo "- Exceeded: $EXCEEDED" >> "$REPORT"
+
+cat "$REPORT" | tail -10
+echo ""
+echo "Report: $REPORT"
+
+if (( EXCEEDED > 0 )); then
+  exit 1
+fi
+exit 0

--- a/scripts/extract-inventory-routes.sh
+++ b/scripts/extract-inventory-routes.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Emits the v1 pages inventory as a JSON array of {persona, route, screenshot_ref}
+# objects. Single source of truth for inventory parsing — consumed by:
+#   - scripts/check-v1-catalog-coverage.sh (parity check, PR-A)
+#   - tools/v1-screenshot-catalog/crawl.ts (catalog crawler, PR-C)
+#
+# Inventory schema (locked in docs/migration/README.md §Locked conventions):
+#   Each persona is an H2 heading: ## Super-Admin / ## Agency Admin / etc.
+#   Tables under that heading have 10 columns; the route column is col 2
+#   (backtick-wrapped) and screenshot_ref is col 10. Rows in summary tables
+#   (different schema) are excluded by the "route starts with backtick-slash"
+#   filter.
+#
+# Usage:
+#   scripts/extract-inventory-routes.sh
+#     [--inventory <path>]   default: docs/migration/v1-pages-inventory.md
+#
+# Output: JSON array on stdout. Exits 0 on success, 2 on missing inventory.
+
+set -u
+
+INVENTORY="docs/migration/v1-pages-inventory.md"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --inventory) INVENTORY="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2 ;;
+  esac
+done
+
+if [[ ! -f "$INVENTORY" ]]; then
+  echo "error: inventory file not found: $INVENTORY" >&2
+  exit 2
+fi
+
+# Locked persona vocabulary (matches docs/migration/README.md §Personas).
+# Order matches the canonical persona section order in the inventory.
+LOCKED_PERSONAS=(
+  "Super-Admin"
+  "Agency Admin"
+  "Care Manager"
+  "Caregiver"
+  "Client"
+  "Family Member"
+)
+
+# awk emits one JSON object per inventory row. We track the active persona
+# section by watching H2 headings and resetting when a new H2 appears. The
+# route filter (col 2 starts with backtick-slash) excludes summary tables and
+# the schema-definition table.
+awk -F'|' -v personas="${LOCKED_PERSONAS[*]}" '
+  BEGIN {
+    n = split(personas, plist, " ")
+    # Build an associative array of locked persona names. Multi-word personas
+    # were space-separated by the IFS join; rejoin them.
+    # Rather than guess, hardcode the locked set:
+    locked["Super-Admin"] = 1
+    locked["Agency Admin"] = 1
+    locked["Care Manager"] = 1
+    locked["Caregiver"] = 1
+    locked["Client"] = 1
+    locked["Family Member"] = 1
+    current_persona = ""
+    first = 1
+    print "["
+  }
+
+  # Match H2 headings. On match, set current_persona if it is a locked persona,
+  # otherwise clear (we are no longer inside a persona section).
+  /^## / {
+    candidate = $0
+    sub(/^## /, "", candidate)
+    sub(/[[:space:]]*$/, "", candidate)
+    if (candidate in locked) {
+      current_persona = candidate
+    } else {
+      current_persona = ""
+    }
+    next
+  }
+
+  # Inventory row: 12 awk-fields under -F"|", route field (col 2) starts with
+  # backtick-slash. Must be inside a persona section.
+  current_persona != "" && NF == 12 {
+    route = $2
+    sub(/^[[:space:]]+/, "", route); sub(/[[:space:]]+$/, "", route)
+    if (route !~ /^`\//) next
+
+    # Strip surrounding backticks
+    sub(/^`/, "", route); sub(/`$/, "", route)
+
+    ref = $10
+    sub(/^[[:space:]]+/, "", ref); sub(/[[:space:]]+$/, "", ref)
+
+    # JSON-escape: backslash and double-quote.
+    persona_json = current_persona
+    route_json = route
+    ref_json = ref
+    gsub(/\\/, "\\\\", persona_json)
+    gsub(/\\/, "\\\\", route_json)
+    gsub(/\\/, "\\\\", ref_json)
+    gsub(/"/, "\\\"", persona_json)
+    gsub(/"/, "\\\"", route_json)
+    gsub(/"/, "\\\"", ref_json)
+
+    if (!first) print ","
+    first = 0
+    printf "  {\"persona\":\"%s\",\"route\":\"%s\",\"screenshot_ref\":\"%s\"}", \
+      persona_json, route_json, ref_json
+  }
+
+  END {
+    if (!first) print ""
+    print "]"
+  }
+' "$INVENTORY"

--- a/scripts/tests/test_extract_inventory_routes.sh
+++ b/scripts/tests/test_extract_inventory_routes.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Tests for scripts/extract-inventory-routes.sh
+# Run from repo root: bash scripts/tests/test_extract_inventory_routes.sh
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/extract-inventory-routes.sh"
+TEST_DIR=$(mktemp -d -t extract-inventory-routes-tests-XXXXXX)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local description="$1"
+  local expected_code="$2"
+  shift 2
+  local actual_output
+  actual_output=$("$@" 2>&1)
+  local actual_code=$?
+  if [[ "$actual_code" == "$expected_code" ]]; then
+    echo "  PASS — $description (exit $actual_code)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description (expected exit $expected_code, got $actual_code)"
+    echo "    output: $actual_output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_json_field() {
+  # assert_json_field <description> <jq-expression> <expected-value> <command...>
+  local description="$1"
+  local jq_expr="$2"
+  local expected="$3"
+  shift 3
+  local actual
+  actual=$("$@" 2>/dev/null | jq -r "$jq_expr" 2>/dev/null)
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description (expected '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Fixture builders ---
+
+write_inventory_two_personas() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# v1 Pages Inventory
+
+## Agency Admin
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| `/admin/dashboard/` | dashboard | data | scaffolded |  | true | false | false | agency-admin/001-dashboard |  |
+| `/admin/clients/` | client list | data | scaffolded |  | true | false | true | not_screenshotted: pending #79 |  |
+
+## Caregiver
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| `/caregiver/clock-in/` | clock in | data | scaffolded |  | true | false | true | caregiver/001-clock-in |  |
+EOF
+}
+
+# --- Tests ---
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP — jq not installed; tests require jq for JSON assertions"
+  exit 0
+fi
+
+echo "Test: script exists and is executable"
+assert_exit "script file exists" 0 test -f "$SCRIPT"
+assert_exit "script is executable" 0 test -x "$SCRIPT"
+
+echo ""
+echo "Test: missing inventory file fails clearly"
+NONEXISTENT="$TEST_DIR/no-such-inventory.md"
+assert_exit "missing inventory exits 2" 2 \
+  bash "$SCRIPT" --inventory "$NONEXISTENT"
+
+echo ""
+echo "Test: emits JSON array"
+INVENTORY_A="$TEST_DIR/inv-a.md"
+write_inventory_two_personas "$INVENTORY_A"
+assert_json_field "output is a JSON array (length 3)" "length" "3" \
+  bash "$SCRIPT" --inventory "$INVENTORY_A"
+
+echo ""
+echo "Test: each row has persona, route, screenshot_ref fields"
+assert_json_field "first row persona is 'Agency Admin'" ".[0].persona" "Agency Admin" \
+  bash "$SCRIPT" --inventory "$INVENTORY_A"
+assert_json_field "first row route is '/admin/dashboard/'" ".[0].route" "/admin/dashboard/" \
+  bash "$SCRIPT" --inventory "$INVENTORY_A"
+assert_json_field "first row screenshot_ref is 'agency-admin/001-dashboard'" ".[0].screenshot_ref" "agency-admin/001-dashboard" \
+  bash "$SCRIPT" --inventory "$INVENTORY_A"
+
+echo ""
+echo "Test: skip-reason rows preserved verbatim in screenshot_ref"
+assert_json_field "second row screenshot_ref preserves 'not_screenshotted: pending #79'" ".[1].screenshot_ref" "not_screenshotted: pending #79" \
+  bash "$SCRIPT" --inventory "$INVENTORY_A"
+
+echo ""
+echo "Test: persona section detection (route under H2 ## Caregiver)"
+assert_json_field "third row persona is 'Caregiver'" ".[2].persona" "Caregiver" \
+  bash "$SCRIPT" --inventory "$INVENTORY_A"
+assert_json_field "third row route is '/caregiver/clock-in/'" ".[2].route" "/caregiver/clock-in/" \
+  bash "$SCRIPT" --inventory "$INVENTORY_A"
+
+echo ""
+echo "Test: skips non-table content (prose, summary tables, headers)"
+INVENTORY_B="$TEST_DIR/inv-b.md"
+cat > "$INVENTORY_B" <<'EOF'
+# v1 Pages Inventory
+
+This is a prose paragraph that should not be parsed as a row.
+
+## Agency Admin
+
+| app | denominator | numerator | notes |
+|-----|-------------|-----------|-------|
+| billing | 3 | 3 | summary table — not an inventory row |
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| `/admin/dashboard/` | dashboard | data | scaffolded |  | true | false | false | agency-admin/001-dashboard |  |
+EOF
+assert_json_field "summary table rows are skipped (length 1)" "length" "1" \
+  bash "$SCRIPT" --inventory "$INVENTORY_B"
+
+echo ""
+echo "Test: H3 sub-section under a persona inherits persona context"
+INVENTORY_C="$TEST_DIR/inv-c.md"
+cat > "$INVENTORY_C" <<'EOF'
+# v1 Pages Inventory
+
+## Agency Admin
+
+### billing
+
+| route | purpose | what_user_sees_can_do | v2_status | severity | multi_tenant_refactor | rls_bypass_by_design | phi_displayed | screenshot_ref | v2_link |
+|-------|---------|-----------------------|-----------|----------|-----------------------|----------------------|---------------|----------------|---------|
+| `/admin/billing/` | billing | data | scaffolded |  | true | false | false | agency-admin/010-billing |  |
+EOF
+assert_json_field "row under H3 inherits 'Agency Admin' persona" ".[0].persona" "Agency Admin" \
+  bash "$SCRIPT" --inventory "$INVENTORY_C"
+
+echo ""
+echo "Test: empty inventory (no persona sections, no rows) emits empty array"
+INVENTORY_D="$TEST_DIR/inv-d.md"
+cat > "$INVENTORY_D" <<'EOF'
+# v1 Pages Inventory
+
+Just prose, no tables.
+EOF
+assert_json_field "empty inventory emits []" "length" "0" \
+  bash "$SCRIPT" --inventory "$INVENTORY_D"
+
+echo ""
+echo "Test: real repo inventory parses without error"
+REAL_INVENTORY="$REPO_ROOT/docs/migration/v1-pages-inventory.md"
+if [[ -f "$REAL_INVENTORY" ]]; then
+  assert_exit "real inventory parses" 0 \
+    bash "$SCRIPT" --inventory "$REAL_INVENTORY"
+else
+  echo "  SKIP — no docs/migration/v1-pages-inventory.md (run from repo root)"
+fi
+
+echo ""
+echo "============================="
+echo "Total: $((PASS + FAIL))"
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/tools/v1-screenshot-catalog/.env.example
+++ b/tools/v1-screenshot-catalog/.env.example
@@ -1,0 +1,34 @@
+# tools/v1-screenshot-catalog/.env.example — copy to .env and fill in.
+# .env is gitignored; .env.example is committed.
+
+# v1 base URL. localhost-only by default (production-hostname blocklist in
+# crawl.ts hard-fails before any auth attempt if this looks like prod).
+V1_BASE_URL=http://localhost:8000
+
+# v1 personas. Match what the PHI-scrubbed seed fixture creates.
+# Leave any unset to skip that persona's section in the catalog (the run
+# manifest records skipped personas).
+V1_SUPER_ADMIN_USERNAME=
+V1_SUPER_ADMIN_PASSWORD=
+V1_AGENCY_ADMIN_USERNAME=
+V1_AGENCY_ADMIN_PASSWORD=
+V1_CARE_MANAGER_USERNAME=
+V1_CARE_MANAGER_PASSWORD=
+V1_CAREGIVER_USERNAME=
+V1_CAREGIVER_PASSWORD=
+V1_FAMILY_MEMBER_USERNAME=
+V1_FAMILY_MEMBER_PASSWORD=
+
+# Outbound integrations on v1's process. v1 is integration-safe by default
+# (Phase 0 INVESTIGATIONS.md): Twilio + Stripe not used; SendGrid uses
+# console backend in dev when EMAIL_HOST_PASSWORD is unset; QuickBooks fails
+# closed without env vars. These flags are belt-and-suspenders — keep them
+# explicit so the runbook is self-documenting.
+TWILIO_DISABLED=1
+SENDGRID_DISABLED=1
+STRIPE_DISABLED=1
+QUICKBOOKS_DISABLED=1
+
+# Crawler tuning (rarely changed)
+CRAWL_PER_ROUTE_TIMEOUT_MS=10000
+CRAWL_RETRY_ATTEMPTS=3

--- a/tools/v1-screenshot-catalog/.gitignore
+++ b/tools/v1-screenshot-catalog/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+*.log
+output/

--- a/tools/v1-screenshot-catalog/README.md
+++ b/tools/v1-screenshot-catalog/README.md
@@ -1,0 +1,136 @@
+# tools/v1-screenshot-catalog/
+
+> **This tool produces input *for* v2 (the screenshot catalog committed to [`docs/legacy/v1-ui-catalog/`](../../docs/legacy/v1-ui-catalog/)). It does not run against v2 itself.** v1 is reached as a remote HTTP target via `V1_BASE_URL`. See [`docs/legacy/README.md`](../../docs/legacy/README.md) for what this tool's output is for.
+
+One-shot Playwright crawler. ~250 LOC of plain TypeScript across three files (`crawl.ts`, `personas.config.ts`, `routes-allowlist.ts`). No abstractions, no plugin systems — runs once per refresh cycle and gets committed alongside its output.
+
+## Read order
+
+Before running anything in this directory:
+
+1. [`INVESTIGATIONS.md`](INVESTIGATIONS.md) — what we know about v1 (personas, integrations, login flow)
+2. [`PHI-CHECKLIST.md`](PHI-CHECKLIST.md) — mandatory pre-crawl gate
+3. [`CAPTION-STYLE.md`](CAPTION-STYLE.md) — for the human caption-authoring follow-up
+
+## Bring-up runbook
+
+The crawler assumes a v1 stack is already running. It does **not** start v1.
+
+### 1. Pre-flight: v1 checked out, migrated, fixture loaded
+
+```bash
+cd ~/Code/COREcare-access
+git fetch && git checkout 9738412a6e41064203fc253d9dd2a5c6a9c2e231
+
+# Use SQLite (default) — single file, deterministic, no extra services
+unset DATABASE_URL
+python manage.py migrate
+
+# Load the PHI-scrubbed fixture (must be authored before first run)
+python manage.py loaddata fixtures/v2_catalog_snapshot.json
+sha256sum fixtures/v2_catalog_snapshot.json
+# Record this hash in docs/legacy/v1-ui-catalog/RUN-MANIFEST.md
+```
+
+> **Verification:** `python manage.py shell` → `from django.contrib.auth import get_user_model; User = get_user_model(); print(User.objects.count())` should match the fixture's expected user count (typically 6 personas × 1+ users each).
+
+### 2. Start v1 with outbound integrations disabled
+
+v1 dev is integration-safe by default (per Phase 0 INVESTIGATIONS.md), but explicit flags make the runbook self-documenting:
+
+```bash
+TWILIO_DISABLED=1 SENDGRID_DISABLED=1 STRIPE_DISABLED=1 QUICKBOOKS_DISABLED=1 \
+  python manage.py runserver 0.0.0.0:8000
+```
+
+> **Verification:** `curl -sf http://localhost:8000/dashboard/login/` returns 200 with the login form HTML.
+
+### 3. Run the crawler
+
+```bash
+cd ~/Code/COREcare-v2/tools/v1-screenshot-catalog
+cp .env.example .env
+# Edit .env: fill in V1_*_USERNAME / V1_*_PASSWORD per persona that the
+# fixture seeded. Leave any persona pair empty to skip its catalog section.
+
+pnpm install
+pnpm exec playwright install chromium
+pnpm crawl --output-dir ../../docs/legacy/v1-ui-catalog/
+```
+
+The crawler runs five pre-flight gates, then crawls inventory rows persona-by-persona. Expect ~30 minutes for a full run against ~134 inventory rows × 2 viewports.
+
+### 4. Reproducibility re-run
+
+After step 3 completes, re-run the crawler against the same v1 commit + same fixture into a different output directory:
+
+```bash
+pnpm crawl --output-dir /tmp/catalog-rerun/
+bash ../../scripts/check-catalog-reproducibility.sh \
+  ../../docs/legacy/v1-ui-catalog/ \
+  /tmp/catalog-rerun/
+```
+
+Expected: <0.5% per-image pixel diff (test T2 of #107's test spec). Larger diffs surface non-determinism that must be root-caused before merge.
+
+### 5. PHI audit
+
+```bash
+# Manual audit per PHI-CHECKLIST.md verification methodology.
+# 10% sample (cap 100), random.seed(42).
+```
+
+Commit the audit artifact (`PHI-AUDIT-<DATE>.md`) alongside the catalog.
+
+## Pre-flight gates
+
+`crawl.ts` runs five pre-flight checks before any auth attempt. All must pass:
+
+1. `V1_BASE_URL` set and reachable (2-second `fetch` ping).
+2. Production-hostname blocklist passed (literal regex array in `crawl.ts`, not env-driven).
+3. All persona env vars set for at least one persona.
+4. Output directory exists and is writable.
+5. Inventory file (`docs/migration/v1-pages-inventory.md`) parses successfully via `scripts/extract-inventory-routes.sh`.
+
+Each gate fails with an actionable error message + the remediation step.
+
+## Network interception
+
+The crawler sets up Playwright network interception that aborts every non-`GET` request unless its URL is on the explicit allowlist (login, role-switch). This is the second-line guard against destructive endpoints — the first line is v1's outbound-integration env disablement (#2 above).
+
+`intercepted-non-GET.log` records every aborted request as the audit artifact for T4 (destructive-endpoint protection).
+
+## Determinism harness
+
+To make T2 (byte-identical re-run) achievable, `crawl.ts` injects a `page.addInitScript` block that:
+
+- Replaces `Math.random()` with a seeded RNG (seed = sha256 of `v1_commit + canonical_id`)
+- Mocks `Date.now()` and `new Date()` to the v1 commit's timestamp
+- Disables CSS animations + transitions
+- Disables image lazy-loading
+
+Each item is documented in `crawl.ts` source comments — future maintainers will want to know why these are there.
+
+## Output layout
+
+```
+<output-dir>/
+├── RUN-MANIFEST.md                    # audit trail (timestamp, v1 SHA, fixture hash, route counts)
+├── crawl.log                          # structured JSON log per route
+├── crawl-bfs-report.md                # routes reachable but not in inventory (cross-check)
+├── intercepted-non-GET.log            # security audit artifact
+├── super-admin/
+│   ├── 001-<route>.desktop.webp
+│   ├── 001-<route>.mobile.webp
+│   └── 001-<route>.md                 # frontmatter only; body TODO until Phase 3
+├── agency-admin/
+└── ... (per persona-slug)
+```
+
+Image files are committed via Git LFS per ADR-010. Captions, manifests, and logs stay in regular git.
+
+## Boundary statement
+
+This tool exists in v2 (`tools/v1-screenshot-catalog/` in `suniljames/COREcare-v2`) but operates against v1 (`hcunanan79/COREcare-access`). It does not modify v1. It does not require commit access to v1. The path `~/Code/COREcare-access/` in the runbook is the developer's local checkout — substitute any local path. The crawler only needs `V1_BASE_URL` to be reachable.
+
+If `V1_BASE_URL` matches a known production hostname, the crawler hard-fails before any credential is sent. The blocklist is a literal regex array in `crawl.ts`, not env-driven (env can be tampered with).

--- a/tools/v1-screenshot-catalog/__tests__/frontmatter-writer.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/frontmatter-writer.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { renderCaption } from "../crawl.ts";
+
+describe("renderCaption", () => {
+  const fm = {
+    canonicalId: "agency-admin/001-dashboard",
+    route: "/admin/todays-shifts/",
+    persona: "Agency Admin",
+    viewport: "desktop" as const,
+    seedState: "populated",
+    v1Commit: "9738412a6e41064203fc253d9dd2a5c6a9c2e231",
+    generated: "2026-05-07",
+  };
+
+  it("starts and ends with --- frontmatter delimiters", () => {
+    const out = renderCaption(fm);
+    const lines = out.trimEnd().split("\n");
+    expect(lines[0]).toBe("---");
+    // Find the second --- delimiter
+    const secondDelim = lines.indexOf("---", 1);
+    expect(secondDelim).toBeGreaterThan(0);
+  });
+
+  it("contains every required frontmatter field", () => {
+    const out = renderCaption(fm);
+    expect(out).toContain("canonical_id: agency-admin/001-dashboard");
+    expect(out).toContain("route: /admin/todays-shifts/");
+    expect(out).toContain("persona: Agency Admin");
+    expect(out).toContain("viewport: desktop");
+    expect(out).toContain("seed_state: populated");
+    expect(out).toContain("v1_commit: 9738412a6e41064203fc253d9dd2a5c6a9c2e231");
+    expect(out).toContain("generated: 2026-05-07");
+  });
+
+  it("includes the TODO marker for the body", () => {
+    const out = renderCaption(fm);
+    expect(out).toContain("<!-- TODO: author CTAs + interaction notes per CAPTION-STYLE.md (Phase 3) -->");
+  });
+
+  it("frontmatter canonical_id matches the file path the caller will use", () => {
+    // The canonical_id is the cross-reference handle. It MUST equal
+    // <persona-slug>/<file-base> exactly — coverage-check parses this.
+    const out = renderCaption(fm);
+    const match = out.match(/canonical_id:\s*(\S+)/);
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe("agency-admin/001-dashboard");
+  });
+
+  it("renders mobile viewport correctly", () => {
+    const mobile = { ...fm, viewport: "mobile" as const };
+    expect(renderCaption(mobile)).toContain("viewport: mobile");
+  });
+
+  it("preserves canonical persona names with spaces", () => {
+    const cm = { ...fm, persona: "Care Manager" };
+    expect(renderCaption(cm)).toContain("persona: Care Manager");
+
+    const fm2 = { ...fm, persona: "Family Member" };
+    expect(renderCaption(fm2)).toContain("persona: Family Member");
+  });
+});

--- a/tools/v1-screenshot-catalog/__tests__/hostname-guard.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/hostname-guard.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isBlockedHost, BLOCKED_HOSTS } from "../crawl.ts";
+
+describe("isBlockedHost", () => {
+  it("blocks the production .elitecare. wildcard", () => {
+    expect(isBlockedHost("https://app.elitecare.bayareaelitehomecare.com")).toBe(true);
+    expect(isBlockedHost("https://prod.elitecare.io")).toBe(true);
+  });
+
+  it("blocks the bayareaelitehomecare.com host literally", () => {
+    expect(isBlockedHost("https://bayareaelitehomecare.com")).toBe(true);
+    expect(isBlockedHost("https://www.bayareaelitehomecare.com/login")).toBe(true);
+  });
+
+  it("blocks corecare.app (v2 production)", () => {
+    expect(isBlockedHost("https://corecare.app")).toBe(true);
+    expect(isBlockedHost("https://api.corecare.app/healthz")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isBlockedHost("https://BAYAREAelitehomecare.com")).toBe(true);
+    expect(isBlockedHost("https://CoreCare.App")).toBe(true);
+  });
+
+  it("does NOT block localhost-shaped URLs", () => {
+    expect(isBlockedHost("http://localhost:8000")).toBe(false);
+    expect(isBlockedHost("http://127.0.0.1:8000/dashboard/login/")).toBe(false);
+    expect(isBlockedHost("http://0.0.0.0:8000")).toBe(false);
+  });
+
+  it("does NOT block arbitrary non-prod hosts", () => {
+    expect(isBlockedHost("http://test.dev")).toBe(false);
+    expect(isBlockedHost("https://example.com")).toBe(false);
+  });
+
+  it("BLOCKED_HOSTS is a non-empty array of regexes", () => {
+    expect(BLOCKED_HOSTS.length).toBeGreaterThan(0);
+    BLOCKED_HOSTS.forEach((re) => expect(re).toBeInstanceOf(RegExp));
+  });
+});

--- a/tools/v1-screenshot-catalog/__tests__/personas.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/personas.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// We re-import personas.config inside each test after mutating env vars.
+// vitest module cache is busted via vi.resetModules.
+import { vi } from "vitest";
+
+const PERSONA_ENVS = [
+  "V1_SUPER_ADMIN_USERNAME", "V1_SUPER_ADMIN_PASSWORD",
+  "V1_AGENCY_ADMIN_USERNAME", "V1_AGENCY_ADMIN_PASSWORD",
+  "V1_CARE_MANAGER_USERNAME", "V1_CARE_MANAGER_PASSWORD",
+  "V1_CAREGIVER_USERNAME", "V1_CAREGIVER_PASSWORD",
+  "V1_FAMILY_MEMBER_USERNAME", "V1_FAMILY_MEMBER_PASSWORD",
+];
+
+describe("personas.config", () => {
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    PERSONA_ENVS.forEach((k) => {
+      originalEnv[k] = process.env[k];
+      delete process.env[k];
+    });
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    PERSONA_ENVS.forEach((k) => {
+      if (originalEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = originalEnv[k];
+    });
+  });
+
+  it("PERSONAS exposes 5 entries (Client persona excluded — no v1 portal)", async () => {
+    const mod = await import("../personas.config.ts");
+    expect(mod.PERSONAS).toHaveLength(5);
+    const slugs = mod.PERSONAS.map((p) => p.slug);
+    expect(slugs).toEqual([
+      "super-admin",
+      "agency-admin",
+      "care-manager",
+      "caregiver",
+      "family-member",
+    ]);
+  });
+
+  it("canonical names match the locked vocabulary", async () => {
+    const mod = await import("../personas.config.ts");
+    const canonicals = mod.PERSONAS.map((p) => p.canonical);
+    expect(canonicals).toEqual([
+      "Super-Admin",
+      "Agency Admin",
+      "Care Manager",
+      "Caregiver",
+      "Family Member",
+    ]);
+  });
+
+  it("ACTIVE_PERSONAS is empty when no env vars are set", async () => {
+    const mod = await import("../personas.config.ts");
+    expect(mod.ACTIVE_PERSONAS).toHaveLength(0);
+    expect(mod.SKIPPED_PERSONAS).toHaveLength(5);
+  });
+
+  it("ACTIVE_PERSONAS includes a persona only when both username + password are set", async () => {
+    process.env.V1_CAREGIVER_USERNAME = "caregiver1@test.com";
+    process.env.V1_CAREGIVER_PASSWORD = "TestCare123!";
+    // Username only — should NOT be active
+    process.env.V1_AGENCY_ADMIN_USERNAME = "admin@test.com";
+
+    const mod = await import("../personas.config.ts");
+    expect(mod.ACTIVE_PERSONAS).toHaveLength(1);
+    expect(mod.ACTIVE_PERSONAS[0].slug).toBe("caregiver");
+    expect(mod.SKIPPED_PERSONAS.map((p) => p.slug)).toContain("agency-admin");
+  });
+
+  it("treats empty-string env vars as unset", async () => {
+    process.env.V1_CAREGIVER_USERNAME = "";
+    process.env.V1_CAREGIVER_PASSWORD = "";
+    const mod = await import("../personas.config.ts");
+    expect(mod.ACTIVE_PERSONAS).toHaveLength(0);
+  });
+});

--- a/tools/v1-screenshot-catalog/crawl.ts
+++ b/tools/v1-screenshot-catalog/crawl.ts
@@ -1,0 +1,537 @@
+// crawl.ts — one-shot Playwright crawler that captures v1 (COREcare-access)
+// UI as a per-persona screenshot catalog committed to docs/legacy/v1-ui-catalog/.
+//
+// READ tools/v1-screenshot-catalog/README.md FIRST. It documents the bring-up
+// runbook and what each pre-flight gate is checking.
+//
+// This file is deliberately ~one screen of code per concern. No abstractions,
+// no plugin systems — one-shot tooling.
+
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync, existsSync, accessSync, constants as fsConstants } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { createHash } from "node:crypto";
+import sharp from "sharp";
+import { ACTIVE_PERSONAS, SKIPPED_PERSONAS, type Persona } from "./personas.config.ts";
+import { ROUTES_ALLOWLIST, ALLOWED_NON_GET_FRAGMENTS } from "./routes-allowlist.ts";
+
+// ---------------------------------------------------------------------------
+// Production-hostname blocklist (literal regexes, not env-driven — env can be
+// tampered with). T11 of #107.
+// ---------------------------------------------------------------------------
+export const BLOCKED_HOSTS: RegExp[] = [
+  /\.elitecare\..+/i,
+  /bayareaelitehomecare\.com/i,
+  /corecare\.app/i,
+];
+
+export function isBlockedHost(url: string): boolean {
+  return BLOCKED_HOSTS.some((re) => re.test(url));
+}
+
+// ---------------------------------------------------------------------------
+// Inventory parsing — shells out to the canonical bash extractor, parses JSON.
+// ---------------------------------------------------------------------------
+
+interface InventoryRow {
+  persona: string;
+  route: string;
+  screenshot_ref: string;
+}
+
+function loadInventory(repoRoot: string): InventoryRow[] {
+  const out = execFileSync("bash", [
+    `${repoRoot}/scripts/extract-inventory-routes.sh`,
+    "--inventory",
+    `${repoRoot}/docs/migration/v1-pages-inventory.md`,
+  ]);
+  return JSON.parse(out.toString("utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Pre-flight gates — fail fast before any auth attempt.
+// ---------------------------------------------------------------------------
+
+interface PreflightArgs {
+  v1BaseUrl: string;
+  outputDir: string;
+  repoRoot: string;
+}
+
+async function preflight(args: PreflightArgs): Promise<void> {
+  // Gate 1: V1_BASE_URL set + reachable
+  if (!args.v1BaseUrl) {
+    fail("Gate 1 failed: V1_BASE_URL is not set. Add it to .env.");
+  }
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), 2_000);
+    const res = await fetch(args.v1BaseUrl, { signal: ctrl.signal });
+    clearTimeout(t);
+    if (res.status >= 500) {
+      fail(`Gate 1 failed: v1 at ${args.v1BaseUrl} returned ${res.status}.`);
+    }
+  } catch (e) {
+    fail(
+      `Gate 1 failed: cannot reach v1 at ${args.v1BaseUrl}. Is \`python manage.py runserver\` running? (${(e as Error).message})`,
+    );
+  }
+
+  // Gate 2: production-hostname blocklist
+  if (isBlockedHost(args.v1BaseUrl)) {
+    fail(
+      `Gate 2 failed: V1_BASE_URL=${args.v1BaseUrl} matches the production blocklist. The crawler refuses to run against production.`,
+    );
+  }
+
+  // Gate 3: at least one persona has both username + password
+  if (ACTIVE_PERSONAS.length === 0) {
+    fail(
+      "Gate 3 failed: no personas have V1_*_USERNAME and V1_*_PASSWORD set in .env. Set credentials for at least one persona.",
+    );
+  }
+
+  // Gate 4: output dir exists + writable
+  if (!existsSync(args.outputDir)) {
+    fail(`Gate 4 failed: --output-dir ${args.outputDir} does not exist. mkdir it first.`);
+  }
+  try {
+    accessSync(args.outputDir, fsConstants.W_OK);
+  } catch {
+    fail(`Gate 4 failed: --output-dir ${args.outputDir} is not writable.`);
+  }
+
+  // Gate 5: inventory parses
+  try {
+    const rows = loadInventory(args.repoRoot);
+    if (!Array.isArray(rows)) throw new Error("inventory output was not an array");
+    if (rows.length === 0) {
+      fail(
+        "Gate 5 failed: inventory parsed to zero rows. Either the inventory file is empty or the parser is broken.",
+      );
+    }
+  } catch (e) {
+    fail(`Gate 5 failed: inventory parse failed (${(e as Error).message}).`);
+  }
+}
+
+function fail(msg: string): never {
+  console.error(`error: ${msg}`);
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Determinism harness — encoded in page.addInitScript before any v1 page JS
+// runs. Each item documented; future maintainers will want to know why.
+// ---------------------------------------------------------------------------
+
+function makeDeterminismScript(canonicalId: string, v1Commit: string): string {
+  // Seeded RNG (mulberry32) — derived from sha256(v1_commit + canonical_id)
+  // so every distinct route gets its own deterministic seed but the SAME
+  // route across re-runs produces the same screenshots.
+  const seedHex = createHash("sha256").update(v1Commit + canonicalId).digest("hex").slice(0, 8);
+  const seed = parseInt(seedHex, 16);
+
+  // The mocked timestamp is the v1 commit's tagger date. We don't actually
+  // know it without `git log`, so we use a stable derived value: parseInt of
+  // the first 8 chars of the SHA. Pages that show "now" or "today" will
+  // render this constant, which is fine — they re-render the same value
+  // every run.
+  const fakeNow = parseInt(v1Commit.slice(0, 8), 16);
+
+  return `
+    (function() {
+      // 1. Seeded RNG. Mulberry32 — small, deterministic.
+      let s = ${seed};
+      Math.random = function() {
+        s = (s + 0x6D2B79F5) | 0;
+        let t = s;
+        t = Math.imul(t ^ (t >>> 15), 1 | t);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+
+      // 2. Mock Date — only the constructor + Date.now. Other Date methods
+      // delegate to the real implementation against the mocked instant.
+      const RealDate = Date;
+      const fixed = ${fakeNow};
+      function MockDate(...args) {
+        if (args.length === 0) return new RealDate(fixed);
+        return new RealDate(...args);
+      }
+      MockDate.now = () => fixed;
+      MockDate.parse = RealDate.parse;
+      MockDate.UTC = RealDate.UTC;
+      MockDate.prototype = RealDate.prototype;
+      Date = MockDate;
+
+      // 3. Disable CSS animations + transitions — prevents partially-animated
+      // screenshots and removes a common source of pixel jitter on re-run.
+      const style = document.createElement('style');
+      style.textContent = '*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; }';
+      (document.head || document.documentElement).appendChild(style);
+
+      // 4. Disable image lazy-loading — force every <img> to load
+      // synchronously on the page so screenshots capture rendered images.
+      document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('img[loading="lazy"]').forEach((el) => {
+          el.loading = 'eager';
+        });
+      });
+    })();
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Network interception — GET-only with explicit non-GET allowlist.
+// ---------------------------------------------------------------------------
+
+interface InterceptedRecord {
+  method: string;
+  url: string;
+  origin: "page-script" | "navigation";
+}
+
+async function setupNetworkInterception(
+  ctx: BrowserContext,
+  v1BaseUrl: string,
+  intercepted: InterceptedRecord[],
+): Promise<void> {
+  await ctx.route("**/*", (route) => {
+    const req = route.request();
+    const method = req.method();
+    const url = req.url();
+
+    // Block any URL matching the production hostname blocklist (defense in
+    // depth — the pre-flight gate already caught V1_BASE_URL, but a page
+    // script could still issue an outbound request to a blocked host).
+    if (isBlockedHost(url) && !url.startsWith(v1BaseUrl)) {
+      intercepted.push({ method, url, origin: "page-script" });
+      route.abort();
+      return;
+    }
+
+    if (method === "GET") {
+      route.continue();
+      return;
+    }
+
+    // Non-GET: must be on the allowlist
+    const allowed = ALLOWED_NON_GET_FRAGMENTS.some((frag) => url.includes(frag));
+    if (allowed) {
+      route.continue();
+      return;
+    }
+
+    intercepted.push({ method, url, origin: "page-script" });
+    route.abort();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Persona login. Django session auth — POST to /dashboard/login/ via the
+// browser form so CSRF + cookies just work.
+// ---------------------------------------------------------------------------
+
+async function login(page: Page, baseUrl: string, persona: Persona): Promise<void> {
+  if (!persona.username || !persona.password) {
+    throw new Error(`persona ${persona.slug} has no credentials`);
+  }
+  await page.goto(`${baseUrl}/dashboard/login/`, { waitUntil: "domcontentloaded" });
+  await page.fill('input[name="username"]', persona.username);
+  await page.fill('input[name="password"]', persona.password);
+  await Promise.all([
+    page.waitForLoadState("domcontentloaded"),
+    page.click('button[type="submit"], input[type="submit"]'),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter writer.
+// ---------------------------------------------------------------------------
+
+interface CaptionFrontmatter {
+  canonicalId: string;
+  route: string;
+  persona: string;       // canonical name
+  viewport: "desktop" | "mobile";
+  seedState: string;     // "populated" | "empty" | etc.
+  v1Commit: string;
+  generated: string;     // YYYY-MM-DD
+}
+
+export function renderCaption(fm: CaptionFrontmatter): string {
+  return `---
+canonical_id: ${fm.canonicalId}
+route: ${fm.route}
+persona: ${fm.persona}
+viewport: ${fm.viewport}
+seed_state: ${fm.seedState}
+v1_commit: ${fm.v1Commit}
+generated: ${fm.generated}
+---
+<!-- TODO: author CTAs + interaction notes per CAPTION-STYLE.md (Phase 3) -->
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Single-route capture. Loads the URL, takes desktop + mobile screenshots,
+// writes the frontmatter-only caption file.
+// ---------------------------------------------------------------------------
+
+interface CaptureArgs {
+  ctx: BrowserContext;
+  baseUrl: string;
+  v1Commit: string;
+  outputDir: string;
+  persona: Persona;
+  row: InventoryRow;
+  index: number;        // sequence number within the persona section
+  perRouteTimeoutMs: number;
+}
+
+interface CaptureResult {
+  status: "captured" | "skipped" | "errored";
+  canonicalId?: string;
+  reason?: string;
+  durationMs: number;
+}
+
+async function captureRoute(args: CaptureArgs): Promise<CaptureResult> {
+  const start = Date.now();
+
+  // Skip rows already in skip-reason state — the inventory pre-declares
+  // them as not_screenshotted: <reason> for documented reasons.
+  if (args.row.screenshot_ref.startsWith("not_screenshotted:")) {
+    const reason = args.row.screenshot_ref.replace(/^not_screenshotted:\s*/, "");
+    return { status: "skipped", reason, durationMs: Date.now() - start };
+  }
+
+  // Derive the route slug from the route path: take the last non-empty
+  // segment (or "root" if path is /). Sequence number prefixed.
+  const cleaned = args.row.route.replace(/^\/|\/$/g, "");
+  const lastSeg = cleaned.split("/").filter((s) => !s.startsWith("<")).pop() || "root";
+  const routeSlug = lastSeg.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
+  const seq = String(args.index).padStart(3, "0");
+  const fileBase = `${seq}-${routeSlug}`;
+  const canonicalId = `${args.persona.slug}/${fileBase}`;
+
+  const personaDir = `${args.outputDir}/${args.persona.slug}`;
+  mkdirSync(personaDir, { recursive: true });
+
+  // Inject determinism harness for this route.
+  await args.ctx.addInitScript({
+    content: makeDeterminismScript(canonicalId, args.v1Commit),
+  });
+
+  const page = await args.ctx.newPage();
+  page.setDefaultTimeout(args.perRouteTimeoutMs);
+
+  try {
+    const url = `${args.baseUrl}${args.row.route}`;
+    await page.goto(url, { waitUntil: "networkidle" });
+
+    // Capture both viewports as PNG, encode as WebP via sharp.
+    for (const [viewport, dims] of [
+      ["desktop", { width: 1440, height: 900 }],
+      ["mobile",  { width: 390,  height: 844 }],
+    ] as const) {
+      await page.setViewportSize(dims);
+      await page.waitForLoadState("networkidle");
+      const png = await page.screenshot({ fullPage: true, type: "png" });
+      const webp = await sharp(png).webp({ quality: 80 }).toBuffer();
+      writeFileSync(`${personaDir}/${fileBase}.${viewport}.webp`, webp);
+    }
+
+    // Write the frontmatter-only caption.
+    const today = new Date().toISOString().slice(0, 10);
+    const caption = renderCaption({
+      canonicalId,
+      route: args.row.route,
+      persona: args.persona.canonical,
+      viewport: "desktop",        // primary viewport (per #107 UX review)
+      seedState: "populated",
+      v1Commit: args.v1Commit,
+      generated: today,
+    });
+    writeFileSync(`${personaDir}/${fileBase}.md`, caption);
+
+    return { status: "captured", canonicalId, durationMs: Date.now() - start };
+  } catch (e) {
+    return {
+      status: "errored",
+      canonicalId,
+      reason: (e as Error).message,
+      durationMs: Date.now() - start,
+    };
+  } finally {
+    await page.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point.
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+  outputDir: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: Partial<CliArgs> = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--output-dir") {
+      args.outputDir = argv[++i];
+    } else if (argv[i] === "--help" || argv[i] === "-h") {
+      console.log("usage: pnpm crawl --output-dir <path>");
+      process.exit(0);
+    } else {
+      console.error(`unknown arg: ${argv[i]}`);
+      process.exit(2);
+    }
+  }
+  if (!args.outputDir) {
+    console.error("error: --output-dir is required");
+    process.exit(2);
+  }
+  return args as CliArgs;
+}
+
+async function main(): Promise<void> {
+  const cli = parseArgs(process.argv.slice(2));
+  const v1BaseUrl = process.env.V1_BASE_URL || "http://localhost:8000";
+  const v1Commit = process.env.V1_COMMIT_SHA || "9738412a6e41064203fc253d9dd2a5c6a9c2e231";
+  const perRouteTimeoutMs = parseInt(process.env.CRAWL_PER_ROUTE_TIMEOUT_MS || "10000", 10);
+  const repoRoot = resolve(dirname(import.meta.url.replace("file://", "")), "../..");
+  const outputDir = resolve(cli.outputDir);
+
+  await preflight({ v1BaseUrl, outputDir, repoRoot });
+
+  const inventory = loadInventory(repoRoot);
+  const intercepted: InterceptedRecord[] = [];
+
+  const browser: Browser = await chromium.launch({ headless: true });
+  const startTs = new Date().toISOString();
+
+  let captured = 0;
+  let skipped = 0;
+  let errored = 0;
+
+  try {
+    for (const persona of ACTIVE_PERSONAS) {
+      const ctx = await browser.newContext({
+        viewport: { width: 1440, height: 900 },
+      });
+      await setupNetworkInterception(ctx, v1BaseUrl, intercepted);
+
+      const page = await ctx.newPage();
+      try {
+        await login(page, v1BaseUrl, persona);
+      } catch (e) {
+        console.error(`login failed for ${persona.slug}: ${(e as Error).message}`);
+        await ctx.close();
+        continue;
+      }
+      await page.close();
+
+      // Inventory rows + any allowlist routes that target this persona.
+      // Allowlist routes get a synthetic screenshot_ref derived from the URL
+      // so the capture loop treats them identically to inventory rows.
+      const allowlistRows = ROUTES_ALLOWLIST.filter(
+        (r) => r.persona === persona.canonical,
+      ).map((r) => ({
+        persona: r.persona,
+        route: r.url,
+        screenshot_ref: `${persona.slug}/allowlist-${r.url.replace(/[^a-z0-9]/gi, "-")}`,
+      }));
+      const personaRows = [
+        ...inventory.filter((r) => r.persona === persona.canonical),
+        ...allowlistRows,
+      ];
+      let index = 0;
+      for (const row of personaRows) {
+        index++;
+        const result = await captureRoute({
+          ctx,
+          baseUrl: v1BaseUrl,
+          v1Commit,
+          outputDir,
+          persona,
+          row,
+          index,
+          perRouteTimeoutMs,
+        });
+
+        if (result.status === "captured") captured++;
+        else if (result.status === "skipped") skipped++;
+        else errored++;
+
+        // structured log line per route
+        console.log(
+          JSON.stringify({
+            event: `route.${result.status === "captured" ? "visited" : result.status}`,
+            persona: persona.slug,
+            route: row.route,
+            canonical_id: result.canonicalId,
+            reason: result.reason,
+            duration_ms: result.durationMs,
+          }),
+        );
+      }
+
+      await ctx.close();
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const endTs = new Date().toISOString();
+
+  // Write RUN-MANIFEST.md
+  const manifest = [
+    `# RUN-MANIFEST — v1 UI catalog crawl`,
+    ``,
+    `**Generated:** ${endTs}`,
+    `**v1 commit:** ${v1Commit}`,
+    `**v1 base URL:** ${v1BaseUrl}`,
+    `**Started:** ${startTs}`,
+    ``,
+    `## Personas`,
+    ``,
+    `**Active:** ${ACTIVE_PERSONAS.map((p) => p.canonical).join(", ") || "(none)"}`,
+    `**Skipped (no credentials):** ${SKIPPED_PERSONAS.map((p) => p.canonical).join(", ") || "(none)"}`,
+    ``,
+    `## Counts`,
+    ``,
+    `- Routes captured: ${captured}`,
+    `- Routes skipped: ${skipped}`,
+    `- Routes errored: ${errored}`,
+    `- Non-GET requests intercepted: ${intercepted.length}`,
+    ``,
+    `## Inventory ↔ catalog parity`,
+    ``,
+    `Run \`bash scripts/check-v1-catalog-coverage.sh\` from the repo root to verify.`,
+    ``,
+  ].join("\n");
+  writeFileSync(`${outputDir}/RUN-MANIFEST.md`, manifest);
+
+  // Write intercepted-non-GET.log (T4 audit artifact)
+  writeFileSync(
+    `${outputDir}/intercepted-non-GET.log`,
+    intercepted.map((r) => JSON.stringify(r)).join("\n") + "\n",
+  );
+
+  if (errored > 0) {
+    console.error(`crawl finished with ${errored} errored routes`);
+    process.exit(1);
+  }
+}
+
+// Only run main() if invoked directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/tools/v1-screenshot-catalog/package.json
+++ b/tools/v1-screenshot-catalog/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@corecare/v1-screenshot-catalog",
+  "version": "0.0.1",
+  "private": true,
+  "description": "One-shot Playwright crawler that captures v1 (COREcare-access) UI as a per-persona screenshot catalog committed to docs/legacy/v1-ui-catalog/. Operates against v1 — does NOT run against v2.",
+  "scripts": {
+    "crawl": "tsx crawl.ts",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "playwright": "^1.49.0",
+    "sharp": "^0.34.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/tools/v1-screenshot-catalog/personas.config.ts
+++ b/tools/v1-screenshot-catalog/personas.config.ts
@@ -1,0 +1,53 @@
+// Env-driven persona credentials. Reads at module load (not lazy) so missing
+// vars surface at startup, not 30 seconds in.
+//
+// The locked persona vocabulary lives in docs/migration/README.md §Personas
+// and is mirrored here. Persona slug ↔ canonical name ↔ env var mapping
+// MUST stay in sync with docs/legacy/README.md §Persona vocabulary.
+
+export interface Persona {
+  slug: string;            // kebab-case directory name
+  canonical: string;       // exact display name from the locked vocabulary
+  username: string | null; // env-driven; null = persona skipped this run
+  password: string | null;
+}
+
+interface PersonaSpec {
+  slug: string;
+  canonical: string;
+  envPrefix: string;
+}
+
+// Order matches docs/migration/README.md §Personas. Client persona omitted
+// — v1 has no Client portal (per Phase 0 INVESTIGATIONS.md, Client is an
+// object-of-care, not a User).
+const PERSONA_SPECS: PersonaSpec[] = [
+  { slug: "super-admin",   canonical: "Super-Admin",   envPrefix: "V1_SUPER_ADMIN" },
+  { slug: "agency-admin",  canonical: "Agency Admin",  envPrefix: "V1_AGENCY_ADMIN" },
+  { slug: "care-manager",  canonical: "Care Manager",  envPrefix: "V1_CARE_MANAGER" },
+  { slug: "caregiver",     canonical: "Caregiver",     envPrefix: "V1_CAREGIVER" },
+  { slug: "family-member", canonical: "Family Member", envPrefix: "V1_FAMILY_MEMBER" },
+];
+
+function loadPersona(spec: PersonaSpec): Persona {
+  const username = process.env[`${spec.envPrefix}_USERNAME`] || null;
+  const password = process.env[`${spec.envPrefix}_PASSWORD`] || null;
+  return {
+    slug: spec.slug,
+    canonical: spec.canonical,
+    username: username && username.length > 0 ? username : null,
+    password: password && password.length > 0 ? password : null,
+  };
+}
+
+export const PERSONAS: Persona[] = PERSONA_SPECS.map(loadPersona);
+
+// Filter to personas with both username + password set; the rest are skipped
+// from the run with their reason logged to RUN-MANIFEST.md.
+export const ACTIVE_PERSONAS: Persona[] = PERSONAS.filter(
+  (p) => p.username !== null && p.password !== null,
+);
+
+export const SKIPPED_PERSONAS: Persona[] = PERSONAS.filter(
+  (p) => p.username === null || p.password === null,
+);

--- a/tools/v1-screenshot-catalog/playwright.config.ts
+++ b/tools/v1-screenshot-catalog/playwright.config.ts
@@ -1,0 +1,18 @@
+import type { PlaywrightTestConfig } from "playwright/test";
+
+// One-shot tooling, not pytest-shaped — this config exists to lock the
+// browser launch options the crawler uses. The crawler itself does not run
+// under @playwright/test; it spawns Playwright directly. This file is here
+// for any future test that wants to share launch options.
+
+const config: PlaywrightTestConfig = {
+  use: {
+    headless: true,
+    viewport: { width: 1440, height: 900 },
+    ignoreHTTPSErrors: false,
+    bypassCSP: false,
+  },
+  timeout: 10_000,
+};
+
+export default config;

--- a/tools/v1-screenshot-catalog/pnpm-lock.yaml
+++ b/tools/v1-screenshot-catalog/pnpm-lock.yaml
@@ -1,0 +1,1559 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      playwright:
+        specifier: ^1.49.0
+        version: 1.59.1
+      sharp:
+        specifier: ^0.34.0
+        version: 0.34.5
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)
+
+packages:
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  detect-libc@2.1.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.3.0: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
+
+  semver@7.7.4: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@2.1.9(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.14
+      rollup: 4.60.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.17):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 2.1.9(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/tools/v1-screenshot-catalog/routes-allowlist.ts
+++ b/tools/v1-screenshot-catalog/routes-allowlist.ts
@@ -1,0 +1,35 @@
+// Routes that the crawler should also visit even though they're not in the
+// pages inventory. Keep this list small — the inventory is the authoritative
+// source.
+//
+// Use cases:
+//   - 404 pages (deliberately invalid URL to capture v1's 404 chrome)
+//   - Modal-only views accessible only via direct URL
+//
+// If you find yourself adding a route here that arguably belongs in the
+// inventory, fix the inventory instead.
+
+export interface AllowlistRoute {
+  url: string;
+  persona: string;       // canonical persona name
+  description: string;   // human-readable why-it's-here
+}
+
+export const ROUTES_ALLOWLIST: AllowlistRoute[] = [
+  // 404 chrome — deliberately invalid URL.
+  {
+    url: "/this-route-does-not-exist-on-purpose-for-the-catalog/",
+    persona: "Agency Admin",
+    description: "404 page chrome — not a real route",
+  },
+];
+
+// HTTP methods + URL fragments that are permitted to leave the crawler.
+// Anything not on this allowlist is aborted by Playwright's request
+// interception (see crawl.ts). T4 of #107 — destructive-endpoint protection.
+export const ALLOWED_NON_GET_FRAGMENTS: string[] = [
+  "/dashboard/login/",
+  "/dashboard/logout/",
+  "/role-switch/",
+  "/auth/magic-link/redeem/",
+];

--- a/tools/v1-screenshot-catalog/tsconfig.json
+++ b/tools/v1-screenshot-catalog/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Phase 1 of [#107](https://github.com/suniljames/COREcare-v2/issues/107). The TypeScript Playwright crawler that captures v1's UI as a per-persona screenshot catalog — written and unit-tested, but not yet executed against v1.

### What this PR adds

- **`tools/v1-screenshot-catalog/`** — TS Playwright crawler with `crawl.ts` (~370 LOC), three config TS files (personas, routes allowlist, playwright config), `package.json` + `tsconfig.json`, `.env.example`, `README.md` bring-up runbook, and `__tests__/` with 18 vitest assertions.
- **`scripts/extract-inventory-routes.sh`** — single source of truth for inventory parsing. Emits JSON `[{persona, route, screenshot_ref}, ...]`. 14 bash tests; 14/14 PASS. Outputs 134 rows from the live inventory across 5 personas (Client correctly absent).
- **`scripts/check-catalog-reproducibility.sh`** — pixelmatch-via-npx for T2 verification, <0.5% per-image pixel diff threshold.
- **CI workflow extensions** — `v1-catalog-coverage.yml` adds a `crawler-tests` job (typecheck + vitest); `v1-doc-hygiene.yml` extends scope to `tools/v1-screenshot-catalog/*.md`.

### Crawler highlights

- **5 pre-flight gates** (V1_BASE_URL reachable / hostname blocklist / persona creds set / output dir writable / inventory parses) — fail-fast with actionable messages before any auth attempt.
- **Production-hostname blocklist** as literal regex array in `crawl.ts` (T11) — env-tampering doesn't help.
- **Network interception** — GET-only by default, explicit non-GET allowlist (login, role-switch). Aborts get logged to `intercepted-non-GET.log` as the T4 audit artifact.
- **Determinism harness** — seeded mulberry32 RNG, mocked `Date`, animations off, lazy-load disable. Each item documented inline.
- **Login via `page.fill` + `page.click`** — Django CSRF handled by the browser naturally.

## Test plan

- [x] `bash scripts/tests/test_extract_inventory_routes.sh` — 14/14 PASS
- [x] `make test-v1-docs` (all four bundles) — PASS
- [x] `cd tools/v1-screenshot-catalog && pnpm typecheck` — clean
- [x] `cd tools/v1-screenshot-catalog && pnpm test` — 18/18 PASS
- [x] `bash scripts/check-v1-catalog-coverage.sh` — 134 rows, 100% coverage, OK
- [x] `bash scripts/check-v1-doc-hygiene.sh tools/v1-screenshot-catalog/*.md` — PASS
- [ ] `pnpm crawl` against v1 — **not yet run** (Phase 2 deliverable; needs the PHI-scrubbed Django fixture authored first)
- [ ] CI passes

## Out of scope (Phase 2 / Phase 3)

- The PHI-scrubbed Django fixture at `~/Code/COREcare-access/fixtures/v2_catalog_snapshot.json` — lives in v1's local checkout, not committed in v2. Authored before Phase 2's authoritative crawl.
- The actual crawl run + catalog binary commit — Phase 2.
- Caption body authoring (~25h human work) — Phase 3, separate follow-up issue.

## NIT (defer to follow-up)

`scripts/check-v1-catalog-coverage.sh` (PR-A) and `scripts/extract-inventory-routes.sh` (this PR) have independent awk parsers for the inventory schema. They produce equivalent results for the locked schema, but the design synthesis (E5) called for one shared parser. A small refactor PR could land coverage-script as a JSON-consumer of the extractor. Not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
