### PR TITLE
ci(#131): auto-post family-section diffs on V1 Reference Commit bump

### DIFF
--- a/.github/workflows/v1-sha-bump-diff-report.yml
+++ b/.github/workflows/v1-sha-bump-diff-report.yml
@@ -1,0 +1,79 @@
+# Auto-post the Family Member section diff report when a PR bumps the
+# `V1 Reference Commit` SHA in docs/migration/README.md.
+#
+# Implements the per-section refresh runbook entry added in #121 — fetches
+# the three runbook diffs (`*/urls.py`, `clients/`, `clients/models.py`)
+# from the private v1 repo across the SHA bump and posts (or updates) a
+# sticky PR comment summarizing them. See #131.
+#
+# === Setup (maintainer prerequisite, one-time) ===
+#
+# Requires a fine-grained PAT scoped to `suniljames/COREcare-access` only,
+# `Contents: Read`, 1-year expiry. Steps:
+#
+#   1. https://github.com/settings/personal-access-tokens/new
+#   2. Repository access: Only select repositories → suniljames/COREcare-access
+#   3. Repository permissions: Contents — Read-only (everything else: No access)
+#   4. Expiration: 1 year (calendar a rotation reminder)
+#   5. Generate, copy the token
+#   6. https://github.com/suniljames/COREcare-v2/settings/secrets/actions/new
+#      Name: V1_REPO_READ_TOKEN
+#      Secret: <paste>
+#
+# === Rotation ===
+#
+# Re-issue the PAT before expiration, update the V1_REPO_READ_TOKEN secret,
+# and bump the rotation date in docs/migration/README.md → "Workflow secrets".
+#
+# === Break-glass ===
+#
+# If the gate is broken (PAT expired, v1 unreachable, comment-API failure)
+# the engineer manually runs the three diffs locally per the runbook entry,
+# ack's in the PR description, and a maintainer uses branch-protection
+# bypass to merge. Do NOT silence the gate; fix it.
+
+name: V1 SHA Bump Diff Report
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/migration/README.md'
+      - 'scripts/post-v1-sha-bump-diff.sh'
+      - 'scripts/tests/test_post_v1_sha_bump_diff.sh'
+      - '.github/workflows/v1-sha-bump-diff-report.yml'
+
+concurrency:
+  group: v1-sha-bump-diff-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  scripts-self-test:
+    name: Diff-report script self-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run diff-report script tests
+        run: bash scripts/tests/test_post_v1_sha_bump_diff.sh
+
+  diff-report:
+    name: Post family-section diff report
+    runs-on: ubuntu-latest
+    needs: scripts-self-test
+    timeout-minutes: 8
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run diff-report script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V1_REPO_READ_TOKEN: ${{ secrets.V1_REPO_READ_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: bash scripts/post-v1-sha-bump-diff.sh

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ test-v1-docs: ## Run v1 doc hygiene + structure + catalog-coverage script self-t
 	bash scripts/tests/test_check_v1_doc_structure.sh
 	bash scripts/tests/test_check_v1_catalog_coverage.sh
 	bash scripts/tests/test_readme_runbook_entries.sh
+	bash scripts/tests/test_post_v1_sha_bump_diff.sh
 
 scan-v1-docs: ## Run hygiene + structure + catalog-coverage scripts over committed docs
 	@if compgen -G "docs/migration/v1-*.md" > /dev/null; then \

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -282,6 +282,27 @@ If any diff is non-empty: re-author affected rows in `v1-pages-inventory.md`. If
 
 ---
 
+## Workflow secrets
+
+CI workflows that touch the private v1 repo (`suniljames/COREcare-access`) authenticate via repo-level secrets. Maintainer-managed; engineers do not need to action these unless adding a new workflow or rotating an existing token.
+
+### `V1_REPO_READ_TOKEN`
+
+Used by `.github/workflows/v1-sha-bump-diff-report.yml` (#131) to clone v1 and run the three Family Member runbook diffs (per the runbook entry above) when a PR bumps the V1 Reference Commit SHA.
+
+- **Type:** GitHub fine-grained personal access token.
+- **Repository access:** `suniljames/COREcare-access` only — never wildcard.
+- **Repository permissions:** `Contents: Read`. Nothing else.
+- **Expiration:** 1 year. Calendar a rotation reminder when issuing.
+- **Last rotated:** 2026-05-07 (initial issuance).
+- **Stored at:** repo Actions secrets, name `V1_REPO_READ_TOKEN`.
+
+**Rotation procedure.** Re-issue the PAT with the same scope and expiry, update the `V1_REPO_READ_TOKEN` secret in the v2 repo settings, then bump the **Last rotated** date above in the PR that records the rotation.
+
+**Break-glass.** If the diff-report gate is broken (PAT expired, v1 unreachable, comment-API failure) and a refresh PR is in flight: the engineer runs the three diffs locally per the [Family Member section runbook entry](#family-member-section--extra-diff-checks-before-re-authoring) above, documents the result in the PR description, and a maintainer uses branch-protection bypass to merge. Then file a new issue to fix the gate. Do not silence the gate; fix it.
+
+---
+
 ## Related work
 
 - **#70 (closed)** — landed `v1-functionality-delta.md` (the feature/data-model layer this set extends).

--- a/scripts/post-v1-sha-bump-diff.sh
+++ b/scripts/post-v1-sha-bump-diff.sh
@@ -241,14 +241,16 @@ main() {
   if [[ -z "$pr_num" ]]; then
     fail_loud "PR number not provided (arg or PR_NUMBER env var)."
   fi
-  if [[ -z "${V1_REPO_READ_TOKEN:-}" ]]; then
-    fail_loud "V1_REPO_READ_TOKEN secret not configured. See workflow file header for setup instructions."
-  fi
 
   echo "Reading PR README diff for PR #${pr_num}…"
   local readme_diff
   readme_diff=$(gh pr diff "$pr_num" -- docs/migration/README.md) \
     || fail_loud "Failed to read PR diff via gh."
+
+  if [[ -z "$readme_diff" ]]; then
+    echo "docs/migration/README.md unchanged in this PR — nothing to report."
+    return 0
+  fi
 
   local commit_sha_lines
   commit_sha_lines=$(printf '%s\n' "$readme_diff" \
@@ -265,17 +267,19 @@ main() {
   read -r OLD_SHA NEW_SHA <<<"$bump"
   echo "SHA bump: ${OLD_SHA:0:7}..${NEW_SHA:0:7}"
 
+  if [[ -z "${V1_REPO_READ_TOKEN:-}" ]]; then
+    fail_loud "V1_REPO_READ_TOKEN secret not configured. See workflow file header for setup instructions."
+  fi
+
   local v1_dir
   v1_dir=$(mktemp -d)
   trap 'rm -rf "$v1_dir"' EXIT
 
   echo "Cloning v1 (filter=blob:none, no-checkout) → $v1_dir"
+  echo "  git clone --filter=blob:none --no-checkout https://x-access-token:***@github.com/suniljames/COREcare-access.git"
   git clone --filter=blob:none --no-checkout --quiet \
-    "https://x-access-token:***@github.com/suniljames/COREcare-access.git" \
-    "$v1_dir" 2>/dev/null \
-    || git clone --filter=blob:none --no-checkout --quiet \
-      "https://x-access-token:${V1_REPO_READ_TOKEN}@github.com/suniljames/COREcare-access.git" \
-      "$v1_dir" \
+    "https://x-access-token:${V1_REPO_READ_TOKEN}@github.com/suniljames/COREcare-access.git" \
+    "$v1_dir" \
     || fail_loud "Failed to clone v1 repo. Check V1_REPO_READ_TOKEN scope and validity."
 
   echo "Fetching old SHA $OLD_SHA"

--- a/scripts/post-v1-sha-bump-diff.sh
+++ b/scripts/post-v1-sha-bump-diff.sh
@@ -29,6 +29,20 @@ DIFF_CAP_BYTES=${DIFF_CAP_BYTES:-12288}
 # Marker used to find an existing comment for in-place sticky update.
 COMMENT_MARKER='<!-- v1-sha-bump-diff-report -->'
 
+# slice_pr_diff_to_readme
+# Reads a full PR diff from stdin (as `gh pr diff` emits, with one
+# `diff --git` header per file) and emits only the section for
+# docs/migration/README.md. Emits nothing when the README is not in
+# the diff. Sliced separately because `gh pr diff` does not accept a
+# `-- <path>` filter the way `git diff` does.
+slice_pr_diff_to_readme() {
+  awk '
+    /^diff --git a\/docs\/migration\/README\.md / { in_section=1; print; next }
+    /^diff --git / { in_section=0 }
+    in_section { print }
+  '
+}
+
 # extract_sha_bump
 # Reads a unified diff of docs/migration/README.md from stdin.
 # Emits "OLD_SHA NEW_SHA" if the `Commit SHA` line was bumped to a different
@@ -242,10 +256,15 @@ main() {
     fail_loud "PR number not provided (arg or PR_NUMBER env var)."
   fi
 
-  echo "Reading PR README diff for PR #${pr_num}…"
+  echo "Reading PR diff for PR #${pr_num}…"
+  local pr_diff_file
+  pr_diff_file=$(mktemp)
+  gh pr diff "$pr_num" >"$pr_diff_file" \
+    || { rm -f "$pr_diff_file"; fail_loud "Failed to read PR diff via gh."; }
+
   local readme_diff
-  readme_diff=$(gh pr diff "$pr_num" -- docs/migration/README.md) \
-    || fail_loud "Failed to read PR diff via gh."
+  readme_diff=$(slice_pr_diff_to_readme <"$pr_diff_file")
+  rm -f "$pr_diff_file"
 
   if [[ -z "$readme_diff" ]]; then
     echo "docs/migration/README.md unchanged in this PR — nothing to report."

--- a/scripts/post-v1-sha-bump-diff.sh
+++ b/scripts/post-v1-sha-bump-diff.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# Auto-post the Family Member section diff report when a PR bumps the
+# `V1 Reference Commit` SHA in docs/migration/README.md.
+#
+# Implements the per-section refresh runbook entry added in #121 — fetches
+# the three runbook diffs (`*/urls.py`, `clients/`, `clients/models.py`)
+# from the private v1 repo across the SHA bump, formats a sticky PR comment,
+# and posts (or updates) it via the GitHub API.
+#
+# Sourced by tests for unit access to the pure functions; runs main when
+# executed directly. See scripts/tests/test_post_v1_sha_bump_diff.sh.
+#
+# === Workflow secrets ===
+# Requires repo secret `V1_REPO_READ_TOKEN`: a fine-grained PAT scoped to
+# `suniljames/COREcare-access` only, `Contents: Read`, 1-year expiry.
+# Rotation: re-issue the PAT, update the repo secret, document the
+# rotation date in docs/migration/README.md ("Workflow secrets" section).
+# Break-glass: if the gate is broken, the engineer manually runs the three
+# diffs locally and ack's in the PR description; a maintainer uses
+# branch-protection bypass to merge.
+
+set -uo pipefail
+
+# Per-diff body cap (12 KB). Total comment cap protected by the per-diff
+# cap × 3 + structure overhead (~5 KB) < 60 KB << GitHub's 65,536-char
+# issue-comment limit.
+DIFF_CAP_BYTES=${DIFF_CAP_BYTES:-12288}
+
+# Marker used to find an existing comment for in-place sticky update.
+COMMENT_MARKER='<!-- v1-sha-bump-diff-report -->'
+
+# extract_sha_bump
+# Reads a unified diff of docs/migration/README.md from stdin.
+# Emits "OLD_SHA NEW_SHA" if the `Commit SHA` line was bumped to a different
+# value; emits nothing (and returns 0) otherwise. The caller distinguishes
+# bump-vs-no-op by checking whether stdout is non-empty.
+extract_sha_bump() {
+  local diff old new
+  diff=$(cat)
+  old=$(printf '%s\n' "$diff" \
+    | grep -E '^-\s*-\s*\*\*Commit SHA:\*\*\s*`[0-9a-f]+`' \
+    | head -1 \
+    | grep -oE '`[0-9a-f]+`' \
+    | tr -d '`' || true)
+  new=$(printf '%s\n' "$diff" \
+    | grep -E '^\+\s*-\s*\*\*Commit SHA:\*\*\s*`[0-9a-f]+`' \
+    | head -1 \
+    | grep -oE '`[0-9a-f]+`' \
+    | tr -d '`' || true)
+  if [[ -n "$old" && -n "$new" && "$old" != "$new" ]]; then
+    printf '%s %s\n' "$old" "$new"
+  fi
+}
+
+# format_stats_row <unified-diff>
+# Emits "<files> <plus> <minus>" counts for a unified diff.
+format_stats_row() {
+  local diff="$1"
+  local files=0 plus=0 minus=0
+  if [[ -n "$diff" ]]; then
+    files=$(printf '%s\n' "$diff" | grep -c '^diff --git ' || true)
+    plus=$(printf '%s\n' "$diff" | grep -cE '^\+[^+]|^\+$' || true)
+    minus=$(printf '%s\n' "$diff" | grep -cE '^-[^-]|^-$' || true)
+  fi
+  printf '%s %s %s\n' "$files" "$plus" "$minus"
+}
+
+# detect_permission_gate <diff>
+# Returns 0 (true) when the diff hits any of the runbook's permission-gate
+# signals: the canonical helper `_check_client_access` (anywhere in the
+# diff including context lines, so a body-change inside the helper is
+# caught), the `is_family` body-check pattern on a +/- line, or the
+# `{% if is_family %}` template-tag pattern. The runbook is explicit that
+# these are example signals, not a fixed contract.
+detect_permission_gate() {
+  local diff="$1"
+  printf '%s\n' "$diff" \
+    | grep -qE '_check_client_access|^[-+].*\bis_family|\{%\s*if\s+is_family'
+}
+
+# detect_fingerprint_match <models-diff>
+# Returns 0 (true) when the clients/models.py diff mentions
+# `ClientFamilyMember` AND a +/- line carries one of the runbook's
+# baseline-invariant tokens: is_active, deleted_at, expires_at, role,
+# permission. Surfaces the row that breaks the runbook's fingerprint.
+detect_fingerprint_match() {
+  local diff="$1"
+  if ! printf '%s\n' "$diff" | grep -q 'ClientFamilyMember'; then
+    return 1
+  fi
+  printf '%s\n' "$diff" \
+    | grep -qE '^[-+].*\b(is_active|deleted_at|expires_at|role|permission)\b'
+}
+
+# truncate_diff <diff>
+# Truncates a unified diff at DIFF_CAP_BYTES and appends the runbook-
+# voiced banner with a copy-pasteable local rerun command. Variables
+# OLD_SHA, NEW_SHA, TRUNCATE_PATHSPEC must be set in the caller's scope.
+truncate_diff() {
+  local diff="$1"
+  local size cut remaining
+  size=${#diff}
+  if (( size <= DIFF_CAP_BYTES )); then
+    printf '%s' "$diff"
+    return
+  fi
+  cut="${diff:0:DIFF_CAP_BYTES}"
+  remaining=$(( size - DIFF_CAP_BYTES ))
+  printf '%s\n\n… %s more bytes truncated. Run locally:\n' "$cut" "$remaining"
+  printf 'git -C <v1-checkout> diff %s..%s -- %s\n' \
+    "${OLD_SHA:-<old>}" "${NEW_SHA:-<new>}" "${TRUNCATE_PATHSPEC:-<pathspec>}"
+}
+
+# format_comment OLD NEW URLS_DIFF CLIENTS_DIFF MODELS_DIFF [WORKFLOW_RUN_URL]
+# Emits the full PR comment body to stdout, including the sticky marker,
+# the hidden machine-parseable stats line, the action call-to-action with
+# only the active branch bolded, the stats table, the optional fingerprint
+# callout, and three collapsed `<details>` blocks. The phrase "silent drift"
+# appears at least once.
+format_comment() {
+  local old="$1" new="$2"
+  local urls_diff="$3" clients_diff="$4" models_diff="$5"
+  local run_url="${6:-}"
+
+  local urls_stats clients_stats models_stats
+  urls_stats=$(format_stats_row "$urls_diff")
+  clients_stats=$(format_stats_row "$clients_diff")
+  models_stats=$(format_stats_row "$models_diff")
+
+  local urls_files urls_plus urls_minus
+  read -r urls_files urls_plus urls_minus <<<"$urls_stats"
+  local clients_files clients_plus clients_minus
+  read -r clients_files clients_plus clients_minus <<<"$clients_stats"
+  local models_files models_plus models_minus
+  read -r models_files models_plus models_minus <<<"$models_stats"
+
+  local total=$(( urls_files + clients_files + models_files ))
+  local action_branch="empty"
+  if (( total > 0 )); then
+    if detect_permission_gate "$clients_diff"; then
+      action_branch="permission"
+    else
+      action_branch="reauthor"
+    fi
+  fi
+
+  local fingerprint_callout=""
+  if detect_fingerprint_match "$models_diff"; then
+    fingerprint_callout=$'\n> **Baseline fingerprint match.** The `clients/models.py` diff touches a `ClientFamilyMember` invariant token (one of `is_active`, `deleted_at`, `expires_at`, `role`, `permission`). v1 has changed a previously-stable property of the model — re-author the rows that depend on it.\n'
+  fi
+
+  local action_block
+  case "$action_branch" in
+    empty)
+      action_block=$'**All diffs empty.** No relevant v1 changes detected for the Family Member section.\n\n**Action: bump `last reconciled` only.**\n\n~~Action: re-author affected rows~~\n~~Action: re-author + flag `CUTOVER_PLAN.md` owners~~'
+      ;;
+    permission)
+      action_block=$'**Action: re-author + flag `CUTOVER_PLAN.md` owners.** Permission gate `_check_client_access` changed in this bump — v2 RLS may need to mirror the v1 change.\n\n~~Action: re-author affected rows~~\n~~Action: bump `last reconciled` only~~'
+      ;;
+    reauthor)
+      action_block=$'**Action: re-author affected rows.** Update `docs/migration/v1-pages-inventory.md` Family Member rows for routes / serializers / templates surfaced below.\n\n~~Action: re-author + flag `CUTOVER_PLAN.md` owners~~\n~~Action: bump `last reconciled` only~~'
+      ;;
+  esac
+
+  local short_old="${old:0:7}" short_new="${new:0:7}"
+
+  local urls_block clients_block models_block
+  OLD_SHA="$old" NEW_SHA="$new" TRUNCATE_PATHSPEC="'*/urls.py'" \
+    urls_block=$(truncate_diff "$urls_diff")
+  OLD_SHA="$old" NEW_SHA="$new" TRUNCATE_PATHSPEC="'clients/'" \
+    clients_block=$(truncate_diff "$clients_diff")
+  OLD_SHA="$old" NEW_SHA="$new" TRUNCATE_PATHSPEC="'clients/models.py'" \
+    models_block=$(truncate_diff "$models_diff")
+
+  cat <<COMMENT
+$COMMENT_MARKER
+<!-- diff-stats: urls=${urls_files},+${urls_plus},-${urls_minus}; clients=${clients_files},+${clients_plus},-${clients_minus}; models=${models_files},+${models_plus},-${models_minus} -->
+
+**V1 Reference Commit bumped:** \`${short_old}..${short_new}\`. Family Member section diff report below.
+
+This is the automated **silent drift** check from the [Family Member refresh runbook](../blob/main/docs/migration/README.md#family-member-section--extra-diff-checks-before-re-authoring).
+
+### Action
+
+${action_block}
+${fingerprint_callout}
+### Stats
+
+| Diff target | Files | +lines | −lines |
+|---|---:|---:|---:|
+| \`*/urls.py\` | ${urls_files} | ${urls_plus} | ${urls_minus} |
+| \`clients/\` | ${clients_files} | ${clients_plus} | ${clients_minus} |
+| \`clients/models.py\` | ${models_files} | ${models_plus} | ${models_minus} |
+
+### Diffs
+
+<details><summary><code>git diff ${short_old}..${short_new} -- '*/urls.py'</code></summary>
+
+\`\`\`diff
+${urls_block:-(empty)}
+\`\`\`
+
+</details>
+
+<details><summary><code>git diff ${short_old}..${short_new} -- 'clients/'</code></summary>
+
+\`\`\`diff
+${clients_block:-(empty)}
+\`\`\`
+
+</details>
+
+<details><summary><code>git diff ${short_old}..${short_new} -- 'clients/models.py'</code></summary>
+
+\`\`\`diff
+${models_block:-(empty)}
+\`\`\`
+
+</details>
+
+---
+
+${run_url:+Workflow run: ${run_url}}
+COMMENT
+}
+
+# fail_loud <message>
+# Print a clearly-marked failure message and exit 1. Used for fail-closed
+# semantics on missing secrets, fetch failures, and API errors.
+fail_loud() {
+  printf '\n!!! v1-sha-bump-diff-report: %s\n' "$1" >&2
+  exit 1
+}
+
+# main "$@"
+# Production entry point. Runs in the GitHub Actions environment with
+# GITHUB_REPOSITORY, GITHUB_BASE_REF, GITHUB_TOKEN, V1_REPO_READ_TOKEN,
+# and a PR number passed as the first arg (or via $PR_NUMBER).
+main() {
+  local pr_num="${1:-${PR_NUMBER:-}}"
+  if [[ -z "$pr_num" ]]; then
+    fail_loud "PR number not provided (arg or PR_NUMBER env var)."
+  fi
+  if [[ -z "${V1_REPO_READ_TOKEN:-}" ]]; then
+    fail_loud "V1_REPO_READ_TOKEN secret not configured. See workflow file header for setup instructions."
+  fi
+
+  echo "Reading PR README diff for PR #${pr_num}…"
+  local readme_diff
+  readme_diff=$(gh pr diff "$pr_num" -- docs/migration/README.md) \
+    || fail_loud "Failed to read PR diff via gh."
+
+  local commit_sha_lines
+  commit_sha_lines=$(printf '%s\n' "$readme_diff" \
+    | grep -E '^[-+]\s*-\s*\*\*Commit SHA:\*\*' || true)
+  echo "Commit SHA lines in README diff:"
+  printf '  %s\n' "${commit_sha_lines:-(none)}"
+
+  local bump
+  bump=$(printf '%s\n' "$readme_diff" | extract_sha_bump)
+  if [[ -z "$bump" ]]; then
+    echo "no SHA bump in this PR — skipping diff report."
+    return 0
+  fi
+  read -r OLD_SHA NEW_SHA <<<"$bump"
+  echo "SHA bump: ${OLD_SHA:0:7}..${NEW_SHA:0:7}"
+
+  local v1_dir
+  v1_dir=$(mktemp -d)
+  trap 'rm -rf "$v1_dir"' EXIT
+
+  echo "Cloning v1 (filter=blob:none, no-checkout) → $v1_dir"
+  git clone --filter=blob:none --no-checkout --quiet \
+    "https://x-access-token:***@github.com/suniljames/COREcare-access.git" \
+    "$v1_dir" 2>/dev/null \
+    || git clone --filter=blob:none --no-checkout --quiet \
+      "https://x-access-token:${V1_REPO_READ_TOKEN}@github.com/suniljames/COREcare-access.git" \
+      "$v1_dir" \
+    || fail_loud "Failed to clone v1 repo. Check V1_REPO_READ_TOKEN scope and validity."
+
+  echo "Fetching old SHA $OLD_SHA"
+  git -C "$v1_dir" fetch --quiet origin "$OLD_SHA" \
+    || fail_loud "Failed to fetch OLD_SHA ($OLD_SHA) from v1. Verify the SHA exists in suniljames/COREcare-access."
+  echo "Fetching new SHA $NEW_SHA"
+  git -C "$v1_dir" fetch --quiet origin "$NEW_SHA" \
+    || fail_loud "Failed to fetch NEW_SHA ($NEW_SHA) from v1. Verify the SHA exists in suniljames/COREcare-access."
+
+  local urls_diff clients_diff models_diff
+  echo "Diffing '*/urls.py'"
+  urls_diff=$(git -C "$v1_dir" diff "$OLD_SHA..$NEW_SHA" -- '*/urls.py' || true)
+  echo "  $(format_stats_row "$urls_diff")"
+  echo "Diffing 'clients/'"
+  clients_diff=$(git -C "$v1_dir" diff "$OLD_SHA..$NEW_SHA" -- 'clients/' || true)
+  echo "  $(format_stats_row "$clients_diff")"
+  echo "Diffing 'clients/models.py'"
+  models_diff=$(git -C "$v1_dir" diff "$OLD_SHA..$NEW_SHA" -- 'clients/models.py' || true)
+  echo "  $(format_stats_row "$models_diff")"
+
+  local run_url=""
+  if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+    run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  fi
+
+  local body
+  body=$(format_comment "$OLD_SHA" "$NEW_SHA" "$urls_diff" "$clients_diff" "$models_diff" "$run_url")
+
+  post_or_update_comment "$pr_num" "$body"
+}
+
+# post_or_update_comment <pr-num> <body>
+# Find an existing sticky comment by marker; PATCH if found, POST otherwise.
+# One retry on transient failure, then fail_loud with the API error body.
+post_or_update_comment() {
+  local pr_num="$1" body="$2"
+  local repo="${GITHUB_REPOSITORY:-}"
+  if [[ -z "$repo" ]]; then
+    fail_loud "GITHUB_REPOSITORY not set; cannot identify the API target."
+  fi
+
+  local existing_id
+  existing_id=$(gh api "repos/${repo}/issues/${pr_num}/comments" --paginate \
+    --jq ".[] | select(.body | startswith(\"${COMMENT_MARKER}\")) | .id" \
+    | head -1 || true)
+
+  local body_file
+  body_file=$(mktemp)
+  printf '%s' "$body" >"$body_file"
+
+  local attempt=1
+  while (( attempt <= 2 )); do
+    if [[ -n "$existing_id" ]]; then
+      echo "Updating existing comment $existing_id"
+      if gh api -X PATCH "repos/${repo}/issues/comments/${existing_id}" \
+        -F "body=@${body_file}" >/dev/null; then
+        rm -f "$body_file"
+        return 0
+      fi
+    else
+      echo "Posting new comment on PR #${pr_num}"
+      if gh api -X POST "repos/${repo}/issues/${pr_num}/comments" \
+        -F "body=@${body_file}" >/dev/null; then
+        rm -f "$body_file"
+        return 0
+      fi
+    fi
+    if (( attempt == 1 )); then
+      echo "Comment-API call failed; retrying once after 5s backoff."
+      sleep 5
+    fi
+    attempt=$(( attempt + 1 ))
+  done
+
+  rm -f "$body_file"
+  fail_loud "Comment-API call failed twice. See log above for the API error body."
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/scripts/tests/test_post_v1_sha_bump_diff.sh
+++ b/scripts/tests/test_post_v1_sha_bump_diff.sh
@@ -292,6 +292,71 @@ assert_not_contains \
   "$no_fp_body" \
   "Baseline fingerprint match"
 
+# --- Assertion 12: slice_pr_diff_to_readme isolates the README section ---
+# Caught a real CI failure: `gh pr diff` does not accept `-- <path>` filtering,
+# so we slice the full PR diff in the script. Regression-protect that.
+
+readonly MULTI_FILE_PR_DIFF=$'diff --git a/Makefile b/Makefile
+index 1111111..2222222 100644
+--- a/Makefile
++++ b/Makefile
+@@ -52,4 +52,5 @@ test-v1-docs:
+ \tbash scripts/tests/test_check_v1_doc_hygiene.sh
++\tbash scripts/tests/test_post_v1_sha_bump_diff.sh
+diff --git a/docs/migration/README.md b/docs/migration/README.md
+index abcdef..fedcba 100644
+--- a/docs/migration/README.md
++++ b/docs/migration/README.md
+@@ -16,7 +16,7 @@
+ - **Repo:** `suniljames/COREcare-access`
+-- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
++- **Commit SHA:** `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+diff --git a/scripts/post-v1-sha-bump-diff.sh b/scripts/post-v1-sha-bump-diff.sh
+new file mode 100755
+index 0000000..3333333
+--- /dev/null
++++ b/scripts/post-v1-sha-bump-diff.sh
+@@ -0,0 +1,3 @@
++#!/usr/bin/env bash
++set -uo pipefail'
+
+readme_only=$(printf '%s\n' "$MULTI_FILE_PR_DIFF" | slice_pr_diff_to_readme)
+
+assert_contains \
+  "12a. slice extracts the README diff header" \
+  "$readme_only" \
+  "diff --git a/docs/migration/README.md b/docs/migration/README.md"
+assert_contains \
+  "12b. slice preserves the SHA-bump line" \
+  "$readme_only" \
+  "+- **Commit SHA:** \`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\`"
+assert_not_contains \
+  "12c. slice excludes the Makefile diff header" \
+  "$readme_only" \
+  "diff --git a/Makefile b/Makefile"
+assert_not_contains \
+  "12d. slice excludes the post-v1-sha-bump-diff.sh diff header" \
+  "$readme_only" \
+  "diff --git a/scripts/post-v1-sha-bump-diff.sh"
+
+# Round-trip: the sliced output should still drive extract_sha_bump correctly.
+result=$(printf '%s\n' "$readme_only" | extract_sha_bump)
+assert \
+  "12e. sliced README section feeds extract_sha_bump correctly" \
+  "[[ '$result' == '9738412a6e41064203fc253d9dd2a5c6a9c2e231 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ]]"
+
+# README absent from the PR → slice returns empty → main() short-circuits.
+no_readme_pr_diff=$'diff --git a/Makefile b/Makefile
+index 1111111..2222222 100644
+--- a/Makefile
++++ b/Makefile
+@@ -52,4 +52,5 @@ test-v1-docs:
++\tbash scripts/tests/test_new.sh'
+empty_slice=$(printf '%s\n' "$no_readme_pr_diff" | slice_pr_diff_to_readme)
+assert \
+  "12f. PR diff without README → slice returns empty (script no-ops)" \
+  "[[ -z '$empty_slice' ]]"
+
 # --- Cross-cutting assertion: 'silent drift' phrase present (Writer requirement) ---
 
 assert_contains \

--- a/scripts/tests/test_post_v1_sha_bump_diff.sh
+++ b/scripts/tests/test_post_v1_sha_bump_diff.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# Tests for scripts/post-v1-sha-bump-diff.sh — the workflow script that
+# fetches the three Family Member runbook diffs across a `V1 Reference
+# Commit` SHA bump and posts a sticky PR comment.
+#
+# Sources the script (without running main) and exercises pure functions
+# with inline fixture inputs. No real network, no real `git`/`gh` calls.
+#
+# Run from repo root: bash scripts/tests/test_post_v1_sha_bump_diff.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/post-v1-sha-bump-diff.sh"
+
+PASS=0
+FAIL=0
+
+assert() {
+  local description="$1"
+  local condition="$2"
+  if eval "$condition"; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description"
+    echo "    condition: $condition"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_contains() {
+  local description="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description"
+    echo "    expected to find: $needle"
+    echo "    in: $(printf '%s' "$haystack" | head -c 400)…"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Case-insensitive variant for behavioral signal matches where the comment's
+# capitalization is grammatical (sentence-cap) but the spec uses lowercase.
+assert_contains_ci() {
+  local description="$1" haystack="$2" needle="$3"
+  if printf '%s' "$haystack" | grep -qiF -- "$needle"; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description"
+    echo "    expected to find (case-insensitive): $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_not_contains() {
+  local description="$1" haystack="$2" needle="$3"
+  if ! printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description"
+    echo "    expected NOT to find: $needle"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+[[ -f "$SCRIPT" ]] || { echo "FAIL — script not found at $SCRIPT"; exit 1; }
+# shellcheck disable=SC1090
+source "$SCRIPT"
+
+echo "== post-v1-sha-bump-diff tests =="
+
+# --- Inline fixtures ---
+
+# Fixture: README diff that bumps the V1 Reference Commit SHA.
+readonly README_BUMP_DIFF=$'diff --git a/docs/migration/README.md b/docs/migration/README.md
+index abcdef..fedcba 100644
+--- a/docs/migration/README.md
++++ b/docs/migration/README.md
+@@ -16,7 +16,7 @@ All facts in this docset were reconciled against:
+
+ - **Repo:** `suniljames/COREcare-access`
+-- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
++- **Commit SHA:** `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+ - **Commit subject:** `feat(#1479): January annual mileage-rate verification banner (#1480)`'
+
+# Fixture: README diff with no SHA-line change (different paragraph touched).
+readonly README_NO_BUMP_DIFF=$'diff --git a/docs/migration/README.md b/docs/migration/README.md
+index abcdef..fedcba 100644
+--- a/docs/migration/README.md
++++ b/docs/migration/README.md
+@@ -2,7 +2,7 @@
+
+ This directory holds reference material about COREcare **v1**.
+
+-**Audience:** engineers contributing to v2.
++**Audience:** engineers contributing to v2 — including AI agents acting on their behalf.'
+
+# Fixture: README diff where the SHA line appears on both sides but the SHA is unchanged.
+readonly README_IDENTICAL_DIFF=$'diff --git a/docs/migration/README.md b/docs/migration/README.md
+index abcdef..fedcba 100644
+--- a/docs/migration/README.md
++++ b/docs/migration/README.md
+@@ -16,7 +16,7 @@
+
+ - **Repo:** `suniljames/COREcare-access`
+-- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
++- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
+ - **Commit subject:** `feat(#1479)…`'
+
+# Fixture: a small urls.py diff (3 routes added).
+readonly URLS_DIFF=$'diff --git a/clients/urls.py b/clients/urls.py
+index 1111111..2222222 100644
+--- a/clients/urls.py
++++ b/clients/urls.py
+@@ -10,3 +10,6 @@ urlpatterns = [
+     path("clients/", views.client_list, name="client_list"),
+     path("clients/<int:pk>/", views.client_detail, name="client_detail"),
++    path("family/portal/", views.family_portal, name="family_portal"),
++    path("family/clients/<int:pk>/", views.family_client_detail, name="family_client_detail"),
++    path("family/visits/", views.family_visits, name="family_visits"),
+ ]'
+
+# Fixture: clients/ diff with NO permission gate change (just template tweak).
+readonly CLIENTS_DIFF_NO_GATE=$'diff --git a/clients/templates/clients/list.html b/clients/templates/clients/list.html
+index 1111111..2222222 100644
+--- a/clients/templates/clients/list.html
++++ b/clients/templates/clients/list.html
+@@ -1,3 +1,3 @@
+-<h1>Clients</h1>
++<h1>Active clients</h1>
+ <ul class="client-list">'
+
+# Fixture: clients/ diff that touches the canonical permission gate.
+readonly CLIENTS_DIFF_PERMISSION=$'diff --git a/clients/permissions.py b/clients/permissions.py
+index 1111111..2222222 100644
+--- a/clients/permissions.py
++++ b/clients/permissions.py
+@@ -3,5 +3,7 @@
+ def _check_client_access(user, client):
+-    return user.is_caregiver_of(client)
++    if user.is_caregiver_of(client):
++        return True
++    return user.is_family_of(client)'
+
+# Fixture: clients/models.py diff that introduces an `is_active` column on ClientFamilyMember.
+readonly MODELS_DIFF_FINGERPRINT=$'diff --git a/clients/models.py b/clients/models.py
+index 1111111..2222222 100644
+--- a/clients/models.py
++++ b/clients/models.py
+@@ -42,6 +42,8 @@ class ClientFamilyMember(models.Model):
+     client = models.ForeignKey(Client, on_delete=models.CASCADE)
+     user = models.OneToOneField(User, on_delete=models.CASCADE)
+     relation = models.CharField(max_length=50)
++    is_active = models.BooleanField(default=True)
++    deactivated_at = models.DateTimeField(null=True, blank=True)'
+
+# Fixture: clients/models.py diff that does NOT touch ClientFamilyMember.
+readonly MODELS_DIFF_NO_MATCH=$'diff --git a/clients/models.py b/clients/models.py
+index 1111111..2222222 100644
+--- a/clients/models.py
++++ b/clients/models.py
+@@ -10,3 +10,4 @@ class Client(models.Model):
+     name = models.CharField(max_length=200)
+     dob = models.DateField(null=True, blank=True)
++    notes = models.TextField(blank=True, default="")'
+
+readonly EMPTY_DIFF=""
+
+# --- Assertion 1: SHA-bump detected ---
+
+result=$(printf '%s\n' "$README_BUMP_DIFF" | extract_sha_bump)
+assert \
+  "1. SHA-bump detected from a fixture diff" \
+  "[[ '$result' == '9738412a6e41064203fc253d9dd2a5c6a9c2e231 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ]]"
+
+# --- Assertion 2: no-op when no SHA line in diff ---
+
+result=$(printf '%s\n' "$README_NO_BUMP_DIFF" | extract_sha_bump)
+assert \
+  "2. no-op when README diff does not touch the Commit SHA line" \
+  "[[ -z '$result' ]]"
+
+# --- Assertion 3: no-op when SHAs identical ---
+
+result=$(printf '%s\n' "$README_IDENTICAL_DIFF" | extract_sha_bump)
+assert \
+  "3. no-op when old and new SHAs are identical (reformat-only)" \
+  "[[ -z '$result' ]]"
+
+# --- Assertion 4: no-op when README modified but SHA line untouched ---
+# Same fixture as #2, expressed as the explicit "different paragraph changed" case.
+
+result=$(printf '%s\n' "$README_NO_BUMP_DIFF" | extract_sha_bump)
+assert \
+  "4. no-op when README change is to a different paragraph" \
+  "[[ -z '$result' ]]"
+
+# --- Assertion 5: sticky-comment marker present (exactly once) ---
+
+body=$(format_comment "9738412abcdef" "aaaaaaabcdef0" "$URLS_DIFF" "$CLIENTS_DIFF_NO_GATE" "$EMPTY_DIFF" "")
+marker_count=$(printf '%s\n' "$body" | grep -c '<!-- v1-sha-bump-diff-report -->' || true)
+assert \
+  "5. sticky-comment marker present exactly once in body" \
+  "[[ $marker_count -eq 1 ]]"
+
+# --- Assertion 6: empty-diff branch wording ---
+
+empty_body=$(format_comment "9738412" "aaaaaaa" "$EMPTY_DIFF" "$EMPTY_DIFF" "$EMPTY_DIFF" "")
+assert_contains_ci \
+  "6a. empty-diff comment contains 'all diffs empty' (case-insensitive)" \
+  "$empty_body" \
+  "all diffs empty"
+assert_contains \
+  "6b. empty-diff comment contains 'bump \`last reconciled\`'" \
+  "$empty_body" \
+  "bump \`last reconciled\`"
+
+# --- Assertion 7: permission-gate branch bolds the right action ---
+
+gate_body=$(format_comment "9738412" "aaaaaaa" "$URLS_DIFF" "$CLIENTS_DIFF_PERMISSION" "$EMPTY_DIFF" "")
+assert_contains \
+  "7a. permission-gate body bolds 'flag \`CUTOVER_PLAN.md\` owners'" \
+  "$gate_body" \
+  "**Action: re-author + flag \`CUTOVER_PLAN.md\` owners.**"
+assert_contains \
+  "7b. permission-gate body mutes 're-author affected rows' (other branch)" \
+  "$gate_body" \
+  "~~Action: re-author affected rows~~"
+assert_contains \
+  "7c. permission-gate body mutes 'bump \`last reconciled\` only' (other branch)" \
+  "$gate_body" \
+  "~~Action: bump \`last reconciled\` only~~"
+
+# --- Assertion 8: truncation banner present + correct rerun command ---
+
+# Build a fake "large" diff using `seq` so we don't ship a kilobyte fixture file.
+# Override DIFF_CAP_BYTES to a small value so even a small fixture exceeds the cap.
+big_diff=$(printf 'diff --git a/clients/urls.py b/clients/urls.py\n'; \
+           for i in $(seq 1 100); do printf '+    path("family/r%d/", views.r%d, name="r%d"),\n' "$i" "$i" "$i"; done)
+DIFF_CAP_BYTES=200 trunc_body=$(format_comment "9738412abc" "aaaaaaab" "$big_diff" "$EMPTY_DIFF" "$EMPTY_DIFF" "")
+assert_contains \
+  "8a. truncation banner present when diff exceeds DIFF_CAP_BYTES" \
+  "$trunc_body" \
+  "more bytes truncated. Run locally:"
+assert_contains \
+  "8b. truncation banner emits a copy-pasteable git diff rerun command with the pathspec" \
+  "$trunc_body" \
+  "git -C <v1-checkout> diff 9738412abc..aaaaaaab -- '*/urls.py'"
+
+# --- Assertion 9: stats counts correct (files / +lines / −lines) ---
+
+read -r urls_files urls_plus urls_minus <<<"$(format_stats_row "$URLS_DIFF")"
+assert \
+  "9a. urls.py fixture counts: 1 file, 3 +lines, 0 -lines" \
+  "[[ '$urls_files' == '1' && '$urls_plus' == '3' && '$urls_minus' == '0' ]]"
+
+read -r p_files p_plus p_minus <<<"$(format_stats_row "$CLIENTS_DIFF_PERMISSION")"
+assert \
+  "9b. permissions.py fixture counts: 1 file, 3 +lines, 1 -lines" \
+  "[[ '$p_files' == '1' && '$p_plus' == '3' && '$p_minus' == '1' ]]"
+
+read -r e_files e_plus e_minus <<<"$(format_stats_row "$EMPTY_DIFF")"
+assert \
+  "9c. empty-diff fixture counts: 0 files, 0 +lines, 0 -lines" \
+  "[[ '$e_files' == '0' && '$e_plus' == '0' && '$e_minus' == '0' ]]"
+
+# --- Assertion 10: hidden machine-parseable diff-stats line ---
+
+stats_body=$(format_comment "9738412" "aaaaaaa" "$URLS_DIFF" "$CLIENTS_DIFF_PERMISSION" "$EMPTY_DIFF" "")
+assert_contains \
+  "10a. comment contains a machine-parseable diff-stats HTML comment" \
+  "$stats_body" \
+  "<!-- diff-stats: urls=1,+3,-0; clients=1,+3,-1; models=0,+0,-0 -->"
+
+# --- Assertion 11: fingerprint-match callout on ClientFamilyMember invariant token ---
+
+fp_body=$(format_comment "9738412" "aaaaaaa" "$EMPTY_DIFF" "$EMPTY_DIFF" "$MODELS_DIFF_FINGERPRINT" "")
+assert_contains \
+  "11a. fingerprint match: callout fires when models.py diff touches is_active near ClientFamilyMember" \
+  "$fp_body" \
+  "Baseline fingerprint match"
+
+no_fp_body=$(format_comment "9738412" "aaaaaaa" "$EMPTY_DIFF" "$EMPTY_DIFF" "$MODELS_DIFF_NO_MATCH" "")
+assert_not_contains \
+  "11b. fingerprint match: no callout when models.py diff does NOT touch ClientFamilyMember" \
+  "$no_fp_body" \
+  "Baseline fingerprint match"
+
+# --- Cross-cutting assertion: 'silent drift' phrase present (Writer requirement) ---
+
+assert_contains \
+  "X. comment body uses 'silent drift' as the searchable signal phrase" \
+  "$stats_body" \
+  "silent drift"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" == 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/v1-sha-bump-diff-report.yml` — a path-filtered GitHub Actions workflow that runs on PRs touching `docs/migration/README.md`. Two jobs: `scripts-self-test:` (always runs) and `diff-report:` (8-min timeout, fail-loud on missing secret).
- Adds `scripts/post-v1-sha-bump-diff.sh` — pure functions for SHA-bump detection, stats counting, permission-gate detection, fingerprint matching, diff truncation, and comment formatting; plus a `main()` that wires `gh pr diff` → `git clone --filter=blob:none` → three runbook diffs → sticky comment via `gh api`. Implements the runbook's three action branches verbatim with only the active branch bolded; emits the sticky-comment marker, hidden machine-parseable diff-stats line, and the writer-required `silent drift` phrase.
- Adds `scripts/tests/test_post_v1_sha_bump_diff.sh` — 19 fixture-driven assertions covering all 11 test-spec items in #131. Sources the script (no real network, no real `git`/`gh` calls). RED-first commit lands the failing test; GREEN-second commit lands the implementation. Wired into `make test-v1-docs`.
- Adds a "Workflow secrets" subsection to `docs/migration/README.md` documenting `V1_REPO_READ_TOKEN` scope (fine-grained PAT, `suniljames/COREcare-access` only, `Contents: Read`), 1-year rotation cadence, and break-glass procedure for when the gate itself is broken.

## Maintainer prerequisite (blocks merge, not implementation)

**Before merging, the `V1_REPO_READ_TOKEN` repo secret must exist** on `suniljames/COREcare-v2`. Setup steps are documented inline at the top of the new workflow file. Without the secret, the `diff-report:` job will fail-loud on every SHA-bump PR — by design, per the committee's fail-closed posture (Security + SRE).

## Test plan

- [x] `bash scripts/tests/test_post_v1_sha_bump_diff.sh` — 19/19 PASS.
  - RED commit (test only, no implementation) — PR diff shows the test landed on its own first.
  - GREEN commit (implementation) — RED → GREEN demonstrated.
- [x] `make test-v1-docs` — all 5 suites green (the four pre-existing scripts plus the new one).
- [x] `make scan-v1-docs` — clean across hygiene, structure, and catalog-coverage.
- [x] `make check` — api lint/test/typecheck and web lint/typecheck/test/build all green (web build run with the same `pk_test_…` dummy Clerk key the `ci.yml` workflow uses).
- [ ] Smoke verification (post-merge, manual, one-time): open a throwaway PR that bumps the README SHA to a known v1 commit; observe the comment lands; capture a screenshot for the runbook archive.

## Committee design review

Full 9-member engineering committee review on issue #131 (UX → SE → Architect → Data → AI/ML → Security → QA → SRE → Writer → EM synthesis). Notable points folded in:

- **Required CI check with documented break-glass** — resolved Architect / SRE tension; required-status posture, with manual rerun + maintainer bypass when the gate itself breaks.
- **Fine-grained PAT, single-repo scope** — Security pinned `Contents: Read` only, 1-year rotation, never `pull_request_target`.
- **Sticky single-comment per PR via marker-based PATCH** — UX + SE; one comment per PR, silent edits across pushes.
- **Hidden machine-parseable `<!-- diff-stats: ... -->` line** — Data; future automation can aggregate ack rates without retrofitting.
- **Baseline-fingerprint callout** — Data + AI/ML; deterministic grep for `is_active` / `deleted_at` / `expires_at` / `role` / `permission` near `ClientFamilyMember` flags the row that breaks the runbook's invariant.
- **`silent drift` searchable phrase preserved** — Writer; PR-comment archive remains greppable alongside the runbook entry.
- **No real network in CI tests** — QA; 19 fixture-driven assertions, `git`/`gh` unstubbed in unit tests because the pure functions don't shell out.
- **8-min timeout, PR-scoped concurrency, fail-loud secret check** — SRE.

## Out-of-scope follow-ups (filed post-merge per committee plan)

- One-sentence runbook pointer: add a line to the existing Family Member runbook entry pointing at the new workflow ("CI also posts these diffs as a PR comment when the SHA is bumped — see `.github/workflows/v1-sha-bump-diff-report.yml`").
- Generalization to other personas — only when their refresh runbook entries land.
- LLM-summarization of large diffs — only if bump cadence makes skim time the actual bottleneck.

## Related

- Closes #131
- Builds on #121 / #130 (manual runbook origin)
- Mirrors CI patterns from `.github/workflows/v1-doc-hygiene.yml` and `.github/workflows/v1-catalog-coverage.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)