### PR TITLE
feat(#107): Phase 2A — crawler bug closure + new tests + reproducibility rewrite + CI gate + runbook

### DIFF
--- a/.github/workflows/v1-catalog-coverage.yml
+++ b/.github/workflows/v1-catalog-coverage.yml
@@ -74,3 +74,42 @@ jobs:
       - name: Unit tests
         run: pnpm test
         working-directory: tools/v1-screenshot-catalog
+
+  phi-audit-artifacts:
+    name: PHI audit artifacts present when catalog binaries added
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: false
+      - name: Detect new catalog binaries vs base ref
+        id: detect
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          # Files added (status=A) or modified (status=M) in
+          # docs/legacy/v1-ui-catalog/ matching *.webp
+          ADDED=$(git diff --name-status --diff-filter=AM "$BASE"...HEAD -- 'docs/legacy/v1-ui-catalog/**/*.webp' | wc -l | tr -d ' ')
+          AUDIT_PRE=$(git diff --name-status --diff-filter=A "$BASE"...HEAD -- 'tools/v1-screenshot-catalog/PHI-AUDIT-PRECRAWL-*.md' | wc -l | tr -d ' ')
+          AUDIT_POST=$(git diff --name-status --diff-filter=A "$BASE"...HEAD -- 'tools/v1-screenshot-catalog/PHI-AUDIT-POSTCRAWL-*.md' | wc -l | tr -d ' ')
+          echo "added=$ADDED" >> "$GITHUB_OUTPUT"
+          echo "audit_pre=$AUDIT_PRE" >> "$GITHUB_OUTPUT"
+          echo "audit_post=$AUDIT_POST" >> "$GITHUB_OUTPUT"
+          echo "WebP files added/modified vs $BASE: $ADDED"
+          echo "PHI-AUDIT-PRECRAWL-*.md added: $AUDIT_PRE"
+          echo "PHI-AUDIT-POSTCRAWL-*.md added: $AUDIT_POST"
+      - name: Require PHI audit artifacts when WebPs are added
+        if: steps.detect.outputs.added != '0'
+        run: |
+          if [[ "${{ steps.detect.outputs.audit_pre }}" == "0" ]]; then
+            echo "FAIL: This PR adds catalog WebPs but no PHI-AUDIT-PRECRAWL-*.md is present in tools/v1-screenshot-catalog/."
+            echo "      Per Security Phase 2 review (#107): the pre-crawl PHI spike audit must commit to the PR alongside the catalog."
+            exit 1
+          fi
+          if [[ "${{ steps.detect.outputs.audit_post }}" == "0" ]]; then
+            echo "FAIL: This PR adds catalog WebPs but no PHI-AUDIT-POSTCRAWL-*.md is present in tools/v1-screenshot-catalog/."
+            echo "      Per Security Phase 2 review (#107): the post-crawl 10%-sample audit must commit to the PR alongside the catalog."
+            exit 1
+          fi
+          echo "OK: PHI audit artifacts present alongside catalog binaries."

--- a/scripts/check-catalog-reproducibility.sh
+++ b/scripts/check-catalog-reproducibility.sh
@@ -1,142 +1,31 @@
 #!/usr/bin/env bash
 # Compares two v1-UI-catalog directories and emits a per-image pixel-diff
-# report. Used to verify T2 of #107: byte-identical (AA-jitter only) re-run.
+# report. T2 of #107: byte-identical (AA-jitter only) re-run.
 #
-# Approach: convert WebPs to PNG via `sharp`, then run `pixelmatch` from npx.
-# Any image with >0.5% pixel diff fails the run.
+# Phase 2A rewrote the comparison logic in TypeScript (sharp + pixelmatch +
+# pngjs in-process, no per-image npx overhead). This bash file is a thin
+# wrapper that invokes the TS implementation via `pnpm check-reproducibility`.
 #
 # Usage:
 #   scripts/check-catalog-reproducibility.sh <baseline-dir> <rerun-dir>
-#     [--threshold-pct N]   default 0.5 (percent of pixels allowed to differ)
+#     [--threshold-pct N]   default 0.5
 #     [--output-dir <path>] default <rerun-dir>/reproducibility-report
 #
 # Exit codes:
-#   0  every image is within threshold
-#   1  one or more images exceed threshold
+#   0  every image is within threshold AND fixture hashes match
+#   1  any image exceeds threshold OR fixture hashes diverge
 #   2  bad invocation
 
-set -u
+set -eu
 
-THRESHOLD_PCT="0.5"
-OUTPUT_DIR=""
-BASELINE=""
-RERUN=""
+# Resolve the crawler-tool dir relative to this script.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOL_DIR="$(cd "$SCRIPT_DIR/../tools/v1-screenshot-catalog" && pwd)"
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --threshold-pct) THRESHOLD_PCT="$2"; shift 2 ;;
-    --output-dir)    OUTPUT_DIR="$2"; shift 2 ;;
-    -h|--help)
-      sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
-      exit 0 ;;
-    --*)
-      echo "unknown flag: $1" >&2
-      exit 2 ;;
-    *)
-      if [[ -z "$BASELINE" ]]; then BASELINE="$1"
-      elif [[ -z "$RERUN" ]]; then RERUN="$1"
-      else echo "unexpected positional arg: $1" >&2; exit 2
-      fi
-      shift ;;
-  esac
-done
-
-if [[ -z "$BASELINE" || -z "$RERUN" ]]; then
-  echo "error: must pass two positional args: <baseline-dir> <rerun-dir>" >&2
-  exit 2
-fi
-if [[ ! -d "$BASELINE" ]]; then echo "error: baseline dir not found: $BASELINE" >&2; exit 2; fi
-if [[ ! -d "$RERUN" ]]; then echo "error: rerun dir not found: $RERUN" >&2; exit 2; fi
-if [[ -z "$OUTPUT_DIR" ]]; then OUTPUT_DIR="$RERUN/reproducibility-report"; fi
-mkdir -p "$OUTPUT_DIR"
-
-if ! command -v npx >/dev/null 2>&1; then
-  echo "error: npx not found; install Node 20+" >&2
+if [[ ! -d "$TOOL_DIR/node_modules" ]]; then
+  echo "error: node_modules missing in $TOOL_DIR — run \`cd $TOOL_DIR && pnpm install\`" >&2
   exit 2
 fi
 
-# Find every WebP under the baseline that has a sibling in the rerun.
-# Outputs report to <OUTPUT_DIR>/report.md and per-image diffs as PNGs.
-REPORT="$OUTPUT_DIR/report.md"
-echo "# Catalog reproducibility report" > "$REPORT"
-echo "" >> "$REPORT"
-echo "**Baseline:** $BASELINE" >> "$REPORT"
-echo "**Rerun:** $RERUN" >> "$REPORT"
-echo "**Threshold:** ${THRESHOLD_PCT}% per-image pixel diff" >> "$REPORT"
-echo "" >> "$REPORT"
-echo "| canonical_id | viewport | diff% | status |" >> "$REPORT"
-echo "|--------------|----------|------:|--------|" >> "$REPORT"
-
-EXCEEDED=0
-TOTAL=0
-
-while IFS= read -r -d '' baseline_file; do
-  rel="${baseline_file#$BASELINE/}"
-  rerun_file="$RERUN/$rel"
-  if [[ ! -f "$rerun_file" ]]; then
-    continue   # rerun is missing this image — caught by the coverage script, not here
-  fi
-  TOTAL=$((TOTAL + 1))
-
-  # canonical_id is the path minus the .{desktop,mobile}.webp suffix
-  canonical_id="${rel%.desktop.webp}"
-  canonical_id="${canonical_id%.mobile.webp}"
-  if [[ "$rel" == *".desktop.webp" ]]; then viewport="desktop"
-  elif [[ "$rel" == *".mobile.webp" ]]; then viewport="mobile"
-  else continue
-  fi
-
-  # Convert both to PNG via sharp (npx). pixelmatch requires PNG.
-  baseline_png=$(mktemp -t catrepro-base.XXXXXX.png)
-  rerun_png=$(mktemp -t catrepro-rerun.XXXXXX.png)
-  diff_png="$OUTPUT_DIR/${canonical_id//\//_}.${viewport}.diff.png"
-  mkdir -p "$(dirname "$diff_png")" 2>/dev/null
-
-  npx --yes sharp-cli "$baseline_file" -o "$baseline_png" -f png >/dev/null 2>&1 || true
-  npx --yes sharp-cli "$rerun_file"    -o "$rerun_png"    -f png >/dev/null 2>&1 || true
-
-  if [[ ! -s "$baseline_png" || ! -s "$rerun_png" ]]; then
-    echo "| $canonical_id | $viewport | n/a | conversion-failed |" >> "$REPORT"
-    EXCEEDED=$((EXCEEDED + 1))
-    rm -f "$baseline_png" "$rerun_png"
-    continue
-  fi
-
-  # pixelmatch via npx. Output: number of differing pixels.
-  diff_output=$(npx --yes pixelmatch "$baseline_png" "$rerun_png" "$diff_png" 0.1 2>/dev/null || true)
-  diff_pixels=$(echo "$diff_output" | grep -oE '[0-9]+' | head -1)
-  diff_pixels="${diff_pixels:-0}"
-
-  # Compute total pixels of the baseline (width × height).
-  total_pixels=$(npx --yes sharp-cli metadata "$baseline_png" 2>/dev/null | python3 -c "import sys, json; m = json.load(sys.stdin); print(m.get('width', 0) * m.get('height', 0))" 2>/dev/null || echo 1)
-  total_pixels="${total_pixels:-1}"
-  if [[ "$total_pixels" -le 0 ]]; then total_pixels=1; fi
-
-  diff_pct=$(awk -v d="$diff_pixels" -v t="$total_pixels" 'BEGIN { printf "%.4f", (d * 100.0) / t }')
-  ok=$(awk -v d="$diff_pct" -v t="$THRESHOLD_PCT" 'BEGIN { print (d <= t) ? 1 : 0 }')
-
-  if [[ "$ok" == "1" ]]; then
-    echo "| $canonical_id | $viewport | ${diff_pct}% | ok |" >> "$REPORT"
-  else
-    echo "| $canonical_id | $viewport | ${diff_pct}% | EXCEEDED |" >> "$REPORT"
-    EXCEEDED=$((EXCEEDED + 1))
-  fi
-
-  rm -f "$baseline_png" "$rerun_png"
-done < <(find "$BASELINE" -name '*.webp' -type f -print0 2>/dev/null)
-
-echo "" >> "$REPORT"
-echo "## Summary" >> "$REPORT"
-echo "" >> "$REPORT"
-echo "- Total compared: $TOTAL" >> "$REPORT"
-echo "- Within threshold: $((TOTAL - EXCEEDED))" >> "$REPORT"
-echo "- Exceeded: $EXCEEDED" >> "$REPORT"
-
-cat "$REPORT" | tail -10
-echo ""
-echo "Report: $REPORT"
-
-if (( EXCEEDED > 0 )); then
-  exit 1
-fi
-exit 0
+cd "$TOOL_DIR"
+exec pnpm exec tsx check-reproducibility.ts "$@"

--- a/scripts/check-v1-catalog-coverage.sh
+++ b/scripts/check-v1-catalog-coverage.sh
@@ -77,9 +77,11 @@ trap 'rm -rf "$WORK"' EXIT
 INV_REFS="$WORK/inv_refs.txt"
 INV_SKIPPED="$WORK/inv_skipped.txt"
 INV_BAD="$WORK/inv_bad.txt"
+INV_SKIP_REASONS="$WORK/inv_skip_reasons.txt"
 : > "$INV_REFS"
 : > "$INV_SKIPPED"
 : > "$INV_BAD"
+: > "$INV_SKIP_REASONS"
 
 awk -F'|' '
   NF == 12 {
@@ -97,6 +99,11 @@ awk -F'|' '
     }
     if (ref ~ /^not_screenshotted:/) {
       print route > "'"$INV_SKIPPED"'"
+      # Capture the reason for taxonomy soft-warn (Stage 5).
+      reason = ref
+      sub(/^not_screenshotted:[[:space:]]*/, "", reason)
+      sub(/[[:space:]]+$/, "", reason)
+      print route "\t" reason > "'"$INV_SKIP_REASONS"'"
       next
     }
     # Otherwise: canonical_id reference
@@ -219,6 +226,26 @@ if (( COVERAGE_PCT < THRESHOLD )); then
   echo ""
   echo "FAIL: coverage ${COVERAGE_PCT}% below threshold ${THRESHOLD}%"
   FAILED=1
+fi
+
+# ---------------------------------------------------------------------------
+# Stage 5 — skip-reason taxonomy soft-warn.
+#
+# Each not_screenshotted: <reason> value should match the locked taxonomy in
+# docs/legacy/README.md §Skip-reason taxonomy. Unknown values are flagged
+# with a WARN (not a FAIL) so the operator can either extend the taxonomy
+# table in the same PR or fix the inventory row.
+# ---------------------------------------------------------------------------
+
+LOCKED_REASONS_RE='^(pending #79|destructive_endpoint|gated_by_capability|no_seed_data|no_authenticated_surface|auth_redirect)$'
+UNKNOWN_REASONS=$(awk -F'\t' -v re="$LOCKED_REASONS_RE" '$2 !~ re {print $0}' "$INV_SKIP_REASONS")
+UNKNOWN_COUNT=$(echo -n "$UNKNOWN_REASONS" | grep -c . || true)
+
+if (( UNKNOWN_COUNT > 0 )); then
+  echo ""
+  echo "WARN: $UNKNOWN_COUNT inventory row(s) use a skip-reason value not in the locked taxonomy:"
+  echo "$UNKNOWN_REASONS" | sed 's/^/  - /'
+  echo "  → extend docs/legacy/README.md §Skip-reason taxonomy or fix the inventory."
 fi
 
 if (( FAILED == 0 )); then

--- a/tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md
+++ b/tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md
@@ -1,0 +1,259 @@
+# Phase 2 Runbook
+
+> **Read order:** [`README.md`](README.md) (bring-up) → [`INVESTIGATIONS.md`](INVESTIGATIONS.md) → [`PHI-CHECKLIST.md`](PHI-CHECKLIST.md) → this file → [`CAPTION-STYLE.md`](CAPTION-STYLE.md).
+
+This runbook is the operator's single-page document for Phase 2 of [#107](https://github.com/suniljames/COREcare-v2/issues/107). Each step has a verification step ("how do I know it worked") and a remediation step ("what if it didn't"). Phase 2A — bug closure — is **already merged**; this runbook drives Phase 2B onwards.
+
+If a step fails: STOP. Do not skip. Fix the failing step or push back on the design — operating on bad inputs is worse than not operating at all.
+
+---
+
+## Summary
+
+Estimated wall-clock: **~4 days** (most of it is the user-owned fixture authoring in 2B).
+
+| Sub-phase | What | Wall-clock | Owner |
+|-----------|------|-----------:|-------|
+| 2B | Author PHI-scrubbed Django fixture | ~1 day | user |
+| 2C | Manual PHI spike (stop-the-line gate) | ~2 hours | user |
+| 2D | Authoritative crawl | ~30 min | user (passive) |
+| 2E | Reproducibility + audits | ~2 hours | user |
+| 2F | Index population + cold smoke | ~1 hour | user + 1 reviewer |
+| 2G | Commit + PR | ~30 min | user |
+
+---
+
+## Phase 2B — Fixture authoring (~1 day)
+
+Author `~/Code/COREcare-access/fixtures/v2_catalog_snapshot.json` per the spec table in [#107 Proposed Solution §Seed fixture spec](https://github.com/suniljames/COREcare-v2/issues/107).
+
+### Steps
+
+1. `cd ~/Code/COREcare-access && git fetch && git checkout 9738412a6e41064203fc253d9dd2a5c6a9c2e231`
+2. `python manage.py migrate` against a fresh SQLite DB (`unset DATABASE_URL` first; SQLite is the default per [INVESTIGATIONS.md](INVESTIGATIONS.md)).
+3. Author `fixtures/v2_catalog_snapshot.json` in Django `loaddata` JSON format. Required entities (per #107 spec):
+   - `User` × 2 staff (Super-Admin with `is_superuser=True`, Agency Admin with `is_staff=True` only)
+   - `User` + `CareManagerProfile` × 1
+   - `User` + `CaregiverProfile` × 3 (active+valid / expiring-soon / expired)
+   - `User` + `ClientFamilyMember` × 1
+   - `Agency` × 2
+   - `Client` × 6 (3 per agency) — names from `[CLIENT_NAME]_001` etc.
+   - Past shifts: 14 days × ~3 per caregiver
+   - Future shifts: 14 days × ~3 per caregiver
+   - Chart notes × ~10 (PHI placeholder vocabulary, no Faker)
+   - Care plans: 1 per client
+   - Expense submissions × ~5
+4. Validate: `python manage.py loaddata fixtures/v2_catalog_snapshot.json` exits 0.
+5. Hash: `shasum -a 256 fixtures/v2_catalog_snapshot.json | tee fixtures/v2_catalog_snapshot.sha256`.
+6. Record path + hash in `tools/v1-screenshot-catalog/INVESTIGATIONS.md` under a new "Fixture snapshot" section.
+
+### Verification
+
+- `python manage.py shell -c "from django.contrib.auth import get_user_model; print(get_user_model().objects.count())"` → 8 users (2 staff + 1 care manager + 3 caregivers + 1 family + maybe a default admin).
+- `python manage.py shell -c "from clients.models import Client; print(Client.objects.count())"` → 6.
+- Open `http://localhost:8000/dashboard/login/` → log in as each persona. Each should land on a populated dashboard, not an empty state.
+
+### Remediation
+
+- If migrations fail against pinned commit, check Python version + Django version in `requirements.txt`; the pinned commit's CI baseline holds.
+- If fixture loading fails on FK constraints, ensure entities are listed in dependency order in the JSON (User before CaregiverProfile, etc.).
+- **Faker output is unacceptable.** All field values come from the locked PHI placeholder set in `docs/migration/README.md`.
+
+---
+
+## Phase 2C — Manual PHI spike (~2 hours, stop-the-line gate)
+
+5 routes per persona × 5 personas = 25 manual single-image samples, audited against [`PHI-CHECKLIST.md`](PHI-CHECKLIST.md) (11 categories, yes/no/N/A).
+
+### Steps
+
+1. v1 running with the fixture loaded (see Phase 2D step 1 below for the bring-up sequence).
+2. For each persona, log in via browser at `http://localhost:8000/dashboard/login/`.
+3. Pick 5 routes per persona — **must include** any client-detail, chart-note, or billing/financial view (per Data Engineer Phase 2 minimum-coverage rule).
+4. Take a single browser screenshot of each route.
+5. For each image: walk the 11 categories in `PHI-CHECKLIST.md`; record yes/no/N/A + free-text note.
+6. Record results in `tools/v1-screenshot-catalog/PHI-AUDIT-PRECRAWL-<YYYY-MM-DD>.md`. Format: 25-row × 11-column table.
+
+### Stop-the-line gate
+
+If **any** category is `no` (PHI present that shouldn't be):
+
+1. STOP.
+2. Identify which fixture field produced the leak.
+3. Fix `fixtures/v2_catalog_snapshot.json`. Re-load. Re-hash.
+4. Re-spike from step 2.
+
+Do not proceed to Phase 2D until **every** category is yes/N/A.
+
+---
+
+## Phase 2D — Authoritative crawl (~30 min)
+
+### Steps
+
+1. **Bring up v1** (in a dedicated terminal):
+   ```bash
+   cd ~/Code/COREcare-access
+   git checkout 9738412a6e41064203fc253d9dd2a5c6a9c2e231
+   unset DATABASE_URL
+   # Outbound integrations are off by default per INVESTIGATIONS.md;
+   # we still set explicit unsets as belt-and-suspenders.
+   unset SENDGRID_API_KEY EMAIL_HOST_PASSWORD QUICKBOOKS_CLIENT_ID QUICKBOOKS_CLIENT_SECRET SENTRY_DSN
+   python manage.py loaddata fixtures/v2_catalog_snapshot.json  # idempotent on a fresh DB
+   python manage.py runserver 0.0.0.0:8000
+   ```
+
+2. **In the v2 worktree**, fill in `tools/v1-screenshot-catalog/.env` (gitignored):
+   ```bash
+   cd tools/v1-screenshot-catalog
+   cp .env.example .env
+   # Edit .env:
+   #   V1_BASE_URL=http://localhost:8000
+   #   V1_FIXTURE_SHA256=<contents of ~/Code/COREcare-access/fixtures/v2_catalog_snapshot.sha256>
+   #   V1_SUPER_ADMIN_USERNAME=superadmin@catalog.local  (etc.)
+   ```
+
+3. **Run pre-flight + crawl**:
+   ```bash
+   pnpm install   # if not already
+   pnpm exec playwright install chromium  # if not already
+   pnpm crawl --output-dir ../../docs/legacy/v1-ui-catalog/
+   ```
+
+   Expected output:
+   - 5 pre-flight gates pass within ~5 seconds
+   - Per-persona login + per-route capture log lines stream to stdout AND `<output-dir>/crawl.log`
+   - Final `run.complete` event with `routes_visited` ≈ 134, `routes_errored: 0`
+   - `RUN-MANIFEST.md`, `crawl.log`, `intercepted-non-GET.log` written to `<output-dir>`
+
+### Verification
+
+- `cat ../../docs/legacy/v1-ui-catalog/RUN-MANIFEST.md` shows the v1 commit, fixture sha256, operator, host, playwright_version, and counts.
+- `tail ../../docs/legacy/v1-ui-catalog/crawl.log` ends with a `run.complete` event.
+- `wc -l ../../docs/legacy/v1-ui-catalog/intercepted-non-GET.log` reports a small number (typically <50: Sentry beacons, web-push posts).
+- **Inspect intercepted-non-GET.log:** every entry must have `origin: page-script`. **If any has `origin: navigation`** (would mean the crawler clicked a destructive button), STOP and fix the crawler before merging.
+
+### Remediation
+
+- If a single persona's login fails, the run continues for other personas (logged as `persona.login` event with `status: failed`). Investigate fixture user credentials match `.env` exactly.
+- If the crawl aborts mid-persona, use `pnpm crawl --output-dir ... --resume-from <persona-slug>` to skip already-completed personas.
+- If Gate 4 fails (output dir not writable), `mkdir -p` the dir first.
+
+---
+
+## Phase 2E — Reproducibility + audits (~2 hours)
+
+### Steps
+
+1. **Reproducibility two-run**:
+   ```bash
+   mkdir -p /tmp/catalog-rerun
+   pnpm crawl --output-dir /tmp/catalog-rerun
+   # then from repo root:
+   bash scripts/check-catalog-reproducibility.sh \
+     docs/legacy/v1-ui-catalog/ \
+     /tmp/catalog-rerun/ \
+     --output-dir docs/legacy/v1-ui-catalog/reproducibility-report
+   ```
+   Expected: every (route, viewport) pair within 0.5% pixel diff. Fixture-hash gate passes.
+
+   **STOP-and-root-cause** if any image exceeds threshold OR fixture hashes diverge between the two runs. Common causes: stale Playwright Chromium build, fixture edited between runs (re-hash and re-load), forgotten determinism harness override.
+
+2. **Coverage check**:
+   ```bash
+   bash scripts/check-v1-catalog-coverage.sh
+   ```
+   Expected: ≥95% coverage. **Update** `docs/migration/v1-pages-inventory.md` rows: replace `not_screenshotted: pending #79` with the canonical_id (e.g., `agency-admin/001-dashboard`) for every captured row, or with a locked skip-reason value (e.g., `no_authenticated_surface`, `auth_redirect`) for genuinely-skipped rows. Re-run the coverage script until OK.
+
+3. **Post-crawl PHI 10% sample audit**:
+   ```bash
+   # Use Python's random.seed(42) to pick the sample; cap 100 images.
+   ```
+   Audit each against `PHI-CHECKLIST.md`. Commit `tools/v1-screenshot-catalog/PHI-AUDIT-POSTCRAWL-<YYYY-MM-DD>.md` (table format).
+
+4. **Secret scan** over the diff:
+   ```bash
+   gitleaks detect --source . --redact --no-git --log-opts="$(git merge-base HEAD origin/main)..HEAD"
+   # Plus a manual grep over caption files:
+   grep -rE '(@|Bearer|password|token|secret)' docs/legacy/v1-ui-catalog/ --include='*.md'
+   ```
+   Both must report zero hits.
+
+5. **Optional empty-state variants** (≤15 routes): identify routes where the empty state is meaningful UX, drop a temporary fixture tweak, re-run with `pnpm crawl --output-dir .../empty-variants --only-routes <id1>,<id2>`. Caption with `seed_state: empty`. Move WebPs into the main catalog dir alongside the populated variants (`<NNN>-<route>.empty.{desktop,mobile}.webp`).
+
+### Verification
+
+- `cat docs/legacy/v1-ui-catalog/reproducibility-report/report.md` summary line shows `Exceeded / failed: 0`.
+- `bash scripts/check-v1-catalog-coverage.sh` exits 0; "OK: catalog coverage holds" printed.
+- `tools/v1-screenshot-catalog/PHI-AUDIT-POSTCRAWL-*.md` shows zero `no` verdicts.
+- gitleaks + manual grep both empty.
+
+### Remediation
+
+- Reproducibility outliers: re-run `pnpm crawl` once more — sometimes a transient v1 server hiccup creates a one-off diff. If diffs persist, examine `reproducibility-report/<canonical_id>.<viewport>.diff.png` to identify the changed region; root-cause via the determinism harness.
+- Coverage gaps: every `not_screenshotted: pending #79` row must be updated. Use a locked skip-reason value or a canonical_id; the soft-warn surfaces drift.
+- PHI hits: STOP. Fix the fixture, re-spike (Phase 2C), re-crawl (Phase 2D).
+
+---
+
+## Phase 2F — Index population + cold smoke (~1 hour)
+
+### Steps
+
+1. **Update `docs/legacy/v1-ui-catalog/README.md`**:
+   - Persona-section table: route counts per persona, lead viewports (Caregiver + Family Member: mobile-first listing).
+   - Generation-provenance section: paragraph (not key-value) referencing v1 commit, fixture hash, RUN-MANIFEST.md, RUN date, crawler git ref.
+   - Mirror the boundary statement from `tools/v1-screenshot-catalog/README.md` opening line.
+2. **Update `docs/legacy/README.md`**:
+   - Pinned references section: v1 SHA, fixture hash, generation date.
+   - Skip-reason taxonomy already includes `no_authenticated_surface` (Phase 2A.5; no edit needed).
+3. **Run T7 cold smoke** with one v2 contributor (or self-with-disclosure):
+   - Open `docs/legacy/v1-ui-catalog/README.md` from a fresh shell. No prior v1 access required.
+   - Find within 60 seconds each:
+     (a) the Agency Admin shift detail page,
+     (b) the Caregiver clock-in flow,
+     (c) the Family Member visit-notes view.
+   - Record times in PR description.
+4. For any case >30 seconds: edit the index README to add the prose that was missing.
+
+### Verification
+
+- `docs/legacy/v1-ui-catalog/README.md` no longer says "pending #107" anywhere.
+- T7 results recorded in PR description.
+
+---
+
+## Phase 2G — Commit + PR (~30 min)
+
+### Steps
+
+1. **LFS size-check**:
+   ```bash
+   git lfs ls-files | wc -l   # expected 200–800 files
+   du -sh docs/legacy/v1-ui-catalog/  # expected 80–300 MB
+   ```
+   If size >500 MB, investigate (q=80 sharp config not honored, or some pages absurdly large). If file count <100 or >1000, investigate.
+
+2. **File the Phase 3 caption-authoring issue** using the locked draft in [#107 Appendix A](https://github.com/suniljames/COREcare-v2/issues/107).
+
+3. **File the LFS-bandwidth-monitoring follow-up issue** (1-month-after-merge SRE task). Reference ADR-010 Alternative B as the escape hatch.
+
+4. **Commit** using the locked format in [#107 Appendix B](https://github.com/suniljames/COREcare-v2/issues/107). Single atomic commit; inventory + catalog ship together.
+
+5. **Push** to `feat/107-phase-2-*` branch:
+   ```bash
+   git push -u origin feat/107-phase-2-authoritative-crawl
+   ```
+
+6. **Open the PR** using the locked 13-line gate-list checklist in [#107 Appendix C](https://github.com/suniljames/COREcare-v2/issues/107). Reviewer signs off line-by-line; no checkmark = no merge.
+
+### Verification
+
+- `git lfs ls-files` count matches RUN-MANIFEST.md count.
+- PR description contains every gate from Appendix C, with evidence per line.
+- Phase 3 issue exists, linked from the catalog README, linked from caption TODO markers.
+
+### Remediation
+
+- If LFS push hits bandwidth limits mid-push: don't `git lfs prune`; check GitHub Settings → Billing → Git LFS for the v2 repo. May need to wait for the next billing cycle or upgrade.
+- If the PHI-audit-artifacts CI gate fails: confirm both `PHI-AUDIT-PRECRAWL-*.md` and `PHI-AUDIT-POSTCRAWL-*.md` were committed in the same PR.

--- a/tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md
+++ b/tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md
@@ -69,7 +69,7 @@ Author `~/Code/COREcare-access/fixtures/v2_catalog_snapshot.json` per the spec t
 
 1. v1 running with the fixture loaded (see Phase 2D step 1 below for the bring-up sequence).
 2. For each persona, log in via browser at `http://localhost:8000/dashboard/login/`.
-3. Pick 5 routes per persona — **must include** any client-detail, chart-note, or billing/financial view (per Data Engineer Phase 2 minimum-coverage rule).
+3. Pick 5 routes per persona — **must include** any client-detail, chart-note, or billing/financial view (per the data-engineer review's minimum-coverage rule on #107).
 4. Take a single browser screenshot of each route.
 5. For each image: walk the 11 categories in `PHI-CHECKLIST.md`; record yes/no/N/A + free-text note.
 6. Record results in `tools/v1-screenshot-catalog/PHI-AUDIT-PRECRAWL-<YYYY-MM-DD>.md`. Format: 25-row × 11-column table.
@@ -157,7 +157,7 @@ Do not proceed to Phase 2D until **every** category is yes/N/A.
    ```
    Expected: every (route, viewport) pair within 0.5% pixel diff. Fixture-hash gate passes.
 
-   **STOP-and-root-cause** if any image exceeds threshold OR fixture hashes diverge between the two runs. Common causes: stale Playwright Chromium build, fixture edited between runs (re-hash and re-load), forgotten determinism harness override.
+   **STOP-and-root-cause** if any image exceeds threshold OR fixture hashes diverge between the two runs. Common causes: stale Playwright/Chromium build, fixture edited between runs (re-hash and re-load), forgotten determinism harness override.
 
 2. **Coverage check**:
    ```bash
@@ -167,7 +167,7 @@ Do not proceed to Phase 2D until **every** category is yes/N/A.
 
 3. **Post-crawl PHI 10% sample audit**:
    ```bash
-   # Use Python's random.seed(42) to pick the sample; cap 100 images.
+   # Sample via python's random.seed(42); cap at 100 images.
    ```
    Audit each against `PHI-CHECKLIST.md`. Commit `tools/v1-screenshot-catalog/PHI-AUDIT-POSTCRAWL-<YYYY-MM-DD>.md` (table format).
 

--- a/tools/v1-screenshot-catalog/__tests__/cli-args.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/cli-args.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { parseArgs } from "../crawl.ts";
+
+// parseArgs is the unit-testable kernel of CLI-flag handling. Phase 2A adds
+// --resume-from, --only-personas, --only-routes for operator recovery.
+
+describe("parseArgs", () => {
+  it("requires --output-dir", () => {
+    expect(() => parseArgs([], { exitOnError: false })).toThrow(/--output-dir is required/);
+  });
+
+  it("accepts --output-dir as the minimum invocation", () => {
+    const args = parseArgs(["--output-dir", "/tmp/out"], { exitOnError: false });
+    expect(args.outputDir).toBe("/tmp/out");
+    expect(args.resumeFrom).toBeUndefined();
+    expect(args.onlyPersonas).toBeUndefined();
+    expect(args.onlyRoutes).toBeUndefined();
+  });
+
+  it("parses --resume-from as a single persona slug", () => {
+    const args = parseArgs(
+      ["--output-dir", "/tmp/out", "--resume-from", "caregiver"],
+      { exitOnError: false },
+    );
+    expect(args.resumeFrom).toBe("caregiver");
+  });
+
+  it("parses --only-personas as a comma-separated list of slugs", () => {
+    const args = parseArgs(
+      ["--output-dir", "/tmp/out", "--only-personas", "super-admin,agency-admin"],
+      { exitOnError: false },
+    );
+    expect(args.onlyPersonas).toEqual(["super-admin", "agency-admin"]);
+  });
+
+  it("parses --only-routes as a comma-separated list of canonical_ids", () => {
+    const args = parseArgs(
+      ["--output-dir", "/tmp/out", "--only-routes", "agency-admin/001-dashboard,caregiver/004-clock-in"],
+      { exitOnError: false },
+    );
+    expect(args.onlyRoutes).toEqual([
+      "agency-admin/001-dashboard",
+      "caregiver/004-clock-in",
+    ]);
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => parseArgs(
+      ["--output-dir", "/tmp/out", "--bogus", "x"],
+      { exitOnError: false },
+    )).toThrow(/unknown arg: --bogus/);
+  });
+
+  it("strips whitespace from comma-separated list values", () => {
+    const args = parseArgs(
+      ["--output-dir", "/tmp/out", "--only-personas", "super-admin, agency-admin , caregiver"],
+      { exitOnError: false },
+    );
+    expect(args.onlyPersonas).toEqual(["super-admin", "agency-admin", "caregiver"]);
+  });
+});

--- a/tools/v1-screenshot-catalog/__tests__/extract-inventory-routes.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/extract-inventory-routes.test.ts
@@ -23,16 +23,20 @@ describe("extract-inventory-routes.sh", () => {
     }
   });
 
+  // Inventory row schema (matches docs/migration/v1-pages-inventory.md):
+  //   | route | purpose | what_user_sees | v2_status | severity | mt | rls | phi | screenshot_ref | v2_link |
+  // Awk -F"|" sees 12 fields total (10 columns + leading + trailing empty).
+
   it("emits a JSON array on stdout", () => {
     const dir = mkdtempSync(join(tmpdir(), "inv-test-"));
     const fixture = join(dir, "inv.md");
     writeFileSync(fixture, [
       "## Super-Admin",
       "",
-      "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
-      "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
-      "| Dashboard | `/admin/dashboard/` | x | x | x | x | x | x | x | super-admin/001-dashboard | x | x |",
-      "| Clients | `/admin/clients/` | x | x | x | x | x | x | x | not_screenshotted: pending #79 | x | x |",
+      "| route | purpose | what | v2 | sev | mt | rls | phi | screenshot_ref | v2_link |",
+      "|-------|---------|------|----|-----|----|----|-----|----------------|---------|",
+      "| `/admin/dashboard/` | x | x | x | x | x | x | x | super-admin/001-dashboard |  |",
+      "| `/admin/clients/` | x | x | x | x | x | x | x | not_screenshotted: pending #79 |  |",
       "",
     ].join("\n"));
     const rows = runScript(fixture) as Array<{ persona: string; route: string; screenshot_ref: string }>;
@@ -46,9 +50,9 @@ describe("extract-inventory-routes.sh", () => {
     writeFileSync(fixture, [
       "## Caregiver",
       "",
-      "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
-      "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
-      "| Today's shifts | `/caregiver/today/` | x | x | x | x | x | x | x | caregiver/001-today | x | x |",
+      "| route | purpose | what | v2 | sev | mt | rls | phi | screenshot_ref | v2_link |",
+      "|-------|---------|------|----|-----|----|----|-----|----------------|---------|",
+      "| `/caregiver/today/` | x | x | x | x | x | x | x | caregiver/001-today |  |",
       "",
     ].join("\n"));
     const rows = runScript(fixture) as Array<{ persona: string; route: string; screenshot_ref: string }>;
@@ -65,9 +69,9 @@ describe("extract-inventory-routes.sh", () => {
     writeFileSync(fixture, [
       "## Random Section",
       "",
-      "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
-      "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
-      "| Should be ignored | `/random/` | x | x | x | x | x | x | x | random-ref | x | x |",
+      "| route | purpose | what | v2 | sev | mt | rls | phi | screenshot_ref | v2_link |",
+      "|-------|---------|------|----|-----|----|----|-----|----------------|---------|",
+      "| `/random/` | x | x | x | x | x | x | x | random-ref |  |",
       "",
     ].join("\n"));
     const rows = runScript(fixture) as unknown[];
@@ -80,10 +84,10 @@ describe("extract-inventory-routes.sh", () => {
     writeFileSync(fixture, [
       "## Super-Admin",
       "",
-      "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
-      "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
-      "| Real route | `/admin/dashboard/` | x | x | x | x | x | x | x | super-admin/001 | x | x |",
-      "| Summary row | total | x | x | x | x | x | x | x | x | x | x |",
+      "| route | purpose | what | v2 | sev | mt | rls | phi | screenshot_ref | v2_link |",
+      "|-------|---------|------|----|-----|----|----|-----|----------------|---------|",
+      "| `/admin/dashboard/` | x | x | x | x | x | x | x | super-admin/001 |  |",
+      "| total | summary | x | x | x | x | x | x | x |  |",
       "",
     ].join("\n"));
     const rows = runScript(fixture) as unknown[];
@@ -97,9 +101,9 @@ describe("extract-inventory-routes.sh", () => {
       .map((name, i) => [
         `## ${name}`,
         "",
-        "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
-        "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
-        `| Route ${i} | \`/route-${i}/\` | x | x | x | x | x | x | x | ref-${i} | x | x |`,
+        "| route | purpose | what | v2 | sev | mt | rls | phi | screenshot_ref | v2_link |",
+        "|-------|---------|------|----|-----|----|----|-----|----------------|---------|",
+        `| \`/route-${i}/\` | x | x | x | x | x | x | x | ref-${i} |  |`,
         "",
       ].join("\n"))
       .join("\n");

--- a/tools/v1-screenshot-catalog/__tests__/extract-inventory-routes.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/extract-inventory-routes.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve, join } from "node:path";
+
+// Tests the canonical inventory parser at scripts/extract-inventory-routes.sh.
+// This is the single source of truth shared between PR-A's coverage script
+// and PR-C's crawler — drift here breaks both.
+
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const SCRIPT = join(REPO_ROOT, "scripts", "extract-inventory-routes.sh");
+
+function runScript(inventoryPath: string): unknown {
+  const out = execFileSync("bash", [SCRIPT, "--inventory", inventoryPath]);
+  return JSON.parse(out.toString("utf-8"));
+}
+
+describe("extract-inventory-routes.sh", () => {
+  beforeAll(() => {
+    if (!existsSync(SCRIPT)) {
+      throw new Error(`script not found: ${SCRIPT}`);
+    }
+  });
+
+  it("emits a JSON array on stdout", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-test-"));
+    const fixture = join(dir, "inv.md");
+    writeFileSync(fixture, [
+      "## Super-Admin",
+      "",
+      "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
+      "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
+      "| Dashboard | `/admin/dashboard/` | x | x | x | x | x | x | x | super-admin/001-dashboard | x | x |",
+      "| Clients | `/admin/clients/` | x | x | x | x | x | x | x | not_screenshotted: pending #79 | x | x |",
+      "",
+    ].join("\n"));
+    const rows = runScript(fixture) as Array<{ persona: string; route: string; screenshot_ref: string }>;
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows).toHaveLength(2);
+  });
+
+  it("captures persona, route, screenshot_ref columns correctly", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-test-"));
+    const fixture = join(dir, "inv.md");
+    writeFileSync(fixture, [
+      "## Caregiver",
+      "",
+      "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
+      "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
+      "| Today's shifts | `/caregiver/today/` | x | x | x | x | x | x | x | caregiver/001-today | x | x |",
+      "",
+    ].join("\n"));
+    const rows = runScript(fixture) as Array<{ persona: string; route: string; screenshot_ref: string }>;
+    expect(rows[0]).toEqual({
+      persona: "Caregiver",
+      route: "/caregiver/today/",
+      screenshot_ref: "caregiver/001-today",
+    });
+  });
+
+  it("ignores rows outside a locked-persona H2 section", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-test-"));
+    const fixture = join(dir, "inv.md");
+    writeFileSync(fixture, [
+      "## Random Section",
+      "",
+      "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
+      "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
+      "| Should be ignored | `/random/` | x | x | x | x | x | x | x | random-ref | x | x |",
+      "",
+    ].join("\n"));
+    const rows = runScript(fixture) as unknown[];
+    expect(rows).toHaveLength(0);
+  });
+
+  it("ignores rows that don't have a backtick-slash route (excludes summary tables)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-test-"));
+    const fixture = join(dir, "inv.md");
+    writeFileSync(fixture, [
+      "## Super-Admin",
+      "",
+      "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
+      "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
+      "| Real route | `/admin/dashboard/` | x | x | x | x | x | x | x | super-admin/001 | x | x |",
+      "| Summary row | total | x | x | x | x | x | x | x | x | x | x |",
+      "",
+    ].join("\n"));
+    const rows = runScript(fixture) as unknown[];
+    expect(rows).toHaveLength(1);
+  });
+
+  it("handles all six locked persona names", () => {
+    const dir = mkdtempSync(join(tmpdir(), "inv-test-"));
+    const fixture = join(dir, "inv.md");
+    const sections = ["Super-Admin", "Agency Admin", "Care Manager", "Caregiver", "Client", "Family Member"]
+      .map((name, i) => [
+        `## ${name}`,
+        "",
+        "| Name | Route | x | x | x | x | x | x | x | screenshot_ref | x | x |",
+        "|------|-------|---|---|---|---|---|---|---|----------------|---|---|",
+        `| Route ${i} | \`/route-${i}/\` | x | x | x | x | x | x | x | ref-${i} | x | x |`,
+        "",
+      ].join("\n"))
+      .join("\n");
+    writeFileSync(fixture, sections);
+    const rows = runScript(fixture) as Array<{ persona: string }>;
+    expect(rows).toHaveLength(6);
+    const personas = rows.map((r) => r.persona).sort();
+    expect(personas).toEqual([
+      "Agency Admin",
+      "Care Manager",
+      "Caregiver",
+      "Client",
+      "Family Member",
+      "Super-Admin",
+    ]);
+  });
+
+  it("exits with code 2 on missing inventory file", () => {
+    let caught: unknown = null;
+    try {
+      execFileSync("bash", [SCRIPT, "--inventory", "/nonexistent/path.md"], { stdio: "pipe" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeTruthy();
+    expect((caught as { status?: number }).status).toBe(2);
+  });
+});

--- a/tools/v1-screenshot-catalog/__tests__/filters.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/filters.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyPersonaFilters,
+  applyRouteFilter,
+  deriveRouteSlug,
+  type CliArgs,
+  type InventoryRow,
+} from "../crawl.ts";
+import type { Persona } from "../personas.config.ts";
+
+const PERSONAS: Persona[] = [
+  { slug: "super-admin",   canonical: "Super-Admin",   username: "u1", password: "p1" },
+  { slug: "agency-admin",  canonical: "Agency Admin",  username: "u2", password: "p2" },
+  { slug: "care-manager",  canonical: "Care Manager",  username: "u3", password: "p3" },
+  { slug: "caregiver",     canonical: "Caregiver",     username: "u4", password: "p4" },
+  { slug: "family-member", canonical: "Family Member", username: "u5", password: "p5" },
+];
+
+const ROWS: InventoryRow[] = [
+  { persona: "Agency Admin", route: "/admin/clients/",                 screenshot_ref: "" },
+  { persona: "Agency Admin", route: "/admin/clients/<id>/chart/",      screenshot_ref: "" },
+  { persona: "Agency Admin", route: "/admin/clients/<id>/chart/notes/", screenshot_ref: "" },
+  { persona: "Agency Admin", route: "/admin/dashboard/",               screenshot_ref: "" },
+  { persona: "Agency Admin", route: "/admin/billing/",                 screenshot_ref: "" },
+];
+
+const baseCli = (overrides: Partial<CliArgs> = {}): CliArgs => ({
+  outputDir: "/tmp/out",
+  ...overrides,
+});
+
+describe("applyPersonaFilters", () => {
+  it("returns all personas when no filters set", () => {
+    const out = applyPersonaFilters(PERSONAS, baseCli());
+    expect(out).toHaveLength(PERSONAS.length);
+    expect(out.map((p) => p.slug)).toEqual(PERSONAS.map((p) => p.slug));
+  });
+
+  it("onlyPersonas restricts to the named slugs, preserving order", () => {
+    const out = applyPersonaFilters(PERSONAS, baseCli({ onlyPersonas: ["caregiver", "agency-admin"] }));
+    expect(out.map((p) => p.slug)).toEqual(["agency-admin", "caregiver"]);
+  });
+
+  it("resumeFrom slices starting at the matching slug", () => {
+    const out = applyPersonaFilters(PERSONAS, baseCli({ resumeFrom: "caregiver" }));
+    expect(out.map((p) => p.slug)).toEqual(["caregiver", "family-member"]);
+  });
+
+  it("resumeFrom not found is a no-op (returns full list)", () => {
+    const out = applyPersonaFilters(PERSONAS, baseCli({ resumeFrom: "client" }));
+    expect(out.map((p) => p.slug)).toEqual(PERSONAS.map((p) => p.slug));
+  });
+
+  it("resumeFrom + onlyPersonas: filter first, then resume within the filtered set", () => {
+    const out = applyPersonaFilters(
+      PERSONAS,
+      baseCli({ onlyPersonas: ["agency-admin", "care-manager", "caregiver"], resumeFrom: "care-manager" }),
+    );
+    expect(out.map((p) => p.slug)).toEqual(["care-manager", "caregiver"]);
+  });
+});
+
+describe("applyRouteFilter", () => {
+  it("returns all rows when no filter set", () => {
+    const out = applyRouteFilter(ROWS, "agency-admin", baseCli());
+    expect(out).toHaveLength(ROWS.length);
+  });
+
+  it("onlyRoutes with NNN- prefix matches the slug exactly (NNN- is stripped)", () => {
+    // "001-clients" → slug "clients" → matches /admin/clients/ only
+    const out = applyRouteFilter(ROWS, "agency-admin", baseCli({
+      onlyRoutes: ["agency-admin/001-clients"],
+    }));
+    expect(out).toHaveLength(1);
+    expect(out[0].route).toBe("/admin/clients/");
+  });
+
+  it("does NOT over-match when slugs share a common suffix (regression for endsWith bug)", () => {
+    // Phase 2A bug: applyRouteFilter used .endsWith(slug) which would match
+    // "/admin/clients/<id>/chart/notes/" (slug "notes") against any tail.
+    // Verify: "agency-admin/notes" matches ONLY the notes row.
+    const out = applyRouteFilter(ROWS, "agency-admin", baseCli({
+      onlyRoutes: ["agency-admin/notes"],
+    }));
+    expect(out).toHaveLength(1);
+    expect(out[0].route).toBe("/admin/clients/<id>/chart/notes/");
+  });
+
+  it("onlyRoutes without NNN- prefix matches by slug directly", () => {
+    const out = applyRouteFilter(ROWS, "agency-admin", baseCli({
+      onlyRoutes: ["agency-admin/dashboard"],
+    }));
+    expect(out).toHaveLength(1);
+    expect(out[0].route).toBe("/admin/dashboard/");
+  });
+
+  it("multiple canonical_ids OR together", () => {
+    const out = applyRouteFilter(ROWS, "agency-admin", baseCli({
+      onlyRoutes: ["agency-admin/001-dashboard", "agency-admin/billing"],
+    }));
+    expect(out.map((r) => r.route).sort()).toEqual([
+      "/admin/billing/",
+      "/admin/dashboard/",
+    ]);
+  });
+
+  it("canonical_ids targeted at OTHER personas are ignored", () => {
+    // Operator passed a caregiver canonical_id; agency-admin filter should
+    // get nothing (the caregiver id matches no agency-admin rows).
+    const out = applyRouteFilter(ROWS, "agency-admin", baseCli({
+      onlyRoutes: ["caregiver/001-clock-in"],
+    }));
+    expect(out).toHaveLength(0);
+  });
+
+  it("returns empty array when onlyRoutes set but matches nothing", () => {
+    const out = applyRouteFilter(ROWS, "agency-admin", baseCli({
+      onlyRoutes: ["agency-admin/nonexistent-route"],
+    }));
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe("deriveRouteSlug", () => {
+  it("takes the last non-placeholder segment", () => {
+    expect(deriveRouteSlug("/admin/clients/<id>/chart/")).toBe("chart");
+    expect(deriveRouteSlug("/admin/dashboard/")).toBe("dashboard");
+  });
+
+  it("strips trailing/leading slashes", () => {
+    expect(deriveRouteSlug("/foo/bar/")).toBe("bar");
+    expect(deriveRouteSlug("foo/bar")).toBe("bar");
+  });
+
+  it("returns 'root' for the bare root path", () => {
+    expect(deriveRouteSlug("/")).toBe("root");
+  });
+
+  it("lowercases and replaces non-alnum with dash", () => {
+    expect(deriveRouteSlug("/admin/Client_Detail/")).toBe("client-detail");
+  });
+});

--- a/tools/v1-screenshot-catalog/__tests__/frontmatter-writer.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/frontmatter-writer.test.ts
@@ -1,12 +1,18 @@
 import { describe, it, expect } from "vitest";
 import { renderCaption } from "../crawl.ts";
 
+// Phase 2A renamed `viewport` → `lead_viewport` because each caption file
+// describes BOTH viewport WebPs (one per route, not one per viewport-pair).
+// The lead_viewport field encodes which viewport is canonical for the
+// persona — Caregiver / Family Member lead with mobile per RESPONSIVE.md;
+// other personas lead with desktop.
+
 describe("renderCaption", () => {
   const fm = {
     canonicalId: "agency-admin/001-dashboard",
     route: "/admin/todays-shifts/",
     persona: "Agency Admin",
-    viewport: "desktop" as const,
+    leadViewport: "desktop" as const,
     seedState: "populated",
     v1Commit: "9738412a6e41064203fc253d9dd2a5c6a9c2e231",
     generated: "2026-05-07",
@@ -16,20 +22,25 @@ describe("renderCaption", () => {
     const out = renderCaption(fm);
     const lines = out.trimEnd().split("\n");
     expect(lines[0]).toBe("---");
-    // Find the second --- delimiter
     const secondDelim = lines.indexOf("---", 1);
     expect(secondDelim).toBeGreaterThan(0);
   });
 
-  it("contains every required frontmatter field", () => {
+  it("contains every required frontmatter field, including lead_viewport", () => {
     const out = renderCaption(fm);
     expect(out).toContain("canonical_id: agency-admin/001-dashboard");
     expect(out).toContain("route: /admin/todays-shifts/");
     expect(out).toContain("persona: Agency Admin");
-    expect(out).toContain("viewport: desktop");
+    expect(out).toContain("lead_viewport: desktop");
     expect(out).toContain("seed_state: populated");
     expect(out).toContain("v1_commit: 9738412a6e41064203fc253d9dd2a5c6a9c2e231");
     expect(out).toContain("generated: 2026-05-07");
+  });
+
+  it("does NOT emit the deprecated `viewport:` field", () => {
+    // The Phase 1 schema used `viewport: desktop|mobile`; Phase 2A renames it.
+    const out = renderCaption(fm);
+    expect(out).not.toMatch(/^viewport:/m);
   });
 
   it("includes the TODO marker for the body", () => {
@@ -38,17 +49,15 @@ describe("renderCaption", () => {
   });
 
   it("frontmatter canonical_id matches the file path the caller will use", () => {
-    // The canonical_id is the cross-reference handle. It MUST equal
-    // <persona-slug>/<file-base> exactly — coverage-check parses this.
     const out = renderCaption(fm);
     const match = out.match(/canonical_id:\s*(\S+)/);
     expect(match).not.toBeNull();
     expect(match?.[1]).toBe("agency-admin/001-dashboard");
   });
 
-  it("renders mobile viewport correctly", () => {
-    const mobile = { ...fm, viewport: "mobile" as const };
-    expect(renderCaption(mobile)).toContain("viewport: mobile");
+  it("renders mobile lead_viewport correctly", () => {
+    const mobile = { ...fm, leadViewport: "mobile" as const };
+    expect(renderCaption(mobile)).toContain("lead_viewport: mobile");
   });
 
   it("preserves canonical persona names with spaces", () => {
@@ -57,5 +66,28 @@ describe("renderCaption", () => {
 
     const fm2 = { ...fm, persona: "Family Member" };
     expect(renderCaption(fm2)).toContain("persona: Family Member");
+  });
+});
+
+// leadViewportFor: pure helper that picks the canonical lead viewport for
+// a given persona slug. Caregiver + Family Member lead mobile; everyone
+// else leads desktop. Phase 2A.
+import { leadViewportFor } from "../crawl.ts";
+
+describe("leadViewportFor", () => {
+  it("returns 'mobile' for caregiver and family-member", () => {
+    expect(leadViewportFor("caregiver")).toBe("mobile");
+    expect(leadViewportFor("family-member")).toBe("mobile");
+  });
+
+  it("returns 'desktop' for super-admin, agency-admin, care-manager, client", () => {
+    expect(leadViewportFor("super-admin")).toBe("desktop");
+    expect(leadViewportFor("agency-admin")).toBe("desktop");
+    expect(leadViewportFor("care-manager")).toBe("desktop");
+    expect(leadViewportFor("client")).toBe("desktop");
+  });
+
+  it("defaults to 'desktop' for unknown persona slugs", () => {
+    expect(leadViewportFor("unknown-slug")).toBe("desktop");
   });
 });

--- a/tools/v1-screenshot-catalog/__tests__/manifest.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/manifest.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { renderManifest } from "../crawl.ts";
+
+// renderManifest is a pure function that produces the markdown body of
+// RUN-MANIFEST.md. Phase 2A added operator/host/playwright_version fields
+// so a forensic reader can answer "who ran this where with what tooling"
+// years from now.
+
+describe("renderManifest", () => {
+  const baseArgs = {
+    v1BaseUrl: "http://localhost:8000",
+    v1Commit: "9738412a6e41064203fc253d9dd2a5c6a9c2e231",
+    fixtureHash: "abcd1234ef567890",
+    activeCanonicals: ["Super-Admin", "Caregiver"],
+    skippedCanonicals: ["Agency Admin"],
+    captured: 134,
+    skipped: 4,
+    errored: 0,
+    intercepted: 12,
+    startTs: "2026-05-07T12:00:00.000Z",
+    endTs: "2026-05-07T12:30:00.000Z",
+    operator: "suniljames",
+    host: "Darwin",
+    playwrightVersion: "1.49.0",
+  } as const;
+
+  it("includes every required field as a labeled line", () => {
+    const md = renderManifest(baseArgs);
+    expect(md).toContain("**v1 commit:** 9738412a6e41064203fc253d9dd2a5c6a9c2e231");
+    expect(md).toContain("**v1 base URL:** http://localhost:8000");
+    expect(md).toContain("**Started:** 2026-05-07T12:00:00.000Z");
+    expect(md).toContain("**Generated:** 2026-05-07T12:30:00.000Z");
+    expect(md).toContain("**Fixture sha256:** abcd1234ef567890");
+  });
+
+  it("records operator, host, and playwright_version (Phase 2A audit fields)", () => {
+    const md = renderManifest(baseArgs);
+    expect(md).toContain("**Operator:** suniljames");
+    expect(md).toContain("**Host:** Darwin");
+    expect(md).toContain("**Playwright version:** 1.49.0");
+  });
+
+  it("lists active and skipped personas", () => {
+    const md = renderManifest(baseArgs);
+    expect(md).toContain("**Active:** Super-Admin, Caregiver");
+    expect(md).toContain("**Skipped (no credentials):** Agency Admin");
+  });
+
+  it("renders counts including non-GET intercepted", () => {
+    const md = renderManifest(baseArgs);
+    expect(md).toContain("Routes captured: 134");
+    expect(md).toContain("Routes skipped: 4");
+    expect(md).toContain("Routes errored: 0");
+    expect(md).toContain("Non-GET requests intercepted: 12");
+  });
+
+  it("renders '(none)' when active or skipped lists are empty", () => {
+    const md = renderManifest({ ...baseArgs, activeCanonicals: [], skippedCanonicals: [] });
+    expect(md).toContain("**Active:** (none)");
+    expect(md).toContain("**Skipped (no credentials):** (none)");
+  });
+
+  it("opens with a forensic-context paragraph (Writer NIT)", () => {
+    const md = renderManifest(baseArgs);
+    // The first non-heading line should be a paragraph that frames the
+    // file's purpose for someone who lands on it cold.
+    expect(md).toMatch(/This manifest documents/);
+  });
+});

--- a/tools/v1-screenshot-catalog/__tests__/network-interception.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/network-interception.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { shouldAllowRequest } from "../crawl.ts";
+
+// shouldAllowRequest decides whether Playwright should `continue` or `abort`
+// a request. It is the unit-testable kernel of crawl.ts's setupNetworkInterception
+// function. T4 of #107 — destructive-endpoint protection — reduces to "what
+// does this function return for each (method, url, v1BaseUrl) input?"
+
+const V1 = "http://localhost:8000";
+
+describe("shouldAllowRequest", () => {
+  it("allows GETs to same-origin URLs", () => {
+    expect(shouldAllowRequest({ method: "GET", url: `${V1}/dashboard/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: true });
+    expect(shouldAllowRequest({ method: "GET", url: `${V1}/admin/clients/42/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: true });
+  });
+
+  it("allows GETs to cross-origin URLs that aren't on the production blocklist", () => {
+    // The crawler may legitimately fetch fonts/CDN assets from third-party hosts.
+    expect(shouldAllowRequest({ method: "GET", url: "https://fonts.googleapis.com/css", v1BaseUrl: V1 }))
+      .toMatchObject({ allow: true });
+  });
+
+  it("blocks any request to a production-blocked host (even GET)", () => {
+    expect(shouldAllowRequest({ method: "GET", url: "https://bayareaelitehomecare.com/", v1BaseUrl: V1 }))
+      .toMatchObject({ allow: false, reason: "blocked-host" });
+    expect(shouldAllowRequest({ method: "POST", url: "https://corecare.app/api/", v1BaseUrl: V1 }))
+      .toMatchObject({ allow: false, reason: "blocked-host" });
+  });
+
+  it("allows non-GET methods that match an allowlist fragment (login)", () => {
+    expect(shouldAllowRequest({ method: "POST", url: `${V1}/dashboard/login/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: true });
+    expect(shouldAllowRequest({ method: "POST", url: `${V1}/dashboard/logout/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: true });
+  });
+
+  it("allows role-switch and magic-link redeem (other allowlisted POSTs)", () => {
+    expect(shouldAllowRequest({ method: "POST", url: `${V1}/role-switch/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: true });
+    expect(shouldAllowRequest({ method: "POST", url: `${V1}/auth/magic-link/redeem/abc/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: true });
+  });
+
+  it("blocks non-GET methods that are NOT on the allowlist", () => {
+    // The destructive-endpoint guard's whole point.
+    expect(shouldAllowRequest({ method: "POST", url: `${V1}/admin/clients/42/delete/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: false, reason: "non-get-not-allowlisted" });
+    expect(shouldAllowRequest({ method: "DELETE", url: `${V1}/admin/clients/42/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: false, reason: "non-get-not-allowlisted" });
+    expect(shouldAllowRequest({ method: "PUT", url: `${V1}/admin/clients/42/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: false, reason: "non-get-not-allowlisted" });
+    expect(shouldAllowRequest({ method: "PATCH", url: `${V1}/admin/clients/42/`, v1BaseUrl: V1 }))
+      .toMatchObject({ allow: false, reason: "non-get-not-allowlisted" });
+  });
+
+  it("returns the matched allowlist fragment in the result for allowlisted POSTs (audit trail)", () => {
+    const r = shouldAllowRequest({
+      method: "POST",
+      url: `${V1}/dashboard/login/`,
+      v1BaseUrl: V1,
+    });
+    expect(r.allow).toBe(true);
+    expect(r.allowedByFragment).toBe("/dashboard/login/");
+  });
+
+  it("blocked-host check runs BEFORE the GET fast-path (a malicious page-script GET to prod is still blocked)", () => {
+    // Defense-in-depth: even if the page tries to GET a production endpoint,
+    // we still abort it. The hostname blocklist is the outer layer.
+    const r = shouldAllowRequest({
+      method: "GET",
+      url: "https://corecare.app/api/users",
+      v1BaseUrl: V1,
+    });
+    expect(r.allow).toBe(false);
+    expect(r.reason).toBe("blocked-host");
+  });
+});

--- a/tools/v1-screenshot-catalog/__tests__/retry.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/retry.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+import { retryWithBackoff } from "../crawl.ts";
+
+// Phase 2A SWE SHOULD-FIX: 3-retry / 1s-3s-9s backoff on TimeoutError, no
+// retry on other errors. This tests the wrapper in isolation; integration
+// with captureRoute is covered by the full E2E run.
+
+class TimeoutError extends Error {
+  override name = "TimeoutError";
+}
+
+describe("retryWithBackoff", () => {
+  it("returns the result on first success without sleeping", async () => {
+    const fn = vi.fn(async () => "ok");
+    const sleep = vi.fn(async () => {});
+    const result = await retryWithBackoff(fn, { attempts: 3, baseMs: 1000, sleep });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries on TimeoutError up to attempts-1 times then re-throws", async () => {
+    const fn = vi.fn(async () => {
+      throw new TimeoutError("timeout");
+    });
+    const sleep = vi.fn(async () => {});
+    await expect(
+      retryWithBackoff(fn, { attempts: 3, baseMs: 1000, sleep }),
+    ).rejects.toThrow(/timeout/);
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2); // sleeps between attempts, not after last
+  });
+
+  it("uses exponential backoff with the documented schedule (1s, 3s, 9s)", async () => {
+    const sleeps: number[] = [];
+    const fn = vi.fn(async () => {
+      throw new TimeoutError("timeout");
+    });
+    const sleep = vi.fn(async (ms: number) => {
+      sleeps.push(ms);
+    });
+    await expect(
+      retryWithBackoff(fn, { attempts: 4, baseMs: 1000, sleep }),
+    ).rejects.toThrow();
+    // 4 attempts = 3 sleeps; 1s, 3s, 9s
+    expect(sleeps).toEqual([1000, 3000, 9000]);
+  });
+
+  it("does NOT retry non-TimeoutError errors; rethrows immediately", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("permanent");
+    });
+    const sleep = vi.fn(async () => {});
+    await expect(
+      retryWithBackoff(fn, { attempts: 3, baseMs: 1000, sleep }),
+    ).rejects.toThrow(/permanent/);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("succeeds if a retry attempt returns successfully", async () => {
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls++;
+      if (calls < 3) throw new TimeoutError("transient");
+      return "eventually-ok";
+    });
+    const sleep = vi.fn(async () => {});
+    const result = await retryWithBackoff(fn, { attempts: 3, baseMs: 1000, sleep });
+    expect(result).toBe("eventually-ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tools/v1-screenshot-catalog/check-reproducibility.ts
+++ b/tools/v1-screenshot-catalog/check-reproducibility.ts
@@ -134,7 +134,14 @@ async function main(): Promise<void> {
   const bHash = readManifestField(cli.baseline, "Fixture sha256");
   const rHash = readManifestField(cli.rerun, "Fixture sha256");
   let fixtureHashOk = true;
-  if (bHash === null || rHash === null) {
+  // The literal `<unset>` placeholder means the crawler ran without
+  // V1_FIXTURE_SHA256 set. Treat it as missing (NOT as a value to compare);
+  // otherwise two runs both placeholdered would produce a false-positive
+  // "fixture hashes match" verdict.
+  const sentinelPattern = /^<unset>$/;
+  const bMissing = bHash === null || sentinelPattern.test(bHash);
+  const rMissing = rHash === null || sentinelPattern.test(rHash);
+  if (bMissing || rMissing) {
     console.warn(
       `warning: fixture-hash gate skipped — RUN-MANIFEST.md missing or no Fixture sha256 field (baseline=${bHash ?? "missing"}, rerun=${rHash ?? "missing"})`,
     );

--- a/tools/v1-screenshot-catalog/check-reproducibility.ts
+++ b/tools/v1-screenshot-catalog/check-reproducibility.ts
@@ -1,0 +1,199 @@
+// Compares two v1-UI-catalog directories and emits a per-image pixel-diff
+// report. T2 of #107: byte-identical (AA-jitter only) re-run.
+//
+// Replaces the prior bash-orchestrated `npx --yes` per-image variant which
+// re-resolved every package on every invocation (300+ npx calls for a full
+// catalog comparison). This in-process variant uses sharp (already installed
+// as a runtime dep) + pixelmatch + pngjs from devDependencies.
+//
+// Usage:
+//   pnpm tsx check-reproducibility.ts <baseline-dir> <rerun-dir>
+//     [--threshold-pct N]   default 0.5 (percent of pixels allowed to differ)
+//     [--output-dir <path>] default <rerun-dir>/reproducibility-report
+//
+// Exit codes:
+//   0  every image is within threshold AND fixture hashes match
+//   1  one or more images exceed threshold OR fixture hashes diverge
+//   2  bad invocation
+
+import { readdirSync, readFileSync, mkdirSync, writeFileSync, statSync, existsSync } from "node:fs";
+import { join, relative } from "node:path";
+import sharp from "sharp";
+// pixelmatch 7.x ships its own types; pngjs types come from @types/pngjs.
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+
+interface CliArgs {
+  baseline: string;
+  rerun: string;
+  thresholdPct: number;
+  outputDir: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: Partial<CliArgs> = { thresholdPct: 0.5 };
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--threshold-pct") {
+      args.thresholdPct = parseFloat(argv[++i]);
+    } else if (argv[i] === "--output-dir") {
+      args.outputDir = argv[++i];
+    } else if (argv[i] === "-h" || argv[i] === "--help") {
+      console.log(
+        "usage: pnpm tsx check-reproducibility.ts <baseline-dir> <rerun-dir> [--threshold-pct N] [--output-dir <path>]",
+      );
+      process.exit(0);
+    } else if (argv[i].startsWith("--")) {
+      console.error(`unknown flag: ${argv[i]}`);
+      process.exit(2);
+    } else {
+      positional.push(argv[i]);
+    }
+  }
+  if (positional.length !== 2) {
+    console.error("error: must pass two positional args: <baseline-dir> <rerun-dir>");
+    process.exit(2);
+  }
+  args.baseline = positional[0];
+  args.rerun = positional[1];
+  args.outputDir ??= `${args.rerun}/reproducibility-report`;
+  return args as CliArgs;
+}
+
+function findWebPs(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    if (!existsSync(dir)) return;
+    for (const name of readdirSync(dir)) {
+      const path = join(dir, name);
+      const st = statSync(path);
+      if (st.isDirectory()) walk(path);
+      else if (st.isFile() && name.endsWith(".webp")) out.push(path);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+async function decodePng(filepath: string): Promise<PNG> {
+  const png = await sharp(filepath).png().toBuffer();
+  return PNG.sync.read(png);
+}
+
+interface DiffResult {
+  canonicalId: string;
+  viewport: string;
+  diffPct: number;
+  status: "ok" | "exceeded" | "size-mismatch" | "missing-rerun";
+}
+
+async function compareImage(baseline: string, rerun: string, diffOut: string): Promise<{ diffPct: number; status: DiffResult["status"] }> {
+  if (!existsSync(rerun)) {
+    return { diffPct: NaN, status: "missing-rerun" };
+  }
+  const [b, r] = await Promise.all([decodePng(baseline), decodePng(rerun)]);
+  if (b.width !== r.width || b.height !== r.height) {
+    return { diffPct: NaN, status: "size-mismatch" };
+  }
+  const diff = new PNG({ width: b.width, height: b.height });
+  const differingPixels = pixelmatch(b.data, r.data, diff.data, b.width, b.height, {
+    threshold: 0.1,
+  });
+  const totalPixels = b.width * b.height;
+  const diffPct = (differingPixels / totalPixels) * 100;
+  mkdirSync(diffOut.substring(0, diffOut.lastIndexOf("/")) || ".", { recursive: true });
+  writeFileSync(diffOut, PNG.sync.write(diff));
+  return { diffPct, status: "ok" };
+}
+
+function readManifestField(dir: string, field: string): string | null {
+  const path = join(dir, "RUN-MANIFEST.md");
+  if (!existsSync(path)) return null;
+  const md = readFileSync(path, "utf-8");
+  const re = new RegExp(`\\*\\*${field}:\\*\\*\\s*(\\S+)`);
+  const m = md.match(re);
+  return m ? m[1] : null;
+}
+
+async function main(): Promise<void> {
+  const cli = parseArgs(process.argv.slice(2));
+
+  if (!existsSync(cli.baseline)) {
+    console.error(`error: baseline dir not found: ${cli.baseline}`);
+    process.exit(2);
+  }
+  if (!existsSync(cli.rerun)) {
+    console.error(`error: rerun dir not found: ${cli.rerun}`);
+    process.exit(2);
+  }
+  mkdirSync(cli.outputDir, { recursive: true });
+
+  // Fixture-hash equality gate (Data Engineer Phase 2 MUST-FIX): if the two
+  // runs used different fixtures, this isn't a determinism failure — it's
+  // fixture drift. Surface that distinction loudly.
+  const bHash = readManifestField(cli.baseline, "Fixture sha256");
+  const rHash = readManifestField(cli.rerun, "Fixture sha256");
+  let fixtureHashOk = true;
+  if (bHash === null || rHash === null) {
+    console.warn(
+      `warning: fixture-hash gate skipped — RUN-MANIFEST.md missing or no Fixture sha256 field (baseline=${bHash ?? "missing"}, rerun=${rHash ?? "missing"})`,
+    );
+  } else if (bHash !== rHash) {
+    console.error(
+      `error: fixture hashes diverge between baseline (${bHash}) and rerun (${rHash}). This is NOT a determinism failure — the seed dataset itself changed between runs. Re-run both crawls against the same fixture before comparing.`,
+    );
+    fixtureHashOk = false;
+  }
+
+  const baselineFiles = findWebPs(cli.baseline);
+  const results: DiffResult[] = [];
+
+  for (const baselineFile of baselineFiles) {
+    const rel = relative(cli.baseline, baselineFile);
+    const rerunFile = join(cli.rerun, rel);
+    const canonicalId = rel
+      .replace(/\.desktop\.webp$/, "")
+      .replace(/\.mobile\.webp$/, "");
+    const viewport = rel.endsWith(".desktop.webp") ? "desktop" : "mobile";
+    const diffPath = join(cli.outputDir, rel.replace(/\.webp$/, ".diff.png"));
+
+    const { diffPct, status } = await compareImage(baselineFile, rerunFile, diffPath);
+    let finalStatus: DiffResult["status"] = status;
+    if (status === "ok" && diffPct > cli.thresholdPct) finalStatus = "exceeded";
+    results.push({ canonicalId, viewport, diffPct, status: finalStatus });
+  }
+
+  const exceeded = results.filter((r) => r.status !== "ok").length;
+  const total = results.length;
+
+  // Render report.md
+  const lines = [
+    "# Catalog reproducibility report",
+    "",
+    `**Baseline:** ${cli.baseline}`,
+    `**Rerun:** ${cli.rerun}`,
+    `**Threshold:** ${cli.thresholdPct}% per-image pixel diff`,
+    `**Fixture hashes match:** ${fixtureHashOk ? "yes" : "NO — see error above"}`,
+    "",
+    "| canonical_id | viewport | diff% | status |",
+    "|--------------|----------|------:|--------|",
+  ];
+  for (const r of results) {
+    const pct = Number.isFinite(r.diffPct) ? `${r.diffPct.toFixed(4)}%` : "n/a";
+    lines.push(`| ${r.canonicalId} | ${r.viewport} | ${pct} | ${r.status} |`);
+  }
+  lines.push("", "## Summary", "", `- Total compared: ${total}`, `- Within threshold: ${total - exceeded}`, `- Exceeded / failed: ${exceeded}`);
+
+  const reportPath = join(cli.outputDir, "report.md");
+  writeFileSync(reportPath, lines.join("\n") + "\n");
+
+  console.log(`Total: ${total}, exceeded/failed: ${exceeded}, fixture hashes match: ${fixtureHashOk}`);
+  console.log(`Report: ${reportPath}`);
+
+  if (exceeded > 0 || !fixtureHashOk) process.exit(1);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tools/v1-screenshot-catalog/crawl.ts
+++ b/tools/v1-screenshot-catalog/crawl.ts
@@ -6,12 +6,25 @@
 //
 // This file is deliberately ~one screen of code per concern. No abstractions,
 // no plugin systems — one-shot tooling.
+//
+// Worker concurrency is intentionally NOT exposed. With ~134 inventory rows × 2
+// viewports = ~270 page loads × 2.5s avg, single-worker runtime is ~11 min on
+// a developer's Mac. Adding workers buys little and adds 4× v1 connection load.
 
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync, existsSync, accessSync, constants as fsConstants } from "node:fs";
+import {
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  accessSync,
+  constants as fsConstants,
+  createWriteStream,
+  type WriteStream,
+} from "node:fs";
 import { resolve, dirname } from "node:path";
 import { createHash } from "node:crypto";
+import { hostname, platform } from "node:os";
 import sharp from "sharp";
 import { ACTIVE_PERSONAS, SKIPPED_PERSONAS, type Persona } from "./personas.config.ts";
 import { ROUTES_ALLOWLIST, ALLOWED_NON_GET_FRAGMENTS } from "./routes-allowlist.ts";
@@ -31,10 +44,43 @@ export function isBlockedHost(url: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Network-interception predicate. Pure function so we can unit-test it
+// without spinning up Playwright. T4 of #107 reduces to "what does this
+// return for each (method, url, v1BaseUrl) input?"
+// ---------------------------------------------------------------------------
+
+export interface AllowDecision {
+  allow: boolean;
+  reason?: "blocked-host" | "non-get-not-allowlisted";
+  allowedByFragment?: string;
+}
+
+export function shouldAllowRequest(input: {
+  method: string;
+  url: string;
+  v1BaseUrl: string;
+}): AllowDecision {
+  // Defense-in-depth: production-hostname block runs first. Even a GET to a
+  // production URL is aborted (a malicious page-script could try this).
+  if (isBlockedHost(input.url) && !input.url.startsWith(input.v1BaseUrl)) {
+    return { allow: false, reason: "blocked-host" };
+  }
+  if (input.method === "GET") {
+    return { allow: true };
+  }
+  // Non-GET: must match an allowlist fragment.
+  const matched = ALLOWED_NON_GET_FRAGMENTS.find((frag) => input.url.includes(frag));
+  if (matched) {
+    return { allow: true, allowedByFragment: matched };
+  }
+  return { allow: false, reason: "non-get-not-allowlisted" };
+}
+
+// ---------------------------------------------------------------------------
 // Inventory parsing — shells out to the canonical bash extractor, parses JSON.
 // ---------------------------------------------------------------------------
 
-interface InventoryRow {
+export interface InventoryRow {
   persona: string;
   route: string;
   screenshot_ref: string;
@@ -47,6 +93,110 @@ function loadInventory(repoRoot: string): InventoryRow[] {
     `${repoRoot}/docs/migration/v1-pages-inventory.md`,
   ]);
   return JSON.parse(out.toString("utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// CLI args. Parser is a pure function so tests can drive it without spawning
+// a process. exitOnError=false makes the parser throw instead of exit — used
+// by tests to assert error messages.
+// ---------------------------------------------------------------------------
+
+export interface CliArgs {
+  outputDir: string;
+  resumeFrom?: string;
+  onlyPersonas?: string[];
+  onlyRoutes?: string[];
+}
+
+interface ParseOpts {
+  exitOnError?: boolean;
+}
+
+export function parseArgs(argv: string[], opts: ParseOpts = { exitOnError: true }): CliArgs {
+  const args: Partial<CliArgs> = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--output-dir") {
+      args.outputDir = argv[++i];
+    } else if (argv[i] === "--resume-from") {
+      args.resumeFrom = argv[++i];
+    } else if (argv[i] === "--only-personas") {
+      args.onlyPersonas = argv[++i]
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    } else if (argv[i] === "--only-routes") {
+      args.onlyRoutes = argv[++i]
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    } else if (argv[i] === "--help" || argv[i] === "-h") {
+      console.log(
+        "usage: pnpm crawl --output-dir <path> [--resume-from <slug>] [--only-personas a,b] [--only-routes id,id]",
+      );
+      process.exit(0);
+    } else {
+      const msg = `unknown arg: ${argv[i]}`;
+      if (opts.exitOnError) {
+        console.error(msg);
+        process.exit(2);
+      }
+      throw new Error(msg);
+    }
+  }
+  if (!args.outputDir) {
+    const msg = "--output-dir is required";
+    if (opts.exitOnError) {
+      console.error(`error: ${msg}`);
+      process.exit(2);
+    }
+    throw new Error(msg);
+  }
+  return args as CliArgs;
+}
+
+// ---------------------------------------------------------------------------
+// Lead-viewport policy. Caregivers and family members work primarily from
+// phones in the field (per docs/design-system/RESPONSIVE.md); their catalog
+// captions lead with the mobile WebP. Other personas lead desktop.
+// ---------------------------------------------------------------------------
+
+export function leadViewportFor(personaSlug: string): "desktop" | "mobile" {
+  return personaSlug === "caregiver" || personaSlug === "family-member"
+    ? "mobile"
+    : "desktop";
+}
+
+// ---------------------------------------------------------------------------
+// Retry-with-backoff. Used to wrap page.goto + screenshot calls in
+// captureRoute. Only TimeoutError is retried; other errors propagate
+// immediately. Schedule: 1s, 3s, 9s (each = baseMs × 3^attempt).
+// ---------------------------------------------------------------------------
+
+interface RetryOpts {
+  attempts: number;
+  baseMs: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export async function retryWithBackoff<T>(fn: () => Promise<T>, opts: RetryOpts): Promise<T> {
+  const sleep = opts.sleep ?? defaultSleep;
+  let lastErr: unknown;
+  for (let i = 0; i < opts.attempts; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastErr = e;
+      if (!(e instanceof Error) || e.name !== "TimeoutError") {
+        throw e;
+      }
+      if (i < opts.attempts - 1) {
+        await sleep(opts.baseMs * Math.pow(3, i));
+      }
+    }
+  }
+  throw lastErr;
 }
 
 // ---------------------------------------------------------------------------
@@ -122,27 +272,23 @@ function fail(msg: string): never {
 }
 
 // ---------------------------------------------------------------------------
-// Determinism harness — encoded in page.addInitScript before any v1 page JS
-// runs. Each item documented; future maintainers will want to know why.
+// Determinism harness — encoded as a single addInitScript registered ONCE per
+// BrowserContext (Phase 2A fix: the prior version registered per-route which
+// accumulated stacked overrides on every page load).
 // ---------------------------------------------------------------------------
 
-function makeDeterminismScript(canonicalId: string, v1Commit: string): string {
-  // Seeded RNG (mulberry32) — derived from sha256(v1_commit + canonical_id)
-  // so every distinct route gets its own deterministic seed but the SAME
-  // route across re-runs produces the same screenshots.
-  const seedHex = createHash("sha256").update(v1Commit + canonicalId).digest("hex").slice(0, 8);
+function makeDeterminismScript(personaSlug: string, v1Commit: string): string {
+  // Seed derived from sha256(v1_commit + persona_slug). Same persona's pages
+  // share an RNG seed; same input across re-runs produces the same output.
+  const seedHex = createHash("sha256").update(v1Commit + personaSlug).digest("hex").slice(0, 8);
   const seed = parseInt(seedHex, 16);
-
-  // The mocked timestamp is the v1 commit's tagger date. We don't actually
-  // know it without `git log`, so we use a stable derived value: parseInt of
-  // the first 8 chars of the SHA. Pages that show "now" or "today" will
-  // render this constant, which is fine — they re-render the same value
-  // every run.
+  // Mocked timestamp: parseInt of v1 SHA's first 8 chars. Stable across runs.
   const fakeNow = parseInt(v1Commit.slice(0, 8), 16);
 
   return `
     (function() {
-      // 1. Seeded RNG. Mulberry32 — small, deterministic.
+      // 1. Seeded RNG (mulberry32). Replaces Math.random for any v1 page
+      //    JS that uses it; same seed → same sequence across re-runs.
       let s = ${seed};
       Math.random = function() {
         s = (s + 0x6D2B79F5) | 0;
@@ -152,28 +298,27 @@ function makeDeterminismScript(canonicalId: string, v1Commit: string): string {
         return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
       };
 
-      // 2. Mock Date — only the constructor + Date.now. Other Date methods
-      // delegate to the real implementation against the mocked instant.
+      // 2. Mock Date constructor + Date.now to a fixed instant. Pages that
+      //    show "now" or "today" render this constant value every run.
       const RealDate = Date;
       const fixed = ${fakeNow};
       function MockDate(...args) {
+        if (!(this instanceof MockDate)) return new RealDate(fixed).toString();
         if (args.length === 0) return new RealDate(fixed);
         return new RealDate(...args);
       }
       MockDate.now = () => fixed;
       MockDate.parse = RealDate.parse;
       MockDate.UTC = RealDate.UTC;
-      MockDate.prototype = RealDate.prototype;
       Date = MockDate;
 
-      // 3. Disable CSS animations + transitions — prevents partially-animated
-      // screenshots and removes a common source of pixel jitter on re-run.
+      // 3. Disable CSS animations + transitions — kills a major source of
+      //    pixel jitter on re-run.
       const style = document.createElement('style');
       style.textContent = '*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; }';
       (document.head || document.documentElement).appendChild(style);
 
-      // 4. Disable image lazy-loading — force every <img> to load
-      // synchronously on the page so screenshots capture rendered images.
+      // 4. Disable image lazy-loading so screenshots capture rendered images.
       document.addEventListener('DOMContentLoaded', () => {
         document.querySelectorAll('img[loading="lazy"]').forEach((el) => {
           el.loading = 'eager';
@@ -184,13 +329,15 @@ function makeDeterminismScript(canonicalId: string, v1Commit: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Network interception — GET-only with explicit non-GET allowlist.
+// Network interception — applies shouldAllowRequest's decision; logs
+// non-allowed requests to the intercepted-non-GET.log audit artifact.
 // ---------------------------------------------------------------------------
 
 interface InterceptedRecord {
   method: string;
   url: string;
   origin: "page-script" | "navigation";
+  reason: string;
 }
 
 async function setupNetworkInterception(
@@ -200,32 +347,22 @@ async function setupNetworkInterception(
 ): Promise<void> {
   await ctx.route("**/*", (route) => {
     const req = route.request();
-    const method = req.method();
-    const url = req.url();
-
-    // Block any URL matching the production hostname blocklist (defense in
-    // depth — the pre-flight gate already caught V1_BASE_URL, but a page
-    // script could still issue an outbound request to a blocked host).
-    if (isBlockedHost(url) && !url.startsWith(v1BaseUrl)) {
-      intercepted.push({ method, url, origin: "page-script" });
+    const decision = shouldAllowRequest({
+      method: req.method(),
+      url: req.url(),
+      v1BaseUrl,
+    });
+    if (!decision.allow) {
+      intercepted.push({
+        method: req.method(),
+        url: req.url(),
+        origin: "page-script",
+        reason: decision.reason ?? "unknown",
+      });
       route.abort();
       return;
     }
-
-    if (method === "GET") {
-      route.continue();
-      return;
-    }
-
-    // Non-GET: must be on the allowlist
-    const allowed = ALLOWED_NON_GET_FRAGMENTS.some((frag) => url.includes(frag));
-    if (allowed) {
-      route.continue();
-      return;
-    }
-
-    intercepted.push({ method, url, origin: "page-script" });
-    route.abort();
+    route.continue();
   });
 }
 
@@ -248,14 +385,16 @@ async function login(page: Page, baseUrl: string, persona: Persona): Promise<voi
 }
 
 // ---------------------------------------------------------------------------
-// Frontmatter writer.
+// Frontmatter writer. Phase 2A renamed `viewport` → `lead_viewport`; each
+// caption describes BOTH viewport WebPs of its route. lead_viewport encodes
+// which viewport is canonical for the persona.
 // ---------------------------------------------------------------------------
 
-interface CaptionFrontmatter {
+export interface CaptionFrontmatter {
   canonicalId: string;
   route: string;
   persona: string;       // canonical name
-  viewport: "desktop" | "mobile";
+  leadViewport: "desktop" | "mobile";
   seedState: string;     // "populated" | "empty" | etc.
   v1Commit: string;
   generated: string;     // YYYY-MM-DD
@@ -266,7 +405,7 @@ export function renderCaption(fm: CaptionFrontmatter): string {
 canonical_id: ${fm.canonicalId}
 route: ${fm.route}
 persona: ${fm.persona}
-viewport: ${fm.viewport}
+lead_viewport: ${fm.leadViewport}
 seed_state: ${fm.seedState}
 v1_commit: ${fm.v1Commit}
 generated: ${fm.generated}
@@ -276,8 +415,94 @@ generated: ${fm.generated}
 }
 
 // ---------------------------------------------------------------------------
+// RUN-MANIFEST.md writer. Pure function — operator/host/playwright_version
+// are passed in so tests don't depend on `os` calls.
+// ---------------------------------------------------------------------------
+
+export interface ManifestArgs {
+  v1BaseUrl: string;
+  v1Commit: string;
+  fixtureHash: string;
+  activeCanonicals: readonly string[];
+  skippedCanonicals: readonly string[];
+  captured: number;
+  skipped: number;
+  errored: number;
+  intercepted: number;
+  startTs: string;
+  endTs: string;
+  operator: string;
+  host: string;
+  playwrightVersion: string;
+}
+
+export function renderManifest(a: ManifestArgs): string {
+  const active = a.activeCanonicals.length > 0 ? a.activeCanonicals.join(", ") : "(none)";
+  const skipped = a.skippedCanonicals.length > 0 ? a.skippedCanonicals.join(", ") : "(none)";
+  return [
+    `# RUN-MANIFEST — v1 UI catalog crawl`,
+    ``,
+    `This manifest documents the authoritative run that produced the catalog`,
+    `committed alongside it. Re-runs against the same v1 commit + same fixture`,
+    `should produce byte-identical output (within \`pixelmatch\` tolerance per`,
+    `\`scripts/check-catalog-reproducibility.sh\`). If they don't, examine the`,
+    `determinism harness in \`tools/v1-screenshot-catalog/crawl.ts\`.`,
+    ``,
+    `**Generated:** ${a.endTs}`,
+    `**Started:** ${a.startTs}`,
+    `**v1 commit:** ${a.v1Commit}`,
+    `**v1 base URL:** ${a.v1BaseUrl}`,
+    `**Fixture sha256:** ${a.fixtureHash}`,
+    `**Operator:** ${a.operator}`,
+    `**Host:** ${a.host}`,
+    `**Playwright version:** ${a.playwrightVersion}`,
+    ``,
+    `## Personas`,
+    ``,
+    `**Active:** ${active}`,
+    `**Skipped (no credentials):** ${skipped}`,
+    ``,
+    `## Counts`,
+    ``,
+    `- Routes captured: ${a.captured}`,
+    `- Routes skipped: ${a.skipped}`,
+    `- Routes errored: ${a.errored}`,
+    `- Non-GET requests intercepted: ${a.intercepted}`,
+    ``,
+    `## Inventory ↔ catalog parity`,
+    ``,
+    `Run \`bash scripts/check-v1-catalog-coverage.sh\` from the repo root to verify.`,
+    ``,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Structured-log emitter. Tees JSON-per-line to stdout AND <output-dir>/crawl.log.
+// ---------------------------------------------------------------------------
+
+interface Logger {
+  emit: (event: Record<string, unknown>) => void;
+  close: () => void;
+}
+
+function makeLogger(filepath: string): Logger {
+  const stream: WriteStream = createWriteStream(filepath, { flags: "w" });
+  return {
+    emit(event) {
+      const line = JSON.stringify(event);
+      console.log(line);
+      stream.write(line + "\n");
+    },
+    close() {
+      stream.end();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Single-route capture. Loads the URL, takes desktop + mobile screenshots,
-// writes the frontmatter-only caption file.
+// writes the frontmatter-only caption file. page.goto + screenshots wrapped
+// in retryWithBackoff against TimeoutError.
 // ---------------------------------------------------------------------------
 
 interface CaptureArgs {
@@ -287,7 +512,7 @@ interface CaptureArgs {
   outputDir: string;
   persona: Persona;
   row: InventoryRow;
-  index: number;        // sequence number within the persona section
+  index: number;
   perRouteTimeoutMs: number;
 }
 
@@ -301,15 +526,11 @@ interface CaptureResult {
 async function captureRoute(args: CaptureArgs): Promise<CaptureResult> {
   const start = Date.now();
 
-  // Skip rows already in skip-reason state — the inventory pre-declares
-  // them as not_screenshotted: <reason> for documented reasons.
   if (args.row.screenshot_ref.startsWith("not_screenshotted:")) {
     const reason = args.row.screenshot_ref.replace(/^not_screenshotted:\s*/, "");
     return { status: "skipped", reason, durationMs: Date.now() - start };
   }
 
-  // Derive the route slug from the route path: take the last non-empty
-  // segment (or "root" if path is /). Sequence number prefixed.
   const cleaned = args.row.route.replace(/^\/|\/$/g, "");
   const lastSeg = cleaned.split("/").filter((s) => !s.startsWith("<")).pop() || "root";
   const routeSlug = lastSeg.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
@@ -320,37 +541,35 @@ async function captureRoute(args: CaptureArgs): Promise<CaptureResult> {
   const personaDir = `${args.outputDir}/${args.persona.slug}`;
   mkdirSync(personaDir, { recursive: true });
 
-  // Inject determinism harness for this route.
-  await args.ctx.addInitScript({
-    content: makeDeterminismScript(canonicalId, args.v1Commit),
-  });
-
   const page = await args.ctx.newPage();
   page.setDefaultTimeout(args.perRouteTimeoutMs);
 
   try {
-    const url = `${args.baseUrl}${args.row.route}`;
-    await page.goto(url, { waitUntil: "networkidle" });
+    await retryWithBackoff(
+      async () => {
+        const url = `${args.baseUrl}${args.row.route}`;
+        await page.goto(url, { waitUntil: "networkidle" });
 
-    // Capture both viewports as PNG, encode as WebP via sharp.
-    for (const [viewport, dims] of [
-      ["desktop", { width: 1440, height: 900 }],
-      ["mobile",  { width: 390,  height: 844 }],
-    ] as const) {
-      await page.setViewportSize(dims);
-      await page.waitForLoadState("networkidle");
-      const png = await page.screenshot({ fullPage: true, type: "png" });
-      const webp = await sharp(png).webp({ quality: 80 }).toBuffer();
-      writeFileSync(`${personaDir}/${fileBase}.${viewport}.webp`, webp);
-    }
+        for (const [viewport, dims] of [
+          ["desktop", { width: 1440, height: 900 }],
+          ["mobile",  { width: 390,  height: 844 }],
+        ] as const) {
+          await page.setViewportSize(dims);
+          await page.waitForLoadState("networkidle");
+          const png = await page.screenshot({ fullPage: true, type: "png" });
+          const webp = await sharp(png).webp({ quality: 80 }).toBuffer();
+          writeFileSync(`${personaDir}/${fileBase}.${viewport}.webp`, webp);
+        }
+      },
+      { attempts: 3, baseMs: 1000 },
+    );
 
-    // Write the frontmatter-only caption.
     const today = new Date().toISOString().slice(0, 10);
     const caption = renderCaption({
       canonicalId,
       route: args.row.route,
       persona: args.persona.canonical,
-      viewport: "desktop",        // primary viewport (per #107 UX review)
+      leadViewport: leadViewportFor(args.persona.slug),
       seedState: "populated",
       v1Commit: args.v1Commit,
       generated: today,
@@ -371,37 +590,59 @@ async function captureRoute(args: CaptureArgs): Promise<CaptureResult> {
 }
 
 // ---------------------------------------------------------------------------
-// Main entry point.
+// Resume / filter logic for the per-persona loop. Pure functions so we can
+// test them in isolation if regressions appear.
 // ---------------------------------------------------------------------------
 
-interface CliArgs {
-  outputDir: string;
+function applyPersonaFilters(
+  personas: readonly Persona[],
+  cli: CliArgs,
+): Persona[] {
+  let result: Persona[] = [...personas];
+  if (cli.onlyPersonas) {
+    const set = new Set(cli.onlyPersonas);
+    result = result.filter((p) => set.has(p.slug));
+  }
+  if (cli.resumeFrom) {
+    const i = result.findIndex((p) => p.slug === cli.resumeFrom);
+    if (i >= 0) result = result.slice(i);
+  }
+  return result;
 }
 
-function parseArgs(argv: string[]): CliArgs {
-  const args: Partial<CliArgs> = {};
-  for (let i = 0; i < argv.length; i++) {
-    if (argv[i] === "--output-dir") {
-      args.outputDir = argv[++i];
-    } else if (argv[i] === "--help" || argv[i] === "-h") {
-      console.log("usage: pnpm crawl --output-dir <path>");
-      process.exit(0);
-    } else {
-      console.error(`unknown arg: ${argv[i]}`);
-      process.exit(2);
-    }
-  }
-  if (!args.outputDir) {
-    console.error("error: --output-dir is required");
-    process.exit(2);
-  }
-  return args as CliArgs;
+function applyRouteFilter(
+  rows: readonly InventoryRow[],
+  personaSlug: string,
+  cli: CliArgs,
+): InventoryRow[] {
+  if (!cli.onlyRoutes) return [...rows];
+  const allowedTails = new Set(
+    cli.onlyRoutes
+      .filter((id) => id.startsWith(`${personaSlug}/`))
+      .map((id) => id.substring(personaSlug.length + 1)),
+  );
+  if (allowedTails.size === 0) return [];
+  // Match against canonical_id tail derived from row index. Since indices
+  // depend on filter order, we approximate by route-slug match: take the
+  // last non-placeholder segment of each row's route and check against tail.
+  return rows.filter((r) => {
+    const cleaned = r.route.replace(/^\/|\/$/g, "");
+    const lastSeg = cleaned.split("/").filter((s) => !s.startsWith("<")).pop() || "root";
+    const slug = lastSeg.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
+    return [...allowedTails].some((tail) => tail.endsWith(slug));
+  });
 }
+
+// ---------------------------------------------------------------------------
+// Main entry point.
+// ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
   const cli = parseArgs(process.argv.slice(2));
   const v1BaseUrl = process.env.V1_BASE_URL || "http://localhost:8000";
   const v1Commit = process.env.V1_COMMIT_SHA || "9738412a6e41064203fc253d9dd2a5c6a9c2e231";
+  const fixtureHash = process.env.V1_FIXTURE_SHA256 || "<unset>";
+  const operator = process.env.GITHUB_USER || process.env.USER || "<unknown>";
   const perRouteTimeoutMs = parseInt(process.env.CRAWL_PER_ROUTE_TIMEOUT_MS || "10000", 10);
   const repoRoot = resolve(dirname(import.meta.url.replace("file://", "")), "../..");
   const outputDir = resolve(cli.outputDir);
@@ -410,6 +651,11 @@ async function main(): Promise<void> {
 
   const inventory = loadInventory(repoRoot);
   const intercepted: InterceptedRecord[] = [];
+  const log = makeLogger(`${outputDir}/crawl.log`);
+
+  const personasToRun = applyPersonaFilters(ACTIVE_PERSONAS, cli);
+
+  log.emit({ event: "preflight.passed", v1_base_url: v1BaseUrl });
 
   const browser: Browser = await chromium.launch({ headless: true });
   const startTs = new Date().toISOString();
@@ -419,25 +665,34 @@ async function main(): Promise<void> {
   let errored = 0;
 
   try {
-    for (const persona of ACTIVE_PERSONAS) {
+    for (const persona of personasToRun) {
       const ctx = await browser.newContext({
         viewport: { width: 1440, height: 900 },
+      });
+      // Determinism harness — registered ONCE per BrowserContext (Phase 2A
+      // bug fix; the prior version registered per-route which accumulated
+      // overrides on every page load).
+      await ctx.addInitScript({
+        content: makeDeterminismScript(persona.slug, v1Commit),
       });
       await setupNetworkInterception(ctx, v1BaseUrl, intercepted);
 
       const page = await ctx.newPage();
       try {
         await login(page, v1BaseUrl, persona);
+        log.emit({ event: "persona.login", persona: persona.slug, status: "success" });
       } catch (e) {
-        console.error(`login failed for ${persona.slug}: ${(e as Error).message}`);
+        log.emit({
+          event: "persona.login",
+          persona: persona.slug,
+          status: "failed",
+          error: (e as Error).message,
+        });
         await ctx.close();
         continue;
       }
       await page.close();
 
-      // Inventory rows + any allowlist routes that target this persona.
-      // Allowlist routes get a synthetic screenshot_ref derived from the URL
-      // so the capture loop treats them identically to inventory rows.
       const allowlistRows = ROUTES_ALLOWLIST.filter(
         (r) => r.persona === persona.canonical,
       ).map((r) => ({
@@ -445,10 +700,14 @@ async function main(): Promise<void> {
         route: r.url,
         screenshot_ref: `${persona.slug}/allowlist-${r.url.replace(/[^a-z0-9]/gi, "-")}`,
       }));
-      const personaRows = [
-        ...inventory.filter((r) => r.persona === persona.canonical),
-        ...allowlistRows,
-      ];
+      const personaRows = applyRouteFilter(
+        [
+          ...inventory.filter((r) => r.persona === persona.canonical),
+          ...allowlistRows,
+        ],
+        persona.slug,
+        cli,
+      );
       let index = 0;
       for (const row of personaRows) {
         index++;
@@ -467,17 +726,14 @@ async function main(): Promise<void> {
         else if (result.status === "skipped") skipped++;
         else errored++;
 
-        // structured log line per route
-        console.log(
-          JSON.stringify({
-            event: `route.${result.status === "captured" ? "visited" : result.status}`,
-            persona: persona.slug,
-            route: row.route,
-            canonical_id: result.canonicalId,
-            reason: result.reason,
-            duration_ms: result.durationMs,
-          }),
-        );
+        log.emit({
+          event: `route.${result.status === "captured" ? "visited" : result.status}`,
+          persona: persona.slug,
+          route: row.route,
+          canonical_id: result.canonicalId,
+          reason: result.reason,
+          duration_ms: result.durationMs,
+        });
       }
 
       await ctx.close();
@@ -488,39 +744,50 @@ async function main(): Promise<void> {
 
   const endTs = new Date().toISOString();
 
-  // Write RUN-MANIFEST.md
-  const manifest = [
-    `# RUN-MANIFEST — v1 UI catalog crawl`,
-    ``,
-    `**Generated:** ${endTs}`,
-    `**v1 commit:** ${v1Commit}`,
-    `**v1 base URL:** ${v1BaseUrl}`,
-    `**Started:** ${startTs}`,
-    ``,
-    `## Personas`,
-    ``,
-    `**Active:** ${ACTIVE_PERSONAS.map((p) => p.canonical).join(", ") || "(none)"}`,
-    `**Skipped (no credentials):** ${SKIPPED_PERSONAS.map((p) => p.canonical).join(", ") || "(none)"}`,
-    ``,
-    `## Counts`,
-    ``,
-    `- Routes captured: ${captured}`,
-    `- Routes skipped: ${skipped}`,
-    `- Routes errored: ${errored}`,
-    `- Non-GET requests intercepted: ${intercepted.length}`,
-    ``,
-    `## Inventory ↔ catalog parity`,
-    ``,
-    `Run \`bash scripts/check-v1-catalog-coverage.sh\` from the repo root to verify.`,
-    ``,
-  ].join("\n");
+  // Resolve playwright version for the manifest from package.json's installed
+  // dep tree; if anything goes wrong, record "unknown" rather than fail.
+  let playwrightVersion = "unknown";
+  try {
+    const pwPkg = await import("playwright/package.json", { with: { type: "json" } });
+    playwrightVersion = (pwPkg as { default?: { version?: string }; version?: string })
+      .default?.version ?? (pwPkg as { version?: string }).version ?? "unknown";
+  } catch {
+    /* keep "unknown" */
+  }
+
+  const manifest = renderManifest({
+    v1BaseUrl,
+    v1Commit,
+    fixtureHash,
+    activeCanonicals: personasToRun.map((p) => p.canonical),
+    skippedCanonicals: SKIPPED_PERSONAS.map((p) => p.canonical),
+    captured,
+    skipped,
+    errored,
+    intercepted: intercepted.length,
+    startTs,
+    endTs,
+    operator,
+    host: `${platform()} ${hostname()}`,
+    playwrightVersion,
+  });
   writeFileSync(`${outputDir}/RUN-MANIFEST.md`, manifest);
 
-  // Write intercepted-non-GET.log (T4 audit artifact)
   writeFileSync(
     `${outputDir}/intercepted-non-GET.log`,
     intercepted.map((r) => JSON.stringify(r)).join("\n") + "\n",
   );
+
+  log.emit({
+    event: "run.complete",
+    duration_ms: new Date(endTs).getTime() - new Date(startTs).getTime(),
+    routes_visited: captured,
+    routes_skipped: skipped,
+    routes_errored: errored,
+    fixture_hash: fixtureHash,
+    playwright_version: playwrightVersion,
+  });
+  log.close();
 
   if (errored > 0) {
     console.error(`crawl finished with ${errored} errored routes`);
@@ -528,7 +795,6 @@ async function main(): Promise<void> {
   }
 }
 
-// Only run main() if invoked directly (not when imported by tests).
 if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((e) => {
     console.error(e);

--- a/tools/v1-screenshot-catalog/crawl.ts
+++ b/tools/v1-screenshot-catalog/crawl.ts
@@ -16,6 +16,7 @@ import { execFileSync } from "node:child_process";
 import {
   mkdirSync,
   writeFileSync,
+  readFileSync,
   existsSync,
   accessSync,
   constants as fsConstants,
@@ -167,6 +168,18 @@ export function leadViewportFor(personaSlug: string): "desktop" | "mobile" {
 }
 
 // ---------------------------------------------------------------------------
+// Route → slug derivation. Shared by captureRoute (which uses it to compose
+// the canonical_id) and applyRouteFilter (which uses it to match operator-
+// supplied canonical_ids against inventory rows).
+// ---------------------------------------------------------------------------
+
+export function deriveRouteSlug(route: string): string {
+  const cleaned = route.replace(/^\/|\/$/g, "");
+  const lastSeg = cleaned.split("/").filter((s) => !s.startsWith("<")).pop() || "root";
+  return lastSeg.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
 // Retry-with-backoff. Used to wrap page.goto + screenshot calls in
 // captureRoute. Only TimeoutError is retried; other errors propagate
 // immediately. Schedule: 1s, 3s, 9s (each = baseMs × 3^attempt).
@@ -207,6 +220,7 @@ interface PreflightArgs {
   v1BaseUrl: string;
   outputDir: string;
   repoRoot: string;
+  fixtureHash: string;
 }
 
 async function preflight(args: PreflightArgs): Promise<void> {
@@ -263,6 +277,16 @@ async function preflight(args: PreflightArgs): Promise<void> {
     }
   } catch (e) {
     fail(`Gate 5 failed: inventory parse failed (${(e as Error).message}).`);
+  }
+
+  // Gate 6: fixture sha256 present. The reproducibility-hash equality gate
+  // (scripts/check-catalog-reproducibility.sh) is a security control — without
+  // a real value, two runs both record `<unset>` and the gate produces a
+  // false-positive match. The audit trail in RUN-MANIFEST.md also requires it.
+  if (!args.fixtureHash || args.fixtureHash === "<unset>") {
+    fail(
+      "Gate 6 failed: V1_FIXTURE_SHA256 is not set. Compute `shasum -a 256 ~/Code/COREcare-access/fixtures/v2_catalog_snapshot.json` and export V1_FIXTURE_SHA256=<hash> before re-running.",
+    );
   }
 }
 
@@ -353,10 +377,14 @@ async function setupNetworkInterception(
       v1BaseUrl,
     });
     if (!decision.allow) {
+      // Distinguishing navigation from page-script lets the runbook's
+      // "STOP if any has origin: navigation" check have teeth — a captured
+      // page that triggers a non-GET navigation is an inventory or
+      // allowlist bug, not a beacon.
       intercepted.push({
         method: req.method(),
         url: req.url(),
-        origin: "page-script",
+        origin: req.isNavigationRequest() ? "navigation" : "page-script",
         reason: decision.reason ?? "unknown",
       });
       route.abort();
@@ -482,11 +510,11 @@ export function renderManifest(a: ManifestArgs): string {
 
 interface Logger {
   emit: (event: Record<string, unknown>) => void;
-  close: () => void;
+  close: () => Promise<void>;
 }
 
-function makeLogger(filepath: string): Logger {
-  const stream: WriteStream = createWriteStream(filepath, { flags: "w" });
+function makeLogger(filepath: string, append: boolean): Logger {
+  const stream: WriteStream = createWriteStream(filepath, { flags: append ? "a" : "w" });
   return {
     emit(event) {
       const line = JSON.stringify(event);
@@ -494,7 +522,12 @@ function makeLogger(filepath: string): Logger {
       stream.write(line + "\n");
     },
     close() {
-      stream.end();
+      // Resolve only after the WriteStream's "finish" event — guarantees the
+      // file is flushed before main() may call process.exit(1).
+      return new Promise<void>((resolve, reject) => {
+        stream.end(() => resolve());
+        stream.on("error", reject);
+      });
     },
   };
 }
@@ -531,9 +564,7 @@ async function captureRoute(args: CaptureArgs): Promise<CaptureResult> {
     return { status: "skipped", reason, durationMs: Date.now() - start };
   }
 
-  const cleaned = args.row.route.replace(/^\/|\/$/g, "");
-  const lastSeg = cleaned.split("/").filter((s) => !s.startsWith("<")).pop() || "root";
-  const routeSlug = lastSeg.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
+  const routeSlug = deriveRouteSlug(args.row.route);
   const seq = String(args.index).padStart(3, "0");
   const fileBase = `${seq}-${routeSlug}`;
   const canonicalId = `${args.persona.slug}/${fileBase}`;
@@ -590,11 +621,13 @@ async function captureRoute(args: CaptureArgs): Promise<CaptureResult> {
 }
 
 // ---------------------------------------------------------------------------
-// Resume / filter logic for the per-persona loop. Pure functions so we can
-// test them in isolation if regressions appear.
+// Resume / filter logic for the per-persona loop. Pure exported functions —
+// covered by __tests__/filters.test.ts. Indices are reassigned per-filtered-
+// row in the main loop, so the operator's <persona>/NNN-slug input matches
+// only by the slug part (the NNN- prefix is stripped before comparison).
 // ---------------------------------------------------------------------------
 
-function applyPersonaFilters(
+export function applyPersonaFilters(
   personas: readonly Persona[],
   cli: CliArgs,
 ): Persona[] {
@@ -610,27 +643,22 @@ function applyPersonaFilters(
   return result;
 }
 
-function applyRouteFilter(
+export function applyRouteFilter(
   rows: readonly InventoryRow[],
   personaSlug: string,
   cli: CliArgs,
 ): InventoryRow[] {
   if (!cli.onlyRoutes) return [...rows];
-  const allowedTails = new Set(
+  // For each canonical_id targeted at this persona, extract the slug part
+  // (strip the optional NNN- prefix). The set of allowed slugs is what we
+  // match against each row's deriveRouteSlug(route).
+  const allowedSlugs = new Set(
     cli.onlyRoutes
       .filter((id) => id.startsWith(`${personaSlug}/`))
-      .map((id) => id.substring(personaSlug.length + 1)),
+      .map((id) => id.substring(personaSlug.length + 1).replace(/^\d+-/, "")),
   );
-  if (allowedTails.size === 0) return [];
-  // Match against canonical_id tail derived from row index. Since indices
-  // depend on filter order, we approximate by route-slug match: take the
-  // last non-placeholder segment of each row's route and check against tail.
-  return rows.filter((r) => {
-    const cleaned = r.route.replace(/^\/|\/$/g, "");
-    const lastSeg = cleaned.split("/").filter((s) => !s.startsWith("<")).pop() || "root";
-    const slug = lastSeg.replace(/[^a-z0-9-]/gi, "-").toLowerCase();
-    return [...allowedTails].some((tail) => tail.endsWith(slug));
-  });
+  if (allowedSlugs.size === 0) return [];
+  return rows.filter((r) => allowedSlugs.has(deriveRouteSlug(r.route)));
 }
 
 // ---------------------------------------------------------------------------
@@ -647,11 +675,13 @@ async function main(): Promise<void> {
   const repoRoot = resolve(dirname(import.meta.url.replace("file://", "")), "../..");
   const outputDir = resolve(cli.outputDir);
 
-  await preflight({ v1BaseUrl, outputDir, repoRoot });
+  await preflight({ v1BaseUrl, outputDir, repoRoot, fixtureHash });
 
   const inventory = loadInventory(repoRoot);
   const intercepted: InterceptedRecord[] = [];
-  const log = makeLogger(`${outputDir}/crawl.log`);
+  // Append to crawl.log when resuming so we don't clobber the prior run's
+  // events; truncate on a fresh run.
+  const log = makeLogger(`${outputDir}/crawl.log`, !!cli.resumeFrom);
 
   const personasToRun = applyPersonaFilters(ACTIVE_PERSONAS, cli);
 
@@ -744,13 +774,14 @@ async function main(): Promise<void> {
 
   const endTs = new Date().toISOString();
 
-  // Resolve playwright version for the manifest from package.json's installed
-  // dep tree; if anything goes wrong, record "unknown" rather than fail.
+  // Resolve playwright version for the manifest by reading its installed
+  // package.json. readFileSync works on every Node version (no import-attribute
+  // syntax dependency); fallbacks to "unknown" only when the file is missing.
   let playwrightVersion = "unknown";
   try {
-    const pwPkg = await import("playwright/package.json", { with: { type: "json" } });
-    playwrightVersion = (pwPkg as { default?: { version?: string }; version?: string })
-      .default?.version ?? (pwPkg as { version?: string }).version ?? "unknown";
+    const pwPkgPath = `${repoRoot}/tools/v1-screenshot-catalog/node_modules/playwright/package.json`;
+    const pwPkg = JSON.parse(readFileSync(pwPkgPath, "utf-8")) as { version?: string };
+    playwrightVersion = pwPkg.version ?? "unknown";
   } catch {
     /* keep "unknown" */
   }
@@ -773,10 +804,10 @@ async function main(): Promise<void> {
   });
   writeFileSync(`${outputDir}/RUN-MANIFEST.md`, manifest);
 
-  writeFileSync(
-    `${outputDir}/intercepted-non-GET.log`,
-    intercepted.map((r) => JSON.stringify(r)).join("\n") + "\n",
-  );
+  const interceptedBody = intercepted.length > 0
+    ? intercepted.map((r) => JSON.stringify(r)).join("\n") + "\n"
+    : "";
+  writeFileSync(`${outputDir}/intercepted-non-GET.log`, interceptedBody);
 
   log.emit({
     event: "run.complete",
@@ -787,7 +818,10 @@ async function main(): Promise<void> {
     fixture_hash: fixtureHash,
     playwright_version: playwrightVersion,
   });
-  log.close();
+  // Await flush so the run.complete event is durably on disk before any
+  // exit. Without this, process.exit(1) below could race the WriteStream's
+  // "finish" event and lose the most-grep'd line of crawl.log.
+  await log.close();
 
   if (errored > 0) {
     console.error(`crawl finished with ${errored} errored routes`);

--- a/tools/v1-screenshot-catalog/package.json
+++ b/tools/v1-screenshot-catalog/package.json
@@ -5,6 +5,7 @@
   "description": "One-shot Playwright crawler that captures v1 (COREcare-access) UI as a per-persona screenshot catalog committed to docs/legacy/v1-ui-catalog/. Operates against v1 — does NOT run against v2.",
   "scripts": {
     "crawl": "tsx crawl.ts",
+    "check-reproducibility": "tsx check-reproducibility.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
@@ -14,6 +15,9 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/pngjs": "^6.0.5",
+    "pixelmatch": "^7.1.0",
+    "pngjs": "^7.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/tools/v1-screenshot-catalog/pnpm-lock.yaml
+++ b/tools/v1-screenshot-catalog/pnpm-lock.yaml
@@ -18,6 +18,15 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      '@types/pngjs':
+        specifier: ^6.0.5
+        version: 6.0.5
+      pixelmatch:
+        specifier: ^7.1.0
+        version: 7.2.0
+      pngjs:
+        specifier: ^7.0.0
+        version: 7.0.0
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -630,6 +639,9 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/pngjs@6.0.5':
+    resolution: {integrity: sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==}
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -749,6 +761,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  pixelmatch@7.2.0:
+    resolution: {integrity: sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==}
+    hasBin: true
+
   playwright-core@1.59.1:
     resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
     engines: {node: '>=18'}
@@ -758,6 +774,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -1228,6 +1248,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pngjs@6.0.5':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -1379,6 +1403,10 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  pixelmatch@7.2.0:
+    dependencies:
+      pngjs: 7.0.0
+
   playwright-core@1.59.1: {}
 
   playwright@1.59.1:
@@ -1386,6 +1414,8 @@ snapshots:
       playwright-core: 1.59.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   postcss@8.5.14:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 2A of [#107](https://github.com/suniljames/COREcare-v2/issues/107) — code-only work that closes the four Phase 1 bugs SWE Phase 2 review caught, adds the missing tests, rewrites the reproducibility check in-process, ships a CI gate enforcing PHI audit artifacts, and authors the PHASE-2-RUNBOOK.md the operator follows for Phase 2B–2G.

Phase 2B (fixture authoring), Phase 2C (PHI spike), and Phase 2D (authoritative crawl) require v1 running locally with a hand-crafted PHI-scrubbed Django fixture; those land in a follow-up PR after the operator runs the runbook.

## What changed

### Phase 1 bugs closed (SWE Phase 2 MUST-FIXes)

- **`addInitScript` per-route accumulation** → moved to per-context after `newContext()`. Seed reframed to `sha256(v1_commit + persona_slug)` — same persona's pages share an RNG, same input across re-runs produces same output. Phase 1's per-route registration accumulated stacked overrides on every page load on the same `BrowserContext`.
- **`crawl.log` not written to disk** → tee'd `WriteStream` to `<output-dir>/crawl.log` plus stdout. Phase 1 only emitted to stdout.
- **`crawl-bfs-report.md` in spec but no BFS** → spec updated (#107 body) to drop this artifact; inventory is authoritative.
- **Reproducibility script `npx --yes` per-image** → rewritten as `tools/v1-screenshot-catalog/check-reproducibility.ts` using `sharp` + `pixelmatch` + `pngjs` in-process. The bash script is now a thin shim invoking `pnpm exec tsx`.

### New crawler features (#107 Phase 2A spec)

- `parseArgs` exposed; new flags `--resume-from <slug>`, `--only-personas a,b`, `--only-routes id,id` for operator recovery + targeted re-crawls.
- `retryWithBackoff` exposed; 3 attempts × 1s/3s/9s schedule, retries `TimeoutError` only. `captureRoute` wraps `page.goto` + screenshot loop.
- `renderManifest` exposed as a pure markdown writer; new fields `Operator`, `Host`, `Playwright version`, `Fixture sha256` for forensic value.
- `renderCaption` frontmatter renamed `viewport` → `lead_viewport`; new pure helper `leadViewportFor(slug)` (Caregiver + Family Member lead mobile per RESPONSIVE.md, others lead desktop).
- `shouldAllowRequest` exposed as the unit-testable kernel of network interception.

### New tests (5 files, 36 new tests)

- `network-interception.test.ts` — covers `shouldAllowRequest` predicate (T4 verification at unit level)
- `extract-inventory-routes.test.ts` — exercises the canonical bash parser via `spawnSync`; column-drift detection
- `cli-args.test.ts` — covers new CLI flags
- `manifest.test.ts` — locks RUN-MANIFEST.md schema including the forensic fields
- `retry.test.ts` — covers `retryWithBackoff` schedule + TimeoutError-only policy

Plus `frontmatter-writer.test.ts` updated for `lead_viewport` rename + new `leadViewportFor` helper.

### Process / CI

- New `phi-audit-artifacts` job in `.github/workflows/v1-catalog-coverage.yml`: any PR adding/modifying `docs/legacy/v1-ui-catalog/**/*.webp` requires both `tools/v1-screenshot-catalog/PHI-AUDIT-PRECRAWL-*.md` AND `PHI-AUDIT-POSTCRAWL-*.md` newly added in the same PR. CI fails with a pointer to the Security Phase 2 review otherwise.
- New Stage 5 in `scripts/check-v1-catalog-coverage.sh`: soft-warns on `not_screenshotted: <reason>` values not in the locked taxonomy from `docs/legacy/README.md`. Surfaces drift without blocking merges.
- New `tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md` — single-page operator runbook with verification + remediation per step for Phase 2B–2G.

## Test plan

- [x] `pnpm test` (tools/v1-screenshot-catalog/): 8 files / 54 tests — all GREEN
- [x] `pnpm typecheck` (tools/v1-screenshot-catalog/): clean
- [x] `bash scripts/tests/test_check_v1_catalog_coverage.sh`: 18/18 pass
- [x] `bash scripts/tests/test_extract_inventory_routes.sh`: 14/14 pass
- [x] `bash scripts/check-v1-catalog-coverage.sh` against current repo: exits 0
- [x] `make -C api lint`: clean (90 mypy files, 92 ruff files)
- [x] `make -C api test`: 124 passed, 3 skipped
- [x] `make -C web typecheck`: clean
- [x] `make -C web test`: 7 passed
- [ ] `make -C web build`: **fails on missing `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`** — confirmed pre-existing on origin/main, NOT a Phase 2A regression. CI environments with the env var configured pass.

## Out of scope (deferred to Phase 2B+ follow-up PR)

- Authoring `~/Code/COREcare-access/fixtures/v2_catalog_snapshot.json` (user-owned, ~1 day)
- Manual PHI spike (~2h)
- Authoritative crawl (~30 min)
- Reproducibility two-run (~30 min)
- Coverage updates to `docs/migration/v1-pages-inventory.md`
- T7 cold smoke
- Index README population (`docs/legacy/v1-ui-catalog/README.md`)
- Catalog binary commit via Git LFS
- Phase 3 caption-authoring issue filing

The operator runs PHASE-2-RUNBOOK.md to execute the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)