### PR TITLE
fix(#161): strip bold-markdown markers when verifying evidence

### DIFF
--- a/scripts/coldreader/tests/test_verifier.py
+++ b/scripts/coldreader/tests/test_verifier.py
@@ -1,0 +1,63 @@
+"""Direct unit tests for `verifier.verify_evidence` markdown handling.
+
+The first live workflow runs surfaced two distinct failure modes that
+verify_evidence didn't cover well: (1) the model dropping `**bold**`
+markers when quoting evidence (2026-05-07 family-member/q3), and (2)
+zero overlap between literal-route-path answers and prose summaries
+(handled separately in fixtures). This file pins the markdown-strip
+normalization so the regression doesn't recur.
+"""
+
+from __future__ import annotations
+
+from verifier import _normalize_for_evidence, verify_evidence
+
+
+def test_strips_bold_double_asterisks_from_haystack_and_needle() -> None:
+    section = "**v1 has no active-flag on `ClientFamilyMember`** — no soft-delete"
+    # Model's quote omits the `**` bold markers.
+    needle = "v1 has no active-flag on `ClientFamilyMember` — no soft-delete"
+    result = verify_evidence((needle,), section, "")
+    assert result.passed, (
+        f"verifier should accept evidence that omits bold markers; got: {result.reason}"
+    )
+
+
+def test_strips_bold_double_underscores() -> None:
+    section = "__some emphasized text__ continues here"
+    needle = "some emphasized text continues here"
+    result = verify_evidence((needle,), section, "")
+    assert result.passed
+
+
+def test_normalize_strips_both_marker_styles() -> None:
+    assert _normalize_for_evidence("**bold** and __also bold__") == "bold and also bold"
+
+
+def test_normalize_preserves_whitespace_and_case() -> None:
+    """Whitespace and case carry semantic weight; only markdown markers are stripped."""
+    raw = "**v1**   has\n  whitespace AND CASE preserved"
+    assert _normalize_for_evidence(raw) == "v1   has\n  whitespace AND CASE preserved"
+
+
+def test_normalize_leaves_single_asterisk_alone() -> None:
+    """Single asterisks are too risky to strip (could collide with prose text)."""
+    raw = "5 * 5 equals 25; *italic*"
+    assert _normalize_for_evidence(raw) == raw
+
+
+def test_evidence_still_rejects_unrelated_strings() -> None:
+    """Markdown stripping must not loosen the check for genuine drift."""
+    section = "**The actual content of the section**"
+    needle = "this is completely unrelated text"
+    result = verify_evidence((needle,), section, "")
+    assert not result.passed
+    assert "not found" in result.reason
+
+
+def test_evidence_check_works_on_index_alone() -> None:
+    section = ""
+    index = "**Cross-reference index** lists shared routes."
+    needle = "Cross-reference index lists shared routes."
+    result = verify_evidence((needle,), section, index)
+    assert result.passed

--- a/scripts/coldreader/verifier.py
+++ b/scripts/coldreader/verifier.py
@@ -26,6 +26,26 @@ class VerifyResult:
     reason: str = ""
 
 
+def _normalize_for_evidence(text: str) -> str:
+    """Strip surface markdown markers before comparing evidence strings.
+
+    The model occasionally drops bold/italic markers (`**`, `__`, `*`, `_`)
+    from a quoted span when it copies "verbatim" — the substance is identical
+    but a literal substring check rejects it. Normalizing both haystack and
+    needle the same way makes the check robust to that.
+
+    Whitespace and case are left alone — those carry semantic weight.
+    """
+    out = text
+    for marker in ("**", "__"):
+        out = out.replace(marker, "")
+    # Single-char emphasis markers are riskier (they collide with text), so
+    # only strip them when adjacent to alphanumeric chars on both sides — i.e.
+    # likely emphasis, not punctuation. Skipped for now; the double-marker
+    # strip alone covers every observed case.
+    return out
+
+
 def verify_evidence(
     evidence: tuple[str, ...],
     section: str,
@@ -35,14 +55,18 @@ def verify_evidence(
 
     Returns the first missing string for inclusion in the failure message.
     Empty evidence → fail (the model didn't ground its answer).
+
+    Both haystack and needle are normalized to strip bold-markdown markers
+    (`**`, `__`) — the model sometimes drops these when quoting a bolded
+    span. Whitespace and casing are preserved.
     """
     if not evidence:
         return VerifyResult(passed=False, reason="model returned no verbatim_evidence")
 
-    sources = (section, index)
+    sources = (_normalize_for_evidence(section), _normalize_for_evidence(index))
     for s in evidence:
         # Trim whitespace at edges; the model's quoting is sometimes loose.
-        needle = s.strip()
+        needle = _normalize_for_evidence(s.strip())
         if not needle:
             return VerifyResult(passed=False, reason="empty evidence string")
         if not any(needle in src for src in sources):


### PR DESCRIPTION
Last live run [25518907208](https://github.com/suniljames/COREcare-v2/actions/runs/25518907208) hit **6/7 PASS** (`shared-routes` flipped to passing thanks to PR #172) but `family-member/q3` failed for a new reason — verbatim_evidence rejected because the model dropped the surrounding `**bold**` markers when quoting a bolded span. The substance was identical:

```
Section says:  **v1 has no active-flag on `ClientFamilyMember`** — no soft-delete...
Model quoted:  v1 has no active-flag on `ClientFamilyMember` — no soft-delete...
```

Adds `_normalize_for_evidence()` that strips `**` and `__` markers from both haystack and needle before the substring check. Single-char emphasis markers (`*`, `_`) are intentionally NOT stripped — they collide with prose (e.g. `5 * 5 = 25`) and the double-marker strip covers every observed case.

Adds 7 tests in `test_verifier.py` pinning the contract: bold normalization on both styles, whitespace and case preserved, single asterisks left alone, unrelated strings still fail. Full suite **63/63**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)