### PR TITLE
fix(#153): correct v1 repo slug to hcunanan79/COREcare-access

### DIFF
--- a/.github/workflows/v1-sha-bump-diff-report.yml
+++ b/.github/workflows/v1-sha-bump-diff-report.yml
@@ -8,11 +8,11 @@
 #
 # === Setup (maintainer prerequisite, one-time) ===
 #
-# Requires a fine-grained PAT scoped to `suniljames/COREcare-access` only,
+# Requires a fine-grained PAT scoped to `hcunanan79/COREcare-access` only,
 # `Contents: Read`, 1-year expiry. Steps:
 #
 #   1. https://github.com/settings/personal-access-tokens/new
-#   2. Repository access: Only select repositories → suniljames/COREcare-access
+#   2. Repository access: Only select repositories → hcunanan79/COREcare-access
 #   3. Repository permissions: Contents — Read-only (everything else: No access)
 #   4. Expiration: 1 year (calendar a rotation reminder)
 #   5. Generate, copy the token

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,6 +1,6 @@
 # V1 Reference Documentation Set
 
-This directory holds reference material about COREcare **v1** (`suniljames/COREcare-access`, a Django monolith) for collaborators building **v2** without v1 source access. The docs describe what v1 does so v2's ground-up rebuild does not silently drop customer-facing capability.
+This directory holds reference material about COREcare **v1** (`hcunanan79/COREcare-access`, a Django monolith) for collaborators building **v2** without v1 source access. The docs describe what v1 does so v2's ground-up rebuild does not silently drop customer-facing capability.
 
 **Audience:** engineers contributing to v2, including AI agents acting on their behalf. **Not customer-facing.**
 
@@ -14,7 +14,7 @@ This directory holds reference material about COREcare **v1** (`suniljames/COREc
 
 All facts in this docset were reconciled against:
 
-- **Repo:** `suniljames/COREcare-access`
+- **Repo:** `hcunanan79/COREcare-access`
 - **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
 - **Commit subject:** `feat(#1479): January annual mileage-rate verification banner (#1480)`
 - **Pinned at:** 2026-05-06
@@ -139,7 +139,7 @@ Plain prose is the doc author's voice. Blockquotes are direct v1 strings. **Neve
 
 ### V1 source references
 
-Refer to v1 by GitHub repo slug `suniljames/COREcare-access`. **Never by absolute filesystem path** (`/Users/`, `/home/`, drive letter). The hygiene scanner blocks absolute paths.
+Refer to v1 by GitHub repo slug `hcunanan79/COREcare-access`. **Never by absolute filesystem path** (`/Users/`, `/home/`, drive letter). The hygiene scanner blocks absolute paths.
 
 When citing a specific v1 file, use the form `<app>/<file>:<line>` — for example, `billing/views.py:142`. The repo slug is implied by context.
 
@@ -285,14 +285,14 @@ If any diff is non-empty: re-author affected rows in `v1-pages-inventory.md`. If
 
 ## Workflow secrets
 
-CI workflows that touch the private v1 repo (`suniljames/COREcare-access`) authenticate via repo-level secrets. Maintainer-managed; engineers do not need to action these unless adding a new workflow or rotating an existing token.
+CI workflows that touch the private v1 repo (`hcunanan79/COREcare-access`) authenticate via repo-level secrets. Maintainer-managed; engineers do not need to action these unless adding a new workflow or rotating an existing token.
 
 ### `V1_REPO_READ_TOKEN`
 
 Used by `.github/workflows/v1-sha-bump-diff-report.yml` (#131) to clone v1 and run the three Family Member runbook diffs (per the runbook entry above) when a PR bumps the V1 Reference Commit SHA.
 
 - **Type:** GitHub fine-grained personal access token.
-- **Repository access:** `suniljames/COREcare-access` only — never wildcard.
+- **Repository access:** `hcunanan79/COREcare-access` only — never wildcard.
 - **Repository permissions:** `Contents: Read`. Nothing else.
 - **Expiration:** 1 year. Calendar a rotation reminder when issuing.
 - **Last rotated:** 2026-05-07 (initial issuance).

--- a/docs/migration/v1-functionality-delta.md
+++ b/docs/migration/v1-functionality-delta.md
@@ -16,7 +16,7 @@ The v2 docs are *customer-facing*, so absence here doesn't always mean "not buil
 
 ## For collaborators without v1 access
 
-If you do not have access to `suniljames/COREcare-access` (the v1 Django repo), this document on its own is **not enough** to rebuild v1's customer-facing surface in v2. It catalogues feature and data-model gaps, but it does not describe v1's pages, user journeys, or integrations.
+If you do not have access to `hcunanan79/COREcare-access` (the v1 Django repo), this document on its own is **not enough** to rebuild v1's customer-facing surface in v2. It catalogues feature and data-model gaps, but it does not describe v1's pages, user journeys, or integrations.
 
 Read these companion documents in `docs/migration/`:
 
@@ -307,4 +307,4 @@ Briefly, things v2 docs commit to that are not in v1:
 
 ---
 
-*Generated 2026-05-06 from press release `[07]-Press-Release.md` + external FAQ `[08]-FAQ-(External).md` against v1 codebase `suniljames/COREcare-access` (commit pinned in [`README.md`](README.md#v1-reference-commit)). The v2 docs are customer-facing; some items below may already be implemented or planned in internal artifacts not surveyed here.*
+*Generated 2026-05-06 from press release `[07]-Press-Release.md` + external FAQ `[08]-FAQ-(External).md` against v1 codebase `hcunanan79/COREcare-access` (commit pinned in [`README.md`](README.md#v1-reference-commit)). The v2 docs are customer-facing; some items below may already be implemented or planned in internal artifacts not surveyed here.*

--- a/docs/migration/v1-glossary.md
+++ b/docs/migration/v1-glossary.md
@@ -2,7 +2,7 @@
 
 > **Read [`README.md`](README.md) first.** It locks the persona vocabulary.
 
-Terms specific to COREcare v1 (`suniljames/COREcare-access`) that appear across this docset. **Persona names** (`Super-Admin`, `Agency Admin`, `Care Manager`, `Caregiver`, `Client`, `Family Member`) and general homecare vocabulary (`Care Plan`, `Visit`, `Shift`, `ADLs`, `PHI`) are defined in [`.claude/pm-context.md`](../../.claude/pm-context.md), not duplicated here.
+Terms specific to COREcare v1 (`hcunanan79/COREcare-access`) that appear across this docset. **Persona names** (`Super-Admin`, `Agency Admin`, `Care Manager`, `Caregiver`, `Client`, `Family Member`) and general homecare vocabulary (`Care Plan`, `Visit`, `Shift`, `ADLs`, `PHI`) are defined in [`.claude/pm-context.md`](../../.claude/pm-context.md), not duplicated here.
 
 This file extends `pm-context.md` with v1-specific terms — model names, internal feature names, and Django app names that come up when reading v1 source.
 

--- a/docs/migration/v1-pages-inventory.md
+++ b/docs/migration/v1-pages-inventory.md
@@ -4,7 +4,7 @@
 
 This document is the **authoritative route catalogue** for v1's customer-facing surface. Every other doc in this set cites into it; do not redefine routes elsewhere. One row per (route, persona) tuple — a route accessible to multiple personas appears in multiple rows.
 
-**Status:** SCAFFOLDED. Persona sections are in place; rows are pending content authoring against `suniljames/COREcare-access` at the [pinned commit](README.md#v1-reference-commit). Until rows are filled, the [`v1-functionality-delta.md`](v1-functionality-delta.md) is the most complete view of v1's feature surface.
+**Status:** SCAFFOLDED. Persona sections are in place; rows are pending content authoring against `hcunanan79/COREcare-access` at the [pinned commit](README.md#v1-reference-commit). Until rows are filled, the [`v1-functionality-delta.md`](v1-functionality-delta.md) is the most complete view of v1's feature surface.
 
 > **Drift detection.** A weekly CI job ([`v1-inventory-coldreader.yml`](../../.github/workflows/v1-inventory-coldreader.yml)) runs the per-persona cold-reader rotation against the live section content. If a row edit breaks the rotation, an auto-managed tracking issue opens. Rotation fixtures live in [`scripts/coldreader/fixtures/`](../../scripts/coldreader/fixtures/); operational details are in [`scripts/coldreader/README.md`](../../scripts/coldreader/README.md).
 
@@ -17,7 +17,7 @@ Coverage is measured per persona section, not globally. Each persona's denominat
 ### Enumeration method (deterministic, reproducible)
 
 ```
-For each Django app in v1 (suniljames/COREcare-access):
+For each Django app in v1 (hcunanan79/COREcare-access):
   1. Read app/urls.py — collect every path()/re_path() entry.
   2. Filter to those rendering HTML (skip JsonResponse, redirect-only, static).
   3. For each URL, read the view (FBV or CBV) — confirm the persona can reach

--- a/scripts/post-v1-sha-bump-diff.sh
+++ b/scripts/post-v1-sha-bump-diff.sh
@@ -12,7 +12,7 @@
 #
 # === Workflow secrets ===
 # Requires repo secret `V1_REPO_READ_TOKEN`: a fine-grained PAT scoped to
-# `suniljames/COREcare-access` only, `Contents: Read`, 1-year expiry.
+# `hcunanan79/COREcare-access` only, `Contents: Read`, 1-year expiry.
 # Rotation: re-issue the PAT, update the repo secret, document the
 # rotation date in docs/migration/README.md ("Workflow secrets" section).
 # Break-glass: if the gate is broken, the engineer manually runs the three
@@ -295,18 +295,18 @@ main() {
   trap 'rm -rf "$v1_dir"' EXIT
 
   echo "Cloning v1 (filter=blob:none, no-checkout) → $v1_dir"
-  echo "  git clone --filter=blob:none --no-checkout https://x-access-token:***@github.com/suniljames/COREcare-access.git"
+  echo "  git clone --filter=blob:none --no-checkout https://x-access-token:***@github.com/hcunanan79/COREcare-access.git"
   git clone --filter=blob:none --no-checkout --quiet \
-    "https://x-access-token:${V1_REPO_READ_TOKEN}@github.com/suniljames/COREcare-access.git" \
+    "https://x-access-token:${V1_REPO_READ_TOKEN}@github.com/hcunanan79/COREcare-access.git" \
     "$v1_dir" \
     || fail_loud "Failed to clone v1 repo. Check V1_REPO_READ_TOKEN scope and validity."
 
   echo "Fetching old SHA $OLD_SHA"
   git -C "$v1_dir" fetch --quiet origin "$OLD_SHA" \
-    || fail_loud "Failed to fetch OLD_SHA ($OLD_SHA) from v1. Verify the SHA exists in suniljames/COREcare-access."
+    || fail_loud "Failed to fetch OLD_SHA ($OLD_SHA) from v1. Verify the SHA exists in hcunanan79/COREcare-access."
   echo "Fetching new SHA $NEW_SHA"
   git -C "$v1_dir" fetch --quiet origin "$NEW_SHA" \
-    || fail_loud "Failed to fetch NEW_SHA ($NEW_SHA) from v1. Verify the SHA exists in suniljames/COREcare-access."
+    || fail_loud "Failed to fetch NEW_SHA ($NEW_SHA) from v1. Verify the SHA exists in hcunanan79/COREcare-access."
 
   local urls_diff clients_diff models_diff
   echo "Diffing '*/urls.py'"

--- a/scripts/tests/test_check_v1_doc_hygiene.sh
+++ b/scripts/tests/test_check_v1_doc_hygiene.sh
@@ -58,7 +58,7 @@ cat > "$FIXTURES/clean.md" <<'EOF'
 # Clean v1 reference doc
 
 This documents `[CLIENT_NAME]` and `[CAREGIVER_NAME]` interactions.
-Reference v1 source: `suniljames/COREcare-access`.
+Reference v1 source: `hcunanan79/COREcare-access`.
 The route `/admin/clients/<id>/` is for `Agency Admin`.
 EOF
 

--- a/scripts/tests/test_post_v1_sha_bump_diff.sh
+++ b/scripts/tests/test_post_v1_sha_bump_diff.sh
@@ -84,7 +84,7 @@ index abcdef..fedcba 100644
 +++ b/docs/migration/README.md
 @@ -16,7 +16,7 @@ All facts in this docset were reconciled against:
 
- - **Repo:** `suniljames/COREcare-access`
+ - **Repo:** `hcunanan79/COREcare-access`
 -- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
 +- **Commit SHA:** `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
  - **Commit subject:** `feat(#1479): January annual mileage-rate verification banner (#1480)`'
@@ -108,7 +108,7 @@ index abcdef..fedcba 100644
 +++ b/docs/migration/README.md
 @@ -16,7 +16,7 @@
 
- - **Repo:** `suniljames/COREcare-access`
+ - **Repo:** `hcunanan79/COREcare-access`
 -- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
 +- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
  - **Commit subject:** `feat(#1479)…`'
@@ -308,7 +308,7 @@ index abcdef..fedcba 100644
 --- a/docs/migration/README.md
 +++ b/docs/migration/README.md
 @@ -16,7 +16,7 @@
- - **Repo:** `suniljames/COREcare-access`
+ - **Repo:** `hcunanan79/COREcare-access`
 -- **Commit SHA:** `9738412a6e41064203fc253d9dd2a5c6a9c2e231`
 +- **Commit SHA:** `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
 diff --git a/scripts/post-v1-sha-bump-diff.sh b/scripts/post-v1-sha-bump-diff.sh


### PR DESCRIPTION
## Summary

The v1 Django repo lives at \`hcunanan79/COREcare-access\`, not \`suniljames/COREcare-access\`. Substitutes the slug across 8 files — 4 docs, 1 hygiene-test fixture, plus the 3 files introduced by PR #141 (workflow YAML, script, script-tests). Also updates the locked-convention example in README's "V1 source references" subsection so future docs cite the correct slug.

## Why now

Caught when starting PAT setup for #131 / PR #141. Without this fix, the diff-report workflow would clone a non-existent repo when the secret is set under \`suniljames\`. \`suniljames\` is not a collaborator on \`hcunanan79/COREcare-access\`, so the \`V1_REPO_READ_TOKEN\` PAT must be issued from the \`hcunanan79\` account anyway — but the slug had to be corrected first.

## What changed

| File | Before | After |
|---|---|---|
| \`docs/migration/README.md\` (5 occurrences inc. line-142 convention example) | \`suniljames/COREcare-access\` | \`hcunanan79/COREcare-access\` |
| \`docs/migration/v1-glossary.md\` | same | same |
| \`docs/migration/v1-functionality-delta.md\` (2 occurrences) | same | same |
| \`docs/migration/v1-pages-inventory.md\` (2 occurrences) | same | same |
| \`scripts/post-v1-sha-bump-diff.sh\` (header, clone URL, 3 fail-loud messages) | same | same |
| \`.github/workflows/v1-sha-bump-diff-report.yml\` (PAT setup instructions) | same | same |
| \`scripts/tests/test_post_v1_sha_bump_diff.sh\` (3 fixture diff lines) | same | same |
| \`scripts/tests/test_check_v1_doc_hygiene.sh\` (clean-doc pass-case fixture) | same | same |

Mechanical substitution; no behavioral changes; no test or convention semantics affected. The pinned SHA \`9738412a6e41064203fc253d9dd2a5c6a9c2e231\` is correct (verified to resolve under \`hcunanan79/COREcare-access\` with the expected commit subject).

## Test plan

- [x] \`make test-v1-docs\` — 25/25 PASS (including the hygiene-test fixture, which flips slug and continues to pass).
- [x] \`make scan-v1-docs\` — clean across hygiene + structure + catalog-coverage.
- [x] \`make check\` — api lint/test/typecheck and web lint/typecheck/test/build all green.
- [x] \`grep -rln "suniljames/COREcare-access"\` over docs + scripts + .github — no remaining references.
- [ ] CI passes.

## Closes

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)