### PR TITLE
docs(#105): author v1-glossary.md + extend anchor-resolution validator

### DIFF
--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -260,7 +260,8 @@ When v1 receives material changes, refresh this docset against the new SHA.
 2. Diff against the previously-pinned SHA in this README. Identify changed apps.
 3. For each changed app, read `urls.py`, views, and templates. Update the pages-inventory rows for affected routes; update journeys if a flow changed end-to-end; update integrations doc if external service contracts changed.
 4. Bump `last reconciled` dates in updated persona sections. Update the SHA in this README.
-5. Run `make scan-v1-docs` locally. Open a PR titled `docs(migration): refresh v1 reference set against <short-sha>`.
+5. Re-resolve `v1-glossary.md` first-use anchors against the bumped docs and update the glossary's `**Status:** AUTHORED. Last reconciled: …` line. The structure script's GL-3 check fails fast if any anchor went stale; the date bump is the artifact even when no link breaks.
+6. Run `make scan-v1-docs` locally. Open a PR titled `docs(migration): refresh v1 reference set against <short-sha>`.
 
 If you find yourself doing this more than twice manually, automate it (per the team's "if you do it twice" principle). The first automation candidate is the `urls.py` enumeration step.
 
@@ -276,7 +277,7 @@ In your local v1 checkout, against the previously-pinned SHA:
 
 Baseline at the currently-pinned SHA: `ClientFamilyMember` has no `is_active`, no soft-delete, no expiry, and no role/permission column — any of those appearing in the diff is a behavioral change that propagates into the section's rows.
 
-If any diff is non-empty: re-author affected rows in `v1-pages-inventory.md`. If `_check_client_access` or any family-permission gate changed: also flag `CUTOVER_PLAN.md` owners — v2 RLS may need to mirror the v1 change. If all diffs are empty: still bump `last reconciled` on the Family Member section. An empty diff is signal; the reconciliation date is the artifact.
+If any diff is non-empty: re-author affected rows in `v1-pages-inventory.md`. If `_check_client_access` or any family-permission gate changed: also flag `CUTOVER_PLAN.md` owners — v2 RLS may need to mirror the v1 change. If `clients/models.py` shows a `ClientFamilyMember` schema shift: also re-author the `ClientFamilyMember` entry in `v1-glossary.md`, which mirrors the v1 baseline (no `is_active`, no soft-delete, no expiry, hard-delete revocation) and goes stale silently. If all diffs are empty: still bump `last reconciled` on the Family Member section. An empty diff is signal; the reconciliation date is the artifact.
 
 **Refresh order — Agency Admin first.** Agency Admin is the most-iterated persona surface in v1 (billing, payroll, scheduling, credentials, compliance). When budget for a refresh is constrained, refresh Agency Admin first; file follow-ups for other personas. The pattern Agency Admin establishes (cell prose, H3 naming, flag accuracy) is the template subsequent persona refreshes inherit.
 

--- a/docs/migration/v1-glossary.md
+++ b/docs/migration/v1-glossary.md
@@ -6,7 +6,7 @@ Terms specific to COREcare v1 (`suniljames/COREcare-access`) that appear across 
 
 This file extends `pm-context.md` with v1-specific terms — model names, internal feature names, and Django app names that come up when reading v1 source.
 
-**Status:** SCAFFOLDED. Entries are pending authoring against the [pinned v1 commit](README.md#v1-reference-commit). The set below is seeded from terms already cited in `v1-functionality-delta.md`.
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
 
 ---
 
@@ -16,41 +16,35 @@ For each term: one-line definition, then a link to its first significant use in 
 
 ---
 
-## Pending entries
+## Entries
 
-Terms that need definition before the docset is complete:
-
-- **`elitecare`** — the Django project root for v1; not an app name. Cited in `v1-functionality-delta.md` and any model-namespacing references.
-- **`InvoiceRevision`** — v1 model representing a corrected, reissued invoice. (`H`-severity gap in delta.)
-- **`BillableServiceCatalog`** — v1 model for agency-managed billable add-on services. (`H`-severity gap in delta.)
-- **`ChartTemplate`** — v1 model for per-client chart customization. (`H`-severity gap in delta.)
-- **`MagicLinkToken`** — v1 model backing email-based magic-link login.
-- **View-As impersonation** — v1 super-admin feature for assuming an agency-admin context with full audit trail. (`H`-severity gap; load-bearing compliance control.)
-- **`promote_to_recurring_view()`** — v1 view function cited in delta; converts a one-off scheduling decision into a recurring rule.
-- **`issue_revision_editor()`** — v1 view function for the corrected-invoice editor flow.
-- **Profile completion gate** — v1 onboarding control that blocks caregivers from accepting shifts until required profile fields are filled.
-- **9-category expense workflow** — v1 expense submission with nine fixed expense classes. (`M`-severity gap.)
-- **Meal-break waiver** — v1 caregiver-consent record for waiving meal breaks under state labor rules.
-- **Overpayment consent** — v1 acknowledgment record for caregivers to accept an overpayment correction.
-- **Action queue** — v1 deterministic-detection feed of items needing a coordinator response, distinct from v2's planned AI-driven coordination assistant.
-- **Health report approval queue** — v1 dual-author health report flow with an explicit approval gate.
-- **`ProfileCompletionMiddleware`** — v1 middleware that redirects caregivers to `/employees/complete-profile/` until their profile is complete; gates clock-in. Cited in the Caregiver section of `v1-pages-inventory.md`.
-- **Visit (v1 aggregate)** — the field-flow aggregate root for caregivers; clock state, mileage, expense reimbursements, comments, and charting all attach to a Visit. Cited in the Caregiver section of `v1-pages-inventory.md`.
-- **Shift offer** — a pending shift assignment surfaced to a caregiver for inline accept or decline before the shift starts. Cited in the Caregiver section of `v1-pages-inventory.md`.
-- **Post-shift summary** — the wrap-up screen rendered after clock-out, reviewing visit duration, billable services, comments, and attachments. Cited in the Caregiver section of `v1-pages-inventory.md`.
-- **Active shift** — the in-flight visit dashboard rendered while a caregiver is clocked in, surfacing chart entry, comments, mileage, and reimbursement actions. Cited in the Caregiver section of `v1-pages-inventory.md`.
-- **`ClientFamilyMember`** — v1 model linking a Django `User` to a `Client` for family-portal visibility; carries per-link permission booleans (`can_view_schedule`, `can_message_caregivers`) and `unique_together(client, user)` but no soft-delete or active flag — revocation is hard-delete in v1. Cited in [`## Family Member`](v1-pages-inventory.md#family-member) section lead and in cross-reference index entries for `clients/` calendar/event routes.
-- **Super-Admin** — v1 platform-operator persona; in v1 single-tenant installs, effectively any Django superuser.
-- **Django superuser** — v1 user-flag (`is_superuser=True`) that grants the strictly Super-Admin-only surface in v1 (the View-As emergency kill switch).
-- **kill-all** — v1 View-As emergency control that terminates every active impersonation session at once; the only HTML route programmatically gated to Django superusers alone.
-- **RLS-bypass surface** — v2 architectural concept naming the set of routes a platform-operator persona reaches across tenant boundaries; v1's audit-logged View-As suite is the precedent.
-
-_(definitions pending content authoring; each will resolve to one-line text + first-use link)_
+- **9-category expense workflow** — v1's unified `Expense` model uses nine fixed categories (supplies, equipment, transportation, meals, training, medical, groceries, admin, other) and eight workflow states (draft, submitted, pending, approved, processed, adjusted, rejected, reimbursed). See [the expense submission journey](v1-user-journeys.md#expense-submission--visit-linked-or-standalone).
+- **Action queue** — v1 deterministic-detection feed of items needing a coordinator response (no-shows at 15-minute grace, overdue care requests, vital-sign trend flags); priority-sorted on the Care Manager caseload page. Distinct from v2's planned AI-driven coordination assistant, which is inferred rather than rule-based. See [the Care Manager caseload journey](v1-user-journeys.md#team-oversight--caseload-action-queue-and-field-expense-submission).
+- **Active shift** — the in-flight visit dashboard rendered while a caregiver is clocked in, surfacing chart entry, comments, mileage, and reimbursement actions. See [the Caregiver caregiver_dashboard section](v1-pages-inventory.md#caregiver_dashboard).
+- **`BillableServiceCatalog`** — v1 model for the agency-managed catalog of add-on billable services with internal name, family-facing label, base price, estimated hours, hourly overage rate, MD-order requirement flag, and a soft-retire pattern that preserves invoice history. See [the Agency Admin billing_catalogs section](v1-pages-inventory.md#billing_catalogs).
+- **`ChartTemplate`** — v1 charting model with a one-active-per-client invariant via `is_active`; owns `ChartTemplateSection` and `ChartTemplateSectionItem` rows that drive per-section inclusion, requirement, and exclusion-reason controls. See [the Agency Admin charting section](v1-pages-inventory.md#charting).
+- <a id="client-v1-vs-v2"></a>**`Client` (v1 record)** — `clients.models.Client`, a v1 subject of care with no `User` linkage and no authenticated route — clients never log in to v1. Distinct from a future v2-hypothetical Client-as-user persona (tracked in [#125](https://github.com/suniljames/COREcare-v2/issues/125)) which would add a Clerk role and RLS policy. See [the Client section](v1-pages-inventory.md#client-section).
+- **`ClientFamilyMember`** — v1 model linking a Django `User` to a `Client` for family-portal visibility, with `unique_together(client, user)` plus per-link permission booleans (`can_view_schedule`, `can_message_caregivers`); v1 has no soft-delete, no active flag, and no expiry — revocation is hard-delete. See [the Family Member section](v1-pages-inventory.md#family-member).
+- **Django superuser** — v1 user flag (`is_superuser=True`) that grants the strictly Super-Admin-only surface in v1 (the View-As emergency kill switch); necessary-but-not-sufficient for the v2 Super-Admin persona, which adds tenant-bypass policy on top. See [the Super-Admin section](v1-pages-inventory.md#super-admin).
+- **`elitecare`** — the v1 Django project root (the `elitecare/` directory containing `settings.py` and `urls.py`); not a Django app name. Top-level admin routes are registered in `elitecare/urls.py` outside any `include()`. See [the Agency Admin top-level routes](v1-pages-inventory.md#agency-admin-top-level).
+- **Health report approval queue** — v1 staff queue of caregiver-initiated health-report requests awaiting approval before family delivery; v1 generates reports in two parallel versions (family-friendly and clinical) and gates the family-facing version behind explicit staff sign-off. See [the Agency Admin charting section](v1-pages-inventory.md#charting).
+- **`InvoiceRevision`** — v1 model representing a corrected, reissued invoice with revision numbering and concurrent-issue row locking; the corrected-invoice editor route depends on it. See [the Agency Admin billing section](v1-pages-inventory.md#billing).
+- **`issue_revision_editor()`** — v1 view function for the corrected-invoice editor flow that reissues an `InvoiceRevision` with concurrent-issue locking. See [the Agency Admin billing section](v1-pages-inventory.md#billing).
+- **kill-all** — v1 View-As emergency control that terminates every active impersonation session at once; the only HTML route programmatically gated to Django superusers alone via `@user_passes_test(lambda u: u.is_superuser)`. See [the Super-Admin top-level routes](v1-pages-inventory.md#super-admin-top-level).
+- <a id="magiclinktoken"></a>**`MagicLinkToken`** — v1 model backing email-based magic-link login; a 30-minute single-use UUID token explicitly disabled for `is_staff`/`is_superuser` users at the view layer (a security stance, not a UX stance — staff are routed through the password-reset flow). See [the Agency Admin auth_service section](v1-pages-inventory.md#auth_service).
+- **Meal-break waiver** — v1 caregiver-consent record (`MealPeriodWaiver`) for waiving meal breaks under state labor rules; an immutable IP-stamped attestation per `BaseAttestation` semantics, gated on `shift_hours > 5` at clock-out, with non-voluntary waivers rolling up into `DailyTimesheet.meal_penalty_count` for premium-pay calculation. See [the clock in and out journey](v1-user-journeys.md#clock-in-and-out-at-a-shift).
+- **Overpayment consent** — v1 acknowledgment record (`OverpaymentConsent`) for caregivers to accept an overpayment correction before deduction; legally-defensible immutable IP-stamped attestation per `BaseAttestation` semantics, mandatory under California labor law and FLSA before any unilateral paycheck deduction. See [the email pipeline integrations section](v1-integrations-and-exports.md#email-pipeline).
+- **Post-shift summary** — the wrap-up screen rendered after clock-out, reviewing visit duration, billable services performed, comments, and attachments. See [the Caregiver caregiver_dashboard section](v1-pages-inventory.md#caregiver_dashboard).
+- **Profile completion gate** — v1 onboarding control that blocks caregivers from accepting shifts or clocking in until required profile fields are filled; enforced at the middleware layer rather than per-view. See [the caregiver onboarding journey](v1-user-journeys.md#caregiver-onboarding--invitation-through-profile-activation).
+- **`ProfileCompletionMiddleware`** — v1 middleware that redirects caregivers to `/employees/complete-profile/` until their profile is complete; the enforcement layer behind the Profile completion gate. See [the caregiver onboarding journey](v1-user-journeys.md#caregiver-onboarding--invitation-through-profile-activation).
+- **`promote_to_recurring_view()`** — v1 view function that converts a one-off `VisitBillableService` attachment into a recurring rule on the parent `CarePlan`; gated by capability and exposed at `/admin/visit-services/<int:vbs_id>/promote/`. See [the Agency Admin billing section](v1-pages-inventory.md#billing).
+- <a id="rls-bypass-surface"></a>**RLS-bypass surface** — v2 architectural concept naming the set of routes a platform-operator persona reaches across tenant boundaries by design; v1's audit-logged View-As suite is the precedent, and v2 design treats every cross-tenant-reachable route as an RLS-bypass surface requiring audit logging. See [the Super-Admin section](v1-pages-inventory.md#super-admin).
+- **Shift offer** — a pending shift assignment surfaced to a caregiver for inline accept or decline before the shift starts. See [the Caregiver caregiver_dashboard section](v1-pages-inventory.md#caregiver_dashboard).
+- <a id="view-as-impersonation"></a>**View-As impersonation** — v1 super-admin feature for assuming an Agency-Admin context to reproduce user-specific issues, with a full audit trail; the operator's audit-log identity remains distinct from the impersonated user's session context, and every step under impersonation writes to the v1 audit log. The v1 precedent for the v2 RLS-bypass surface concept. See [the View-As impersonation journey](v1-user-journeys.md#view-as-impersonation-with-audit-trail).
+- **Visit (v1 aggregate)** — the field-flow aggregate root for caregivers; clock state, mileage, expense reimbursements, comments, and charting all attach to a Visit, and most caregiver routes are keyed on `<int:visit_id>`. See [the Caregiver section](v1-pages-inventory.md#caregiver).
 
 ---
 
 ## Cross-cutting v1 conventions
 
-These are not single terms but recurring patterns in v1 source. Calling them out here because they show up in inventory rows and journey traces.
-
-_(pending)_
+A recurring v1 pattern surfaces across this docset: route handlers that stream files or render scoped landings frequently lack audit logging, and v2 must close those gaps. Rows flagged this way include the Family Member dashboard, the family-portal access helper `_check_client_access`, expense-receipt downloads on both the Caregiver and Care Manager portals, and the Care Manager `cm_serve_receipt` handler. The pattern is consistent enough that v2 design should treat any new download or scoped-landing handler as audit-required by default rather than opt-in. Magic-link login is already audit-logged on use in v1 and serves as the worked example of the desired posture.

--- a/scripts/check-v1-doc-structure.sh
+++ b/scripts/check-v1-doc-structure.sh
@@ -53,6 +53,7 @@ INVENTORY="$DIR/v1-pages-inventory.md"
 DELTA="$DIR/v1-functionality-delta.md"
 INTEGRATIONS="$DIR/v1-integrations-and-exports.md"
 JOURNEYS="$DIR/v1-user-journeys.md"
+GLOSSARY="$DIR/v1-glossary.md"
 
 REQUIRED_PERSONAS=(
   "Super-Admin"
@@ -541,6 +542,137 @@ if [[ -f "$JOURNEYS" ]]; then
     if [[ -n "$jl7_violations" ]]; then
       while IFS= read -r line; do fail "$line"; done <<< "$jl7_violations"
     fi
+  fi
+fi
+
+# --- v1-glossary.md (#105) ---
+# Validates the glossary doc once it has been authored. The status header
+# gates block-level checks: a SCAFFOLDED prefix skips them (so the in-flight
+# scaffold doesn't emit noisy violations during partial drafts); the
+# AUTHORED form turns them on. Anchor resolution against the inventory,
+# journeys, and integrations docs is always-on, mirroring JL-7.
+#
+# GL-1: status header is "**Status:** SCAFFOLDED..." (any trailing prose)
+#       OR "**Status:** AUTHORED. Last reconciled: YYYY-MM-DD against
+#       v1 commit `<sha>`." (exact form). Missing or malformed fails.
+# GL-2: when AUTHORED, no placeholder markers remain — `_(pending)_`,
+#       `_(definitions pending)_`, `_(definitions pending content authoring`,
+#       `_(pending content authoring)_`. Anything that announces itself
+#       as not-yet-authored.
+# GL-3: every link from the glossary to v1-pages-inventory.md#anchor,
+#       v1-user-journeys.md#anchor, or v1-integrations-and-exports.md#anchor
+#       resolves against an existing heading or explicit <a id> in the
+#       target doc. Always-on. If a target doc is absent on disk, links
+#       into it are reported as orphan (the glossary cannot point at a
+#       doc the docset omits).
+if [[ -f "$GLOSSARY" ]]; then
+  # GL-1: status header form (always enforced).
+  glossary_status_line=$(grep -E '^\*\*Status:\*\*' "$GLOSSARY" | head -1)
+  if [[ -z "$glossary_status_line" ]]; then
+    fail "$GLOSSARY missing **Status:** header line"
+    GLOSSARY_AUTHORED=0
+  elif echo "$glossary_status_line" | grep -qE '^\*\*Status:\*\* SCAFFOLDED'; then
+    GLOSSARY_AUTHORED=0
+  elif echo "$glossary_status_line" | grep -qE '^\*\*Status:\*\* AUTHORED\. Last reconciled: [0-9]{4}-[0-9]{2}-[0-9]{2} against v1 commit `[0-9a-f]{7,40}`\.[[:space:]]*$'; then
+    GLOSSARY_AUTHORED=1
+  else
+    fail "$GLOSSARY **Status:** header malformed; expected exactly 'SCAFFOLDED.' or 'AUTHORED. Last reconciled: YYYY-MM-DD against v1 commit \`<sha>\`.' (got: $glossary_status_line)"
+    GLOSSARY_AUTHORED=0
+  fi
+
+  if [[ "${GLOSSARY_AUTHORED:-0}" == "1" ]]; then
+    # GL-2: no placeholder/pending markers.
+    GL2_PATTERNS=(
+      '_(pending)_'
+      '_(definitions pending)_'
+      '_(definitions pending content authoring'
+      '_(pending content authoring)_'
+    )
+    for pat in "${GL2_PATTERNS[@]}"; do
+      if grep -qF "$pat" "$GLOSSARY"; then
+        fail "$GLOSSARY still contains placeholder marker '$pat'"
+      fi
+    done
+  fi
+
+  # GL-3: anchor resolution against inventory, journeys, integrations (always).
+  # Build per-target anchor sets, then walk the glossary and emit a violation
+  # per orphan link. Mirrors JL-7's awk pattern but keyed on three target docs.
+  # If a target doc is absent on disk, its anchor set stays empty — links
+  # into it will report as orphan, which is the desired behavior (the
+  # glossary cannot point at a doc the docset omits).
+  gl3_target_files=()
+  [[ -f "$INVENTORY" ]]    && gl3_target_files+=("$INVENTORY")
+  [[ -f "$JOURNEYS" ]]     && gl3_target_files+=("$JOURNEYS")
+  [[ -f "$INTEGRATIONS" ]] && gl3_target_files+=("$INTEGRATIONS")
+  gl3_violations=$(awk '
+    function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }
+    function to_anchor(s,   a) {
+      a = tolower(s)
+      gsub(/[ \t]+/, "-", a)
+      gsub(/[^a-z0-9_-]/, "", a)
+      return a
+    }
+    # Pass 1..3: collect anchors per target file. FILENAME tracks which file
+    # is currently being read; we tag anchors with a target prefix.
+    FNR == 1 {
+      f = FILENAME
+      if (f ~ /v1-pages-inventory\.md$/)            { TARGET = "INV" }
+      else if (f ~ /v1-user-journeys\.md$/)         { TARGET = "JRN" }
+      else if (f ~ /v1-integrations-and-exports\.md$/) { TARGET = "ITG" }
+      else if (f ~ /v1-glossary\.md$/)              { TARGET = "GLS" }
+      else                                           { TARGET = "OTHER" }
+    }
+    # Pre-glossary passes: collect anchors.
+    TARGET != "GLS" {
+      if ($0 ~ /^#+ /) {
+        h = $0
+        sub(/^#+[[:space:]]*/, "", h)
+        ANCHORS[TARGET, to_anchor(trim(h))] = 1
+      }
+      line = $0
+      while (match(line, /<a id="[^"]+"/)) {
+        a = substr(line, RSTART + 7, RLENGTH - 8)
+        ANCHORS[TARGET, a] = 1
+        line = substr(line, RSTART + RLENGTH)
+      }
+      next
+    }
+    # Glossary pass: resolve outbound links.
+    TARGET == "GLS" {
+      line = $0
+      while (match(line, /\(v1-pages-inventory\.md#[^)]+\)/)) {
+        link = substr(line, RSTART, RLENGTH)
+        anchor = substr(link, 24, length(link) - 24)
+        if (!(("INV", anchor) in ANCHORS)) {
+          print FILENAME ":" FNR ": GL-3: anchor \"" anchor "\" not found in v1-pages-inventory.md"
+        }
+        line = substr(line, RSTART + RLENGTH)
+      }
+      line = $0
+      while (match(line, /\(v1-user-journeys\.md#[^)]+\)/)) {
+        link = substr(line, RSTART, RLENGTH)
+        # "(v1-user-journeys.md#" is 21 chars; anchor starts at char 22.
+        anchor = substr(link, 22, length(link) - 22)
+        if (!(("JRN", anchor) in ANCHORS)) {
+          print FILENAME ":" FNR ": GL-3: anchor \"" anchor "\" not found in v1-user-journeys.md"
+        }
+        line = substr(line, RSTART + RLENGTH)
+      }
+      line = $0
+      while (match(line, /\(v1-integrations-and-exports\.md#[^)]+\)/)) {
+        link = substr(line, RSTART, RLENGTH)
+        # "(v1-integrations-and-exports.md#" is 32 chars; anchor starts at char 33.
+        anchor = substr(link, 33, length(link) - 33)
+        if (!(("ITG", anchor) in ANCHORS)) {
+          print FILENAME ":" FNR ": GL-3: anchor \"" anchor "\" not found in v1-integrations-and-exports.md"
+        }
+        line = substr(line, RSTART + RLENGTH)
+      }
+    }
+  ' "${gl3_target_files[@]}" "$GLOSSARY")
+  if [[ -n "$gl3_violations" ]]; then
+    while IFS= read -r line; do fail "$line"; done <<< "$gl3_violations"
   fi
 fi
 

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -1268,6 +1268,466 @@ p.write_text(text)
 PY
 assert_exit "JL-7: valid ../blob/<branch> anchor passes" 0 "$STRUCTURE" --dir "$TEST_DIR/jl7-blob-valid"
 
+# =====================================================================
+# v1-glossary.md checks (#105)
+# =====================================================================
+#
+# GL-1: status header form — "**Status:** SCAFFOLDED" prefix gates block-level
+#       checks off; "**Status:** AUTHORED. Last reconciled: YYYY-MM-DD against
+#       v1 commit `<sha>`." (exact form) gates them on; missing or malformed
+#       fails. Mirrors JL-1.
+# GL-2: when AUTHORED, no placeholder/pending markers remain — `_(pending)_`,
+#       `_(definitions pending)_`, `_(definitions pending content authoring;`,
+#       `_(pending content authoring)_`. Anything that announces itself as
+#       not-yet-authored.
+# GL-3: every link from the glossary to v1-pages-inventory.md#anchor,
+#       v1-user-journeys.md#anchor, or v1-integrations-and-exports.md#anchor
+#       resolves against an existing heading or explicit <a id> in the target
+#       doc. Always-on, mirrors JL-7. The integrations doc is permitted as a
+#       link target only when present; absent, glossary links into it must
+#       not exist (the glossary cannot point at a doc the docset omits).
+
+write_glossary_inventory() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# v1 Pages Inventory
+
+## Super-Admin
+
+<a id="super-admin-top-level"></a>
+### top-level (elitecare/urls.py)
+
+## Agency Admin
+
+### dashboard
+### employees
+### auth_service
+### billing
+### charting
+### clients
+
+## Care Manager
+
+### care_manager
+
+## Caregiver
+
+### caregiver_dashboard
+
+## Client
+
+<a id="client-section"></a>
+
+## Family Member
+
+### dashboard
+
+## Shared routes
+
+EOF
+}
+
+write_glossary_journeys() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# V1 User Journeys
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Super-Admin
+
+### View-As impersonation with audit trail
+A Super-Admin starts a View-As session.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#super-admin-top-level) — does thing.
+
+**Side effects:**
+- DB: writes a row.
+
+### Agency management — capability administration and View-As kill switch
+A Super-Admin manages.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#super-admin-top-level) — does thing.
+
+**Side effects:**
+- DB: writes a row.
+
+## Agency Admin
+
+### J1
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#dashboard) — x.
+
+**Side effects:**
+- DB: y.
+
+### J2
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#dashboard) — x.
+
+**Side effects:**
+- DB: y.
+
+### J3
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#dashboard) — x.
+
+**Side effects:**
+- DB: y.
+
+### J4
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#dashboard) — x.
+
+**Side effects:**
+- DB: y.
+
+### J5
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#employees) — x.
+
+**Side effects:**
+- DB: y.
+
+## Care Manager
+
+### Team oversight — caseload action queue and field-expense submission
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#care_manager) — x.
+
+**Side effects:**
+- DB: y.
+
+### J2
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#care_manager) — x.
+
+**Side effects:**
+- DB: y.
+
+## Caregiver
+
+### J1
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#caregiver_dashboard) — x.
+
+**Side effects:**
+- DB: y.
+
+### J2
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#caregiver_dashboard) — x.
+
+**Side effects:**
+- DB: y.
+
+### J3
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#caregiver_dashboard) — x.
+
+**Side effects:**
+- DB: y.
+
+### J4
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#caregiver_dashboard) — x.
+
+**Side effects:**
+- DB: y.
+
+## Client
+
+### J1
+v1 has no Client-as-actor surface — see [the Client section](v1-pages-inventory.md#client-section).
+
+**Route trace:**
+1. v1 has no Client-authenticated route for this journey.
+
+**Side effects:**
+- DB: n/a — no Client-authenticated v1 surface.
+
+### J2
+v1 has no Client-as-actor surface — see [the Client section](v1-pages-inventory.md#client-section).
+
+**Route trace:**
+1. v1 has no Client-authenticated route for this journey.
+
+**Side effects:**
+- DB: n/a — no Client-authenticated v1 surface.
+
+## Family Member
+
+### J1
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#family-member) — x.
+
+**Side effects:**
+- DB: y.
+
+### J2
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#family-member) — x.
+
+**Side effects:**
+- DB: y.
+
+### J3
+Lead.
+
+**Route trace:**
+1. [a](v1-pages-inventory.md#family-member) — x.
+
+**Side effects:**
+- DB: y.
+EOF
+}
+
+# A glossary-shaped integrations doc the script's existing CL/SL/EL checks
+# also tolerate — minimal entries, valid schema; only used as a link target
+# for GL-3 anchor resolution.
+write_glossary_integrations() {
+  local path="$1"
+  cat > "$path" <<EOF
+# V1 Integrations and Exports
+
+## Schema
+
+table.
+
+## External integrations
+
+### Billing and payments
+
+$INTEGRATIONS_HEADER
+$INTEGRATIONS_SEP
+| QuickBooks Online | Intuit | OAuth | outbound; sync | _no UI surface — operator-only_ | Sees: nothing. | missing | H |
+
+### Payroll
+### Accounting
+### Messaging and notifications (third-party)
+
+$INTEGRATIONS_HEADER
+$INTEGRATIONS_SEP
+| Magic-link login email | internal | User submits form | outbound; sync | _no UI surface — operator-only_ | Sees: link in inbox. | missing | D |
+
+### Identity, auth, and SSO (third-party)
+### Other
+
+## Internal notification and email backend
+
+### Email pipeline
+
+$INTEGRATIONS_HEADER
+$INTEGRATIONS_SEP
+| Overpayment consent request | internal | Recovery initiated | outbound; sync | _no UI surface — operator-only_ | Sees: consent link. | missing | H |
+
+## Customer-facing exports
+
+## Cross-references
+EOF
+}
+
+write_authored_glossary() {
+  local path="$1"
+  cat > "$path" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Entries
+
+- **`elitecare`** — v1 Django project root. See [the Agency Admin top-level routes](v1-pages-inventory.md#dashboard).
+- **`MagicLinkToken`** — v1 model. See [the magic-link login email entry](v1-integrations-and-exports.md#email-pipeline).
+- **View-As impersonation** — v1 platform-operator surface. See [the View-As journey](v1-user-journeys.md#view-as-impersonation-with-audit-trail).
+EOF
+}
+
+echo ""
+echo "-- v1-glossary.md (#105) --"
+
+# --- Pass: SCAFFOLDED status skips block-level gates ---
+mkdir -p "$TEST_DIR/glossary-scaffolded"
+write_glossary_inventory "$TEST_DIR/glossary-scaffolded/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/glossary-scaffolded/v1-functionality-delta.md"
+cat > "$TEST_DIR/glossary-scaffolded/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** SCAFFOLDED. Entries are pending authoring.
+
+## Pending entries
+
+- **`elitecare`** — pending.
+
+_(definitions pending content authoring; each will resolve to one-line text + first-use link)_
+EOF
+assert_exit "GL: SCAFFOLDED status skips GL-2, passes" 0 "$STRUCTURE" --dir "$TEST_DIR/glossary-scaffolded"
+
+# --- Pass: fully AUTHORED glossary ---
+mkdir -p "$TEST_DIR/glossary-good"
+write_glossary_inventory "$TEST_DIR/glossary-good/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/glossary-good/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/glossary-good/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/glossary-good/v1-integrations-and-exports.md"
+write_authored_glossary "$TEST_DIR/glossary-good/v1-glossary.md"
+assert_exit "GL: AUTHORED glossary with all checks satisfied passes" 0 "$STRUCTURE" --dir "$TEST_DIR/glossary-good"
+
+# --- GL-1: missing status line ---
+mkdir -p "$TEST_DIR/gl1-missing"
+write_glossary_inventory "$TEST_DIR/gl1-missing/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl1-missing/v1-functionality-delta.md"
+cat > "$TEST_DIR/gl1-missing/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+## Entries
+
+- **`elitecare`** — v1 Django project root.
+EOF
+assert_exit "GL-1: missing **Status:** header fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl1-missing"
+
+# --- GL-1: malformed status line ---
+mkdir -p "$TEST_DIR/gl1-bad"
+write_glossary_inventory "$TEST_DIR/gl1-bad/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl1-bad/v1-functionality-delta.md"
+cat > "$TEST_DIR/gl1-bad/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED maybe.
+
+## Entries
+
+- **`elitecare`** — v1 Django project root.
+EOF
+assert_exit "GL-1: malformed **Status:** header fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl1-bad"
+
+# --- GL-2: AUTHORED with `_(pending)_` marker fails ---
+mkdir -p "$TEST_DIR/gl2-pending"
+write_glossary_inventory "$TEST_DIR/gl2-pending/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl2-pending/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/gl2-pending/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/gl2-pending/v1-integrations-and-exports.md"
+cat > "$TEST_DIR/gl2-pending/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Entries
+
+- **`elitecare`** — v1 Django project root.
+
+## Cross-cutting v1 conventions
+
+_(pending)_
+EOF
+assert_exit "GL-2: AUTHORED with '_(pending)_' marker fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl2-pending"
+
+# --- GL-2: AUTHORED with `_(definitions pending)_` marker fails ---
+mkdir -p "$TEST_DIR/gl2-defs-pending"
+write_glossary_inventory "$TEST_DIR/gl2-defs-pending/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl2-defs-pending/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/gl2-defs-pending/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/gl2-defs-pending/v1-integrations-and-exports.md"
+cat > "$TEST_DIR/gl2-defs-pending/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Entries
+
+- **`elitecare`** — v1 Django project root.
+
+_(definitions pending content authoring; each will resolve to one-line text + first-use link)_
+EOF
+assert_exit "GL-2: AUTHORED with '_(definitions pending)_' marker fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl2-defs-pending"
+
+# --- GL-3: AUTHORED with link to nonexistent inventory anchor fails ---
+mkdir -p "$TEST_DIR/gl3-bad-inventory"
+write_glossary_inventory "$TEST_DIR/gl3-bad-inventory/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl3-bad-inventory/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/gl3-bad-inventory/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/gl3-bad-inventory/v1-integrations-and-exports.md"
+cat > "$TEST_DIR/gl3-bad-inventory/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Entries
+
+- **`elitecare`** — v1 Django project root. See [a section](v1-pages-inventory.md#nonexistent-anchor).
+EOF
+assert_exit "GL-3: orphan inventory anchor fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl3-bad-inventory"
+
+# --- GL-3: AUTHORED with link to nonexistent journeys anchor fails ---
+mkdir -p "$TEST_DIR/gl3-bad-journeys"
+write_glossary_inventory "$TEST_DIR/gl3-bad-journeys/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl3-bad-journeys/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/gl3-bad-journeys/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/gl3-bad-journeys/v1-integrations-and-exports.md"
+cat > "$TEST_DIR/gl3-bad-journeys/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Entries
+
+- **View-As impersonation** — v1 platform-operator surface. See [the View-As journey](v1-user-journeys.md#nonexistent-journey).
+EOF
+assert_exit "GL-3: orphan journeys anchor fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl3-bad-journeys"
+
+# --- GL-3: AUTHORED with link to nonexistent integrations anchor fails ---
+mkdir -p "$TEST_DIR/gl3-bad-integrations"
+write_glossary_inventory "$TEST_DIR/gl3-bad-integrations/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl3-bad-integrations/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/gl3-bad-integrations/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/gl3-bad-integrations/v1-integrations-and-exports.md"
+cat > "$TEST_DIR/gl3-bad-integrations/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Entries
+
+- **`MagicLinkToken`** — v1 model. See [the magic-link login email entry](v1-integrations-and-exports.md#nonexistent-section).
+EOF
+assert_exit "GL-3: orphan integrations anchor fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl3-bad-integrations"
+
+# --- GL-3: AUTHORED with valid anchors across all three docs passes ---
+# (Already covered by glossary-good above; listed for symmetry.)
+mkdir -p "$TEST_DIR/gl3-all-good"
+write_glossary_inventory "$TEST_DIR/gl3-all-good/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl3-all-good/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/gl3-all-good/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/gl3-all-good/v1-integrations-and-exports.md"
+write_authored_glossary "$TEST_DIR/gl3-all-good/v1-glossary.md"
+assert_exit "GL-3: valid anchors across inventory + journeys + integrations passes" 0 "$STRUCTURE" --dir "$TEST_DIR/gl3-all-good"
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [[ "$FAIL" == 0 ]] || exit 1

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -1667,6 +1667,49 @@ _(definitions pending content authoring; each will resolve to one-line text + fi
 EOF
 assert_exit "GL-2: AUTHORED with '_(definitions pending)_' marker fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl2-defs-pending"
 
+# --- GL-2: AUTHORED with `_(definitions pending content authoring` substring fails ---
+# Note the substring shape — script's pattern array deliberately matches the
+# scaffold suffix without requiring a closing `_`, so any partial-author
+# placeholder of this shape is caught.
+mkdir -p "$TEST_DIR/gl2-defs-authoring-substr"
+write_glossary_inventory "$TEST_DIR/gl2-defs-authoring-substr/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl2-defs-authoring-substr/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/gl2-defs-authoring-substr/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/gl2-defs-authoring-substr/v1-integrations-and-exports.md"
+cat > "$TEST_DIR/gl2-defs-authoring-substr/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Entries
+
+- **`elitecare`** — v1 Django project root.
+
+_(definitions pending content authoring; partial draft)_
+EOF
+assert_exit "GL-2: AUTHORED with '_(definitions pending content authoring' substring fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl2-defs-authoring-substr"
+
+# --- GL-2: AUTHORED with `_(pending content authoring)_` marker fails ---
+mkdir -p "$TEST_DIR/gl2-pending-authoring"
+write_glossary_inventory "$TEST_DIR/gl2-pending-authoring/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/gl2-pending-authoring/v1-functionality-delta.md"
+write_glossary_journeys "$TEST_DIR/gl2-pending-authoring/v1-user-journeys.md"
+write_glossary_integrations "$TEST_DIR/gl2-pending-authoring/v1-integrations-and-exports.md"
+cat > "$TEST_DIR/gl2-pending-authoring/v1-glossary.md" <<'EOF'
+# V1 Glossary
+
+**Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
+
+## Entries
+
+- **`elitecare`** — v1 Django project root.
+
+## Cross-cutting v1 conventions
+
+_(pending content authoring)_
+EOF
+assert_exit "GL-2: AUTHORED with '_(pending content authoring)_' marker fails" 1 "$STRUCTURE" --dir "$TEST_DIR/gl2-pending-authoring"
+
 # --- GL-3: AUTHORED with link to nonexistent inventory anchor fails ---
 mkdir -p "$TEST_DIR/gl3-bad-inventory"
 write_glossary_inventory "$TEST_DIR/gl3-bad-inventory/v1-pages-inventory.md"


### PR DESCRIPTION
## Summary

- Replaces the placeholder bullet list in `docs/migration/v1-glossary.md` with 24 alphabetical, present-tense one-line entries; each carries a first-use anchor into `v1-pages-inventory.md`, `v1-user-journeys.md`, or `v1-integrations-and-exports.md`. Cross-cutting conventions section populated with the audit-gap clustering pattern surfaced across the docset. Status flipped from `SCAFFOLDED` to `AUTHORED` against pinned v1 commit `9738412`. Stable `<a id>` anchors added on the load-bearing v1-vs-v2 boundary entries (`client-v1-vs-v2`, `magiclinktoken`, `rls-bypass-surface`, `view-as-impersonation`).
- Extends `scripts/check-v1-doc-structure.sh` with three new gates — GL-1 (status-header form), GL-2 (placeholder/pending-marker scan), GL-3 (anchor resolution against inventory, journeys, and integrations). Closes the QA-flagged gap that the issue's API/Endpoint test would otherwise pass vacuously. Self-tests added in `scripts/tests/test_check_v1_doc_structure.sh` (10 new cases, positive + negative) following the existing JL-fixture style.
- `docs/migration/README.md` refresh runbook gains a glossary anchor re-resolution step (main runbook step 5) and a `ClientFamilyMember`-schema-shift callout in the Family Member subsection. The glossary mirrors v1 baseline state and would otherwise drift silently between SHA bumps.

Closes #105.

## Test plan

- [x] `make test-v1-docs` — 6 + 57 = 63 self-tests pass
- [x] `bash scripts/check-v1-doc-hygiene.sh docs/migration/v1-*.md` — 0 violations
- [x] `bash scripts/check-v1-doc-structure.sh` — 0 violations (GL-1/GL-2/GL-3 fire on the authored glossary; all anchors resolve)
- [x] `make scan-v1-docs` — clean
- [x] `make -C api lint test` — green (124 passed, 3 skipped)
- [x] `make check` (full) — green locally with the CI-set `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` test value
- [ ] CI green on this PR
- [ ] Sunil PHI sign-off (per the file's existing Definition of Done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)