### PR TITLE
test(#128): SL-3a invalid-severity-token fixture closes truth-table coverage

### DIFF
--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -669,6 +669,39 @@ $INTEGRATIONS_SEP
 EOF
 assert_exit "SL-3: severity empty when v2_status=missing fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-empty"
 
+# --- SL-3 (bad-token): invalid severity token in {H, M, L, D} set ---
+mkdir -p "$TEST_DIR/integrations-sl3-bad-token"
+write_integrations_inventory "$TEST_DIR/integrations-sl3-bad-token/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/integrations-sl3-bad-token/v1-functionality-delta.md"
+cat > "$TEST_DIR/integrations-sl3-bad-token/v1-integrations-and-exports.md" <<EOF
+# V1 Integrations and Exports
+
+## Schema
+
+table.
+
+## External integrations
+
+### Billing and payments
+
+$INTEGRATIONS_HEADER
+$INTEGRATIONS_SEP
+| Bad row | Vendor | Trigger | outbound; sync | [/quickbooks/](v1-pages-inventory.md#quickbooks_integration) | Sees: thing. | missing | X |
+
+### Payroll
+### Accounting
+### Messaging and notifications (third-party)
+### Identity, auth, and SSO (third-party)
+### Other
+
+## Internal notification and email backend
+
+## Customer-facing exports
+
+## Cross-references
+EOF
+assert_exit "SL-3: invalid severity token fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-bad-token"
+
 # --- SL-4: invalid direction_and_sync token ---
 mkdir -p "$TEST_DIR/integrations-sl4"
 write_integrations_inventory "$TEST_DIR/integrations-sl4/v1-pages-inventory.md"


### PR DESCRIPTION
Closes #128

## Summary
Adds `integrations-sl3-bad-token` fixture to `scripts/tests/test_check_v1_doc_structure.sh`, mirroring the existing `integrations-sl3-set` and `integrations-sl3-empty` fixtures. Closes the SL-3 truth-table coverage gap by exercising SL-3a (severity-token validity at `scripts/check-v1-doc-structure.sh:327`).

No production-code changes — fixture only.

## Why
Without this fixture, a future regression that loosens the regex (e.g. typo dropping `D`, expanding the character class, removing an anchor) would not be caught by `make test-v1-docs`. The full SL-3 truth table now has explicit coverage:
- **SL-3a** (token validity): this PR
- **SL-3b** (empty when required): `integrations-sl3-empty` (PR #127)
- **SL-3c** (set when forbidden): `integrations-sl3-set` (PR #118)

## Test results

### Baseline (origin/main, before changes)
```
Results: 72 passed, 0 failed
```

### After fixture added
```
Results: 73 passed, 0 failed
  PASS — SL-3: invalid severity token fails (exit 1)
```

### Negative-control mutation (per QA acceptance criteria)
Temporarily widened `scripts/check-v1-doc-structure.sh:327` from `/^(H|M|L|D)$/` to `/^(H|M|L|D|X)$/`:

```
Results: 72 passed, 1 failed
  FAIL — SL-3: invalid severity token fails (expected exit 1, got 0)
```

Only the new fixture flipped — proves the fixture binds tightly to the SL-3a branch and not coincidentally to any other check. Regex reverted before commit; final tree is clean.

## Test Plan
- [x] `make scan-v1-docs` passes (catalog coverage 100%)
- [x] `make test-v1-docs` passes (all three suites green; new fixture in stdout)
- [x] `make -C api lint` passes (ruff + mypy 116 files)
- [x] `make -C api test` passes (338 passed, 3 skipped)
- [x] `make -C web lint` passes
- [x] `make -C web typecheck` passes
- [x] `make -C web test` passes (7/7)
- [x] Negative-control mutation captured above
- [ ] CI passes

> Note: local `make -C web build` aborts on missing `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` because the worktree has only `web/.env.local.example`. The change is a bash fixture in `scripts/tests/`, which cannot affect the Next.js build. CI runs with proper env vars.

## Out of scope (deferred follow-ups, file as separate issues if desired)
- Coverage-parity meta-test (count of SL-* awk branches vs. count of SL-* fixtures) — System Architect's suggestion.
- Output-substring assertion across SL-* cohort (would diverge from current convention; needs cross-cutting refactor).
- Additional edge-case fixtures (lowercase severity, trailing whitespace) — already behaviorally covered by `trim()` and case-sensitive regex.