### PR TITLE
test(#122): boundary fixture proving Family Member rules STOP at next H2

### DIFF
--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -368,6 +368,33 @@ EOF
 write_good_delta "$TEST_DIR/family-good-noaudit/v1-functionality-delta.md"
 assert_exit "Family Member well-formed row with 'no audit' phrase passes" 0 "$STRUCTURE" --dir "$TEST_DIR/family-good-noaudit"
 
+# Boundary fixture: a malformed Shared-routes row placed AFTER ## Family Member
+# must NOT be subjected to Family Member per-row rules. Origin: PR #113 Q4 NIT.
+mkdir -p "$TEST_DIR/family-shared-boundary"
+cat > "$TEST_DIR/family-shared-boundary/v1-pages-inventory.md" <<'EOF'
+# v1 Pages Inventory
+
+## Super-Admin
+## Agency Admin
+## Care Manager
+## Caregiver
+## Client
+
+## Family Member
+
+| route | purpose |
+|-------|---------|
+| `/family/billing-pdf/` | 🔒 PHI · Family invoice PDF; linked-client only; HIPAA-access-logged in v1. |
+
+## Shared routes
+
+| route | purpose | persona | v2_status | severity |
+|-------|---------|---------|-----------|----------|
+| `/family-signup/` | Public signup form. | none | implemented | L |
+EOF
+write_good_delta "$TEST_DIR/family-shared-boundary/v1-functionality-delta.md"
+assert_exit "Family Member structure rules STOP at '## Shared routes' H2 boundary" 0 "$STRUCTURE" --dir "$TEST_DIR/family-shared-boundary"
+
 # =============================================================================
 # Integrations-and-exports doc tests (CL-1, CL-2, SL-1..SL-4, EL-1, EL-2)
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds one fixture (`family-shared-boundary`) to `scripts/tests/test_check_v1_doc_structure.sh` that proves the awk extractor at `scripts/check-v1-doc-structure.sh:147` terminates the `## Family Member` section at the next H2 boundary, so a malformed row in `## Shared routes` is not subjected to Family-Member-only rules.
- Origin: PR #113 Q4 NIT — surfaced because every existing Family-Member fixture places the section in isolation, leaving the boundary invariant unverified.

## What the fixture asserts

The inventory contains:
1. A well-formed Family Member row (passes all three rules — `linked-client only`, `HIPAA-access-logged in v1`, `🔒 PHI · ` prefix).
2. A `## Shared routes` section immediately after, with one row whose first cell IS a backticked slug (`/family-signup/`) — required so it would match the route-row regex `^\|[[:space:]]*\`` if the boundary leaked. The row violates **all three** Family Member rules.

Assertion: structure check exits 0. If the awk boundary at `scripts/check-v1-doc-structure.sh:147` (`in_section && /^## / { in_section = 0 }`) ever leaks, the Shared-routes row gets fed to the per-row Family-Member loop at `scripts/check-v1-doc-structure.sh:152-174` and fails on all three rules — flipping the test red.

## Mutation test (proof the fixture isn't a tautology)

Temporarily removed the boundary clause from `scripts/check-v1-doc-structure.sh` and reran:

```
FAIL — Family Member structure rules STOP at '## Shared routes' H2 boundary (expected exit 0, got 1)
  output: FAIL: ... '## Family Member' row '/family-signup/' missing literal phrase 'linked-client only'
  FAIL: ... '## Family Member' row '/family-signup/' must contain EXACTLY one of the two audit-posture phrases
  FAIL: ... '## Family Member' row '/family-signup/' purpose cell must begin with '🔒 PHI · ' prefix
```

Note the error message names `/family-signup/` — a Shared-routes row — confirming the leak. Reverted the mutation; suite is back to green.

## Test count

The Definition of Done in #122 cited `(existing 18 self-tests + the new one = 19/19)` — that count was correct when PR #113 landed but stale today (subsequent PRs #98 and #104 added integrations and journeys tests). Actual delta is **42 → 43** for `test_check_v1_doc_structure.sh`. All other v1-docs tests unaffected.

## Test plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` — 43 passed, 0 failed.
- [x] `make test-v1-docs` — 17 + 43 + 18 + 6 = 84 passed across the four v1-doc test files.
- [x] Mutation test (remove boundary clause) → fixture turns red with three correctly-named violations on the Shared-routes row.
- [x] Revert mutation → suite green.
- [x] API portion of `make check`: ruff lint + format, mypy (90 files), pytest (124 passed, 3 skipped).
- [x] Web lint, typecheck, vitest (7 passed).
- [ ] Web build skipped locally — pre-existing missing-Clerk-key env issue (reproduces on main checkout, not caused by this change). CI runs the build with proper env.

Closes #122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)