### PR TITLE
fix(#161): include literal route names in shared-routes/q2 fixture

### DIFF
--- a/scripts/coldreader/fixtures/shared-routes.yaml
+++ b/scripts/coldreader/fixtures/shared-routes.yaml
@@ -28,9 +28,10 @@ questions:
       Which routes are authored directly in the Shared routes section
       (not cross-referenced from a persona section)?
     expected_fact_summary: |
-      Five routes — four portal-switching routes for users with both
-      caregiver and care-manager roles, plus one public rate-limited
-      self-registration route for family members.
+      Five routes total: switch-role, portal-chooser, set-default-portal,
+      clear-default-portal (four portal-switching routes for users with
+      both caregiver and care-manager roles), and family-signup (a public
+      rate-limited self-registration route for family members).
 
   - id: q3
     text: >-


### PR DESCRIPTION
Final calibration. Live run [25518663107](https://github.com/suniljames/COREcare-v2/actions/runs/25518663107) hit **6/7 PASS** with the new model-answer visibility from PR #168 surfacing the exact reason for the remaining failure: the model answered shared-routes/q2 with the five literal route paths (`/switch-role/, /portal-chooser/, /set-default-portal/, /clear-default-portal/, /family-signup/`) — perfectly correct but pure URL paths against a prose-only fixture summary, yielding 0% keyword overlap.

Updates the `expected_fact_summary` to include the route slugs alongside the prose categorization, so it matches both list-style and prose-style answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)