### PR TITLE
fix(#161): apply ruff format to runner.py (CI fix)

### DIFF
--- a/scripts/coldreader/runner.py
+++ b/scripts/coldreader/runner.py
@@ -176,9 +176,7 @@ def run_rotation(
 
     result = RotationResult(persona=fx.persona)
     for q in fx.questions:
-        response, failure = _score_question(
-            fx, q, section, index, client, allow_retry=allow_retry
-        )
+        response, failure = _score_question(fx, q, section, index, client, allow_retry=allow_retry)
         result.usage = result.usage + response.usage
         if failure is not None:
             result.failures.append(failure)


### PR DESCRIPTION
Tiny follow-up: PR #168 landed the model_answer addition without a final ruff-format pass; the workflow's lint step caught it. Apply the canonical formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)