### PR TITLE
fix(#134): extend JL-7 anchor-resolution to absolute GitHub URLs and ../blob/ form

### DIFF
--- a/scripts/check-v1-doc-structure.sh
+++ b/scripts/check-v1-doc-structure.sh
@@ -22,6 +22,13 @@
 #      v2_status / severity / direction_and_sync cell carries a valid token
 #      (SL-2, SL-3, SL-4), and every surfaces_at_routes inventory link
 #      resolves against an existing inventory anchor (EL-1, EL-2). Issue #98.
+#   7. v1-user-journeys.md, if present, has the **Status:** header form, the
+#      six persona H2s, and (when AUTHORED) the per-persona journey-count
+#      minimums, the Route trace + Side effects sub-blocks under each H3, and
+#      no placeholder / filler residue (JL-1..JL-6). Every anchor citation to
+#      v1-pages-inventory.md — whether written as a relative path, an absolute
+#      GitHub URL, or a `../blob/<branch>/...` form — resolves to a real
+#      heading or <a id> in the inventory (JL-7). Issues #104, #134.
 #
 # Usage:
 #   scripts/check-v1-doc-structure.sh [--dir <docs-dir>]
@@ -507,11 +514,23 @@ if [[ -f "$JOURNEYS" ]]; then
         next
       }
       {
+        # `[^()]*` permits any non-paren prefix between the opening `(` and the
+        # literal `v1-pages-inventory.md#`, covering all three target forms:
+        #   - relative:                (v1-pages-inventory.md#anchor)
+        #   - absolute GitHub URL:     (https://github.com/<o>/<r>/blob/<b>/docs/migration/v1-pages-inventory.md#anchor)
+        #   - sibling-blob form:       (../blob/<branch>/docs/migration/v1-pages-inventory.md#anchor)
+        # Note: `[^()]*v1-pages-inventory.md` would also match a hypothetical
+        # `*-v1-pages-inventory.md` sibling file. No such file exists in the
+        # docset today; this is a known collateral-match shape.
         line = $0
-        while (match(line, /\(v1-pages-inventory\.md#[^)]+\)/)) {
+        while (match(line, /\([^()]*v1-pages-inventory\.md#[^)]+\)/)) {
           link = substr(line, RSTART, RLENGTH)
-          # Strip "(v1-pages-inventory.md#" (length 23) and trailing ")".
-          anchor = substr(link, 24, length(link) - 24)
+          # Find the literal marker inside the captured link and slice the
+          # anchor from immediately after it to immediately before the closing ")".
+          # `index()` does not mutate RSTART/RLENGTH (only `match()` does).
+          marker_pos = index(link, "v1-pages-inventory.md#")
+          anchor_start = marker_pos + 22   # length of "v1-pages-inventory.md#"
+          anchor = substr(link, anchor_start, length(link) - anchor_start)
           if (!(anchor in ANCHORS)) {
             print FILENAME ":" FNR ": JL-7: anchor \"" anchor "\" not found in v1-pages-inventory.md"
           }

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -1169,6 +1169,78 @@ p.write_text(text)
 PY
 assert_exit "JL-7: orphan inventory anchor fails" 1 "$STRUCTURE" --dir "$TEST_DIR/jl7"
 
+# --- JL-7: orphan absolute GitHub URL anchor fails ---
+mkdir -p "$TEST_DIR/jl7-abs-orphan"
+write_journeys_inventory "$TEST_DIR/jl7-abs-orphan/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/jl7-abs-orphan/v1-functionality-delta.md"
+write_good_journeys "$TEST_DIR/jl7-abs-orphan/v1-user-journeys.md"
+python3 - "$TEST_DIR/jl7-abs-orphan/v1-user-journeys.md" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])
+text = p.read_text()
+text = text.replace(
+    "(v1-pages-inventory.md#super-admin-top-level)",
+    "(https://github.com/suniljames/COREcare-v2/blob/main/docs/migration/v1-pages-inventory.md#nonexistent-anchor)",
+    1,
+)
+p.write_text(text)
+PY
+assert_exit "JL-7: orphan absolute-URL anchor fails" 1 "$STRUCTURE" --dir "$TEST_DIR/jl7-abs-orphan"
+
+# --- JL-7: valid absolute GitHub URL anchor passes ---
+mkdir -p "$TEST_DIR/jl7-abs-valid"
+write_journeys_inventory "$TEST_DIR/jl7-abs-valid/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/jl7-abs-valid/v1-functionality-delta.md"
+write_good_journeys "$TEST_DIR/jl7-abs-valid/v1-user-journeys.md"
+python3 - "$TEST_DIR/jl7-abs-valid/v1-user-journeys.md" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])
+text = p.read_text()
+text = text.replace(
+    "(v1-pages-inventory.md#super-admin-top-level)",
+    "(https://github.com/suniljames/COREcare-v2/blob/main/docs/migration/v1-pages-inventory.md#super-admin-top-level)",
+    1,
+)
+p.write_text(text)
+PY
+assert_exit "JL-7: valid absolute-URL anchor passes" 0 "$STRUCTURE" --dir "$TEST_DIR/jl7-abs-valid"
+
+# --- JL-7: orphan ../blob/<branch> anchor fails ---
+mkdir -p "$TEST_DIR/jl7-blob-orphan"
+write_journeys_inventory "$TEST_DIR/jl7-blob-orphan/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/jl7-blob-orphan/v1-functionality-delta.md"
+write_good_journeys "$TEST_DIR/jl7-blob-orphan/v1-user-journeys.md"
+python3 - "$TEST_DIR/jl7-blob-orphan/v1-user-journeys.md" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])
+text = p.read_text()
+text = text.replace(
+    "(v1-pages-inventory.md#super-admin-top-level)",
+    "(../blob/main/docs/migration/v1-pages-inventory.md#nonexistent-anchor)",
+    1,
+)
+p.write_text(text)
+PY
+assert_exit "JL-7: orphan ../blob/<branch> anchor fails" 1 "$STRUCTURE" --dir "$TEST_DIR/jl7-blob-orphan"
+
+# --- JL-7: valid ../blob/<branch> anchor passes ---
+mkdir -p "$TEST_DIR/jl7-blob-valid"
+write_journeys_inventory "$TEST_DIR/jl7-blob-valid/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/jl7-blob-valid/v1-functionality-delta.md"
+write_good_journeys "$TEST_DIR/jl7-blob-valid/v1-user-journeys.md"
+python3 - "$TEST_DIR/jl7-blob-valid/v1-user-journeys.md" <<'PY'
+import sys, pathlib
+p = pathlib.Path(sys.argv[1])
+text = p.read_text()
+text = text.replace(
+    "(v1-pages-inventory.md#super-admin-top-level)",
+    "(../blob/main/docs/migration/v1-pages-inventory.md#super-admin-top-level)",
+    1,
+)
+p.write_text(text)
+PY
+assert_exit "JL-7: valid ../blob/<branch> anchor passes" 0 "$STRUCTURE" --dir "$TEST_DIR/jl7-blob-valid"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [[ "$FAIL" == 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- Widens the JL-7 awk regex in `scripts/check-v1-doc-structure.sh` from the relative-only `\(v1-pages-inventory\.md#[^)]+\)` to `\([^()]*v1-pages-inventory\.md#[^)]+\)`, covering relative + absolute-GitHub-URL + `../blob/<branch>/...` link forms in one pattern.
- Switches anchor extraction from a hard-coded prefix-length slice to an `index()`-based form so it works against variable-length prefixes.
- Violation message preserved byte-for-byte: `JL-7: anchor "<name>" not found in v1-pages-inventory.md`.

Closes #134.

## Test plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` — **46/46 passes**, 0 fails (42 prior + 4 new).
- [x] Four new tests cover the symmetric matrix:
  - orphan absolute-URL → exits 1
  - valid absolute-URL → exits 0
  - orphan `../blob/<branch>` → exits 1
  - valid `../blob/<branch>` → exits 0
- [x] `bash scripts/check-v1-doc-structure.sh` against live docset → exit 0, no regressions.
- [x] `make scan-v1-docs` clean (catalog coverage 100%).
- [ ] CI `v1-doc-hygiene.yml` passes on this branch.

## Notes

- Issue body said `41 prior + 4 new = 45`. Actual prior count was 42, so 46 total. Wording-only off-by-one; suite is fully green.
- Pre-existing shellcheck infos (SC2016, SC2164) in `check-v1-doc-structure.sh` and `test_check_v1_doc_structure.sh` were not introduced by this PR.
- Header doc block at the top of `check-v1-doc-structure.sh` extended with a JL-7 entry per Writer review (WL-2).
- Inline comment near the new regex notes the known collateral-match shape: `[^()]*v1-pages-inventory.md` would also match a hypothetical `*-v1-pages-inventory.md` sibling. None exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)