### PR TITLE
docs(#146): point Family Member runbook at v1-sha-bump diff-report workflow

### DIFF
--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -279,6 +279,8 @@ Baseline at the currently-pinned SHA: `ClientFamilyMember` has no `is_active`, n
 
 If any diff is non-empty: re-author affected rows in `v1-pages-inventory.md`. If `_check_client_access` or any family-permission gate changed: also flag `CUTOVER_PLAN.md` owners — v2 RLS may need to mirror the v1 change. If `clients/models.py` shows a `ClientFamilyMember` schema shift: also re-author the `ClientFamilyMember` entry in `v1-glossary.md`, which mirrors the v1 baseline (no `is_active`, no soft-delete, no expiry, hard-delete revocation) and goes stale silently. If all diffs are empty: still bump `last reconciled` on the Family Member section. An empty diff is signal; the reconciliation date is the artifact.
 
+CI posts these diffs as a sticky PR comment when a PR bumps the V1 Reference Commit SHA — see `.github/workflows/v1-sha-bump-diff-report.yml` (#131).
+
 **Refresh order — Agency Admin first.** Agency Admin is the most-iterated persona surface in v1 (billing, payroll, scheduling, credentials, compliance). When budget for a refresh is constrained, refresh Agency Admin first; file follow-ups for other personas. The pattern Agency Admin establishes (cell prose, H3 naming, flag accuracy) is the template subsequent persona refreshes inherit.
 
 ---


### PR DESCRIPTION
## Summary

- Inserts one paragraph into the Family Member runbook entry in `docs/migration/README.md` pointing at the diff-report workflow added in #141.
- Closes the discoverability gap committee-flagged in design review: today an engineer reading the runbook has no in-text signal that CI runs the diffs; the secrets section back-references the runbook but the runbook does not forward-reference the workflow.
- Wording was finalized by the engineering committee — see the synthesis comment on #146 for the rationale (drop "also", add "sticky", match line 293 phrasing, plain backticks).

## Test plan

- [x] `test -f .github/workflows/v1-sha-bump-diff-report.yml` returns 0.
- [x] `make scan-v1-docs` exits 0.
- [x] The new sentence appears between the paragraph ending "the reconciliation date is the artifact." and the "**Refresh order — Agency Admin first.**" paragraph (visual diff).
- [x] PR touches only `docs/migration/README.md`.

`make check` was not run: this PR touches only documentation; the api/web lint/test/build gates in `make check` have no relationship to the change. The committee-agreed test specification on #146 is `make scan-v1-docs` plus the file-existence and placement checks above.

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)