### PR TITLE
docs(#121): Family Member section refresh runbook entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ test-v1-docs: ## Run v1 doc hygiene + structure + catalog-coverage script self-t
 	bash scripts/tests/test_check_v1_doc_hygiene.sh
 	bash scripts/tests/test_check_v1_doc_structure.sh
 	bash scripts/tests/test_check_v1_catalog_coverage.sh
+	bash scripts/tests/test_readme_runbook_entries.sh
 
 scan-v1-docs: ## Run hygiene + structure + catalog-coverage scripts over committed docs
 	@if compgen -G "docs/migration/v1-*.md" > /dev/null; then \

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -264,6 +264,20 @@ When v1 receives material changes, refresh this docset against the new SHA.
 
 If you find yourself doing this more than twice manually, automate it (per the team's "if you do it twice" principle). The first automation candidate is the `urls.py` enumeration step.
 
+### Family Member section — extra diff checks before re-authoring
+
+Family Member is the lowest-frequency persona for v2 development AND the lowest-frequency persona surface in v1. Small family-portal patches accumulate undetected between refreshes — silent drift the hygiene scanner cannot catch. Run these checks every time the `V1 Reference Commit` above is bumped, regardless of which persona motivated the bump.
+
+In your local v1 checkout, against the previously-pinned SHA:
+
+- `git diff <old>..<new> -- '*/urls.py'` — surfaces new family-prefixed routes anywhere in v1, including sub-URLConf refactors a top-level `dashboard/urls.py` diff would miss.
+- `git diff <old>..<new> -- clients/` — surfaces changes to permission gating, serializers, and family-facing templates. Helper names like `_check_client_access`, body checks like `is_family or …`, and template tags like `{% if is_family %}` are *examples of what to look for*, not a fixed contract — the gate may be renamed but the semantics are what matter.
+- `git diff <old>..<new> -- clients/models.py` — surfaces `ClientFamilyMember` schema shifts.
+
+Baseline at the currently-pinned SHA: `ClientFamilyMember` has no `is_active`, no soft-delete, no expiry, and no role/permission column — any of those appearing in the diff is a behavioral change that propagates into the section's rows.
+
+If any diff is non-empty: re-author affected rows in `v1-pages-inventory.md`. If `_check_client_access` or any family-permission gate changed: also flag `CUTOVER_PLAN.md` owners — v2 RLS may need to mirror the v1 change. If all diffs are empty: still bump `last reconciled` on the Family Member section. An empty diff is signal; the reconciliation date is the artifact.
+
 **Refresh order — Agency Admin first.** Agency Admin is the most-iterated persona surface in v1 (billing, payroll, scheduling, credentials, compliance). When budget for a refresh is constrained, refresh Agency Admin first; file follow-ups for other personas. The pattern Agency Admin establishes (cell prose, H3 naming, flag accuracy) is the template subsequent persona refreshes inherit.
 
 ---

--- a/scripts/tests/test_readme_runbook_entries.sh
+++ b/scripts/tests/test_readme_runbook_entries.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Tests for invariants of per-section refresh-runbook entries in
+# docs/migration/README.md. The hygiene scanner only covers v1-*.md files,
+# so README runbook entries have no automated guardrail without this script.
+#
+# Run from repo root: bash scripts/tests/test_readme_runbook_entries.sh
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+README="$REPO_ROOT/docs/migration/README.md"
+
+PASS=0
+FAIL=0
+
+assert() {
+  local description="$1"
+  local condition="$2"
+  if eval "$condition"; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description"
+    echo "    condition: $condition"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "== README runbook-entry tests =="
+
+[[ -f "$README" ]] || { echo "FAIL — README not found at $README"; exit 1; }
+
+# --- Family Member section refresh entry (#121) ---
+
+assert \
+  "Family Member entry header present" \
+  "grep -q '^### Family Member section' '$README'"
+
+assert \
+  "Family Member entry uses 'extra diff checks' phrase" \
+  "grep -q 'extra diff checks' '$README'"
+
+assert \
+  "Family Member entry uses 'silent drift' as searchable signal" \
+  "grep -q 'silent drift' '$README'"
+
+assert \
+  "Family Member entry includes cadence trigger tied to V1 Reference Commit" \
+  "grep -qE 'Run these checks every time the.*V1 Reference Commit' '$README'"
+
+assert \
+  "Family Member entry references ClientFamilyMember baseline" \
+  "grep -q 'ClientFamilyMember' '$README'"
+
+# Placement: line of '### Family Member section' must fall between
+# the '## Refresh runbook' header and the '## Related work' header.
+runbook_line=$(grep -n '^## Refresh runbook$' "$README" | head -1 | cut -d: -f1)
+related_line=$(grep -n '^## Related work$' "$README" | head -1 | cut -d: -f1)
+entry_line=$(grep -n '^### Family Member section' "$README" | head -1 | cut -d: -f1)
+
+if [[ -n "$runbook_line" && -n "$related_line" && -n "$entry_line" ]]; then
+  assert \
+    "Family Member entry placed inside '## Refresh runbook' section (after header, before '## Related work')" \
+    "[[ $entry_line -gt $runbook_line && $entry_line -lt $related_line ]]"
+else
+  echo "  FAIL — placement check skipped: missing one of (runbook=$runbook_line, related=$related_line, entry=$entry_line)"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" == 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- Adds an H3 entry under `## Refresh runbook` in `docs/migration/README.md` for the Family Member section, closing the silent-drift gap the hygiene scanner cannot catch (Family Member is the lowest-frequency persona for both v2 development and v1 patching).
- Binds three concrete diffs (`'*/urls.py'`, `clients/`, `clients/models.py`) to every `V1 Reference Commit` bump, with an inlined `ClientFamilyMember` baseline fingerprint and explicit branches for non-empty / permission-changed / empty-diff outcomes.
- Adds `scripts/tests/test_readme_runbook_entries.sh` (six grep/awk assertions including a placement check) wired into the `test-v1-docs` make target — README runbook content was previously uncovered by any automated guardrail.

## Test plan

- [x] New script `bash scripts/tests/test_readme_runbook_entries.sh` — 6/6 PASS (RED before commit, GREEN after).
- [x] `make scan-v1-docs` — clean across hygiene, structure, and catalog-coverage.
- [x] `make test-v1-docs` — all suites green including the new readme-runbook-entries stanza.
- [x] `make check` — api lint/test/typecheck, web lint/test/typecheck/build all green (web build run with the same dummy Clerk publishable key the CI workflow uses).
- [x] Entry length ≤ 25 lines (DoD constraint, validated manually — 13 content lines).

## Committee design review

Issue #121 went through the full engineering committee (UX → SE → Architect → Data → AI/ML → Security → QA → SRE → Writer → EM synthesis). Notable findings folded into this PR:

- **QA caught a trivial test** in the original spec (`make scan-v1-docs` exits 0) — hygiene only scans `v1-*.md` files, so `README.md` changes pass it regardless of content. Replaced with content-aware grep assertions plus a placement check.
- **SE/Security** broadened the original `dashboard/urls.py` diff to `'*/urls.py'` glob (catches sub-URLConf refactors) and the `clients/views.py` diff to `clients/` directory (covers serializers, templates, and permission gating outside `views.py`).
- **Data** inlined the `ClientFamilyMember` baseline fingerprint so the diff has a comparison point without chasing a closed-issue verdict.
- **SRE** added the cadence trigger ("run every time the V1 Reference Commit is bumped, regardless of which persona motivated the bump") and the empty-diff-still-bumps-`last reconciled` rule.
- **Writer** held the entry under 25 lines and locked in "drift" / "silent drift" as the searchable signal words.

## Follow-ups (filed post-merge per committee plan)

- v1-SHA-bump CI guardrail — when the V1 reference SHA is bumped, CI auto-posts the family-section diffs as a PR comment for ack.
- README runbook structure-check coverage — extend `check-v1-doc-structure.sh` to enforce invariants on the README's runbook section directly (this PR adds one such test; the follow-up generalizes the approach).

## Related

- Closes #121
- Umbrella: #78
- Origin: PR #113 SRE review (R3 NIT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
