### PR TITLE
fix(#142): coldreader NIT 1 (confidence telemetry) + NIT 2 (testable cost cap)

### DIFF
--- a/scripts/coldreader/README.md
+++ b/scripts/coldreader/README.md
@@ -12,7 +12,7 @@ Originated in [issue #123](https://github.com/suniljames/COREcare-v2/issues/123)
 2. **Loop:** for each persona in the whitelist, extract the section + cross-reference index, send to Claude Haiku 4.5 with the 3 rotation questions.
 3. **Score:** the model returns `{answer, verbatim_evidence, confidence}` via structured tool-use. The verifier asserts (a) every `verbatim_evidence` string literally appears in the section/index and (b) the answer contains every `must_mention` entry (within `tolerance` misses; case-insensitive substring; OR-groups for paraphrase tolerance).
 4. **Retry:** any failed question retries once with extended thinking. If still failing → real drift, run fails.
-5. **Surface:** the run posts a step summary including per-question hit counts (`q1: 5 of 5`, `q2: 4 of 5`); on drift, opens or comments on a deduplicated tracking issue (`coldreader-drift` label). Auto-closes the issue when a subsequent run passes.
+5. **Surface:** the run posts a step summary including per-question hit counts (`q1: 5 of 5`, `q2: 4 of 5`); on drift, opens or comments on a deduplicated tracking issue (`coldreader-drift` label). Auto-closes the issue when a subsequent run passes. The model's self-reported `confidence` field is observation-only — it does NOT gate retry (the objective `must_mention` check is the gate). Passing answers that report `confidence=low` are surfaced as an aggregate `Low-confidence passes: N` line in the step summary plus per-question `WARNING coldreader: low-confidence pass …` log lines on stderr (payload bounded to persona slug + question id + confidence enum value — never answer or evidence text).
 
 ## Layout
 
@@ -158,4 +158,4 @@ Expected cost on Haiku 4.5 with prompt caching: ≈ $0.05 per run × 4 runs/mont
 
 ## Initial monitoring period
 
-For the first 4 weekly runs after merge, review the step summary even on PASS — confirm the cache-hit ratio is ≥ 0.85 and total token counts match the projection, and watch the per-question `must_mention` hit counts for trends (e.g., `5 of 5` slowly drifting to `4 of 5` on a particular question is an early signal of inventory or model-output drift). After that, only failures need attention.
+For the first 4 weekly runs after merge, review the step summary even on PASS — confirm the cache-hit ratio is ≥ 0.85 and total token counts match the projection, and watch the per-question `must_mention` hit counts for trends (e.g., `5 of 5` slowly drifting to `4 of 5` on a particular question is an early signal of inventory or model-output drift). The `Low-confidence passes` count is a complementary signal: a sustained non-zero trend across consecutive runs indicates inventory ambiguity or model-quality regression even when the must_mention gate still passes — pair it with the matching `WARNING coldreader: low-confidence pass …` log lines on stderr when triaging. After that 4-week window, only failures need attention.

--- a/scripts/coldreader/run.py
+++ b/scripts/coldreader/run.py
@@ -15,14 +15,21 @@ The CLI exits 0 on full PASS, 1 on any drift detected, 2 on parser/fixture error
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 import sys
 from pathlib import Path
 
-from client import MODEL, AnthropicRotationClient
+from client import MODEL, AnthropicRotationClient, Usage
 from fixtures import iter_repo_fixtures, load_fixture
 from inventory import PERSONAS, extract_index, extract_section
-from runner import RotationResult, dry_run_smoke, render_summary_markdown, run_rotation
+from runner import (
+    RotationResult,
+    check_cost_caps,
+    dry_run_smoke,
+    render_summary_markdown,
+    run_rotation,
+)
 
 EXIT_PASS = 0
 EXIT_DRIFT = 1
@@ -63,6 +70,13 @@ def _print_summary_to_step_summary(markdown: str) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    # WARNING goes to stderr → workflow run log. Without basicConfig the
+    # runner's "low-confidence pass" log line would be silently dropped in CI.
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(levelname)s coldreader: %(message)s",
+        stream=sys.stderr,
+    )
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
@@ -142,19 +156,13 @@ def main(argv: list[str] | None = None) -> int:
         total_input += result.usage.input_tokens
         total_output += result.usage.output_tokens
 
-        if total_input > _RUN_TOKEN_INPUT_HARD_CAP:
-            print(
-                f"cost guardrail tripped: total uncached input tokens "
-                f"{total_input} exceeds {_RUN_TOKEN_INPUT_HARD_CAP}; aborting.",
-                file=sys.stderr,
-            )
-            return EXIT_SETUP_ERROR
-        if total_output > _RUN_TOKEN_OUTPUT_HARD_CAP:
-            print(
-                f"cost guardrail tripped: total output tokens "
-                f"{total_output} exceeds {_RUN_TOKEN_OUTPUT_HARD_CAP}; aborting.",
-                file=sys.stderr,
-            )
+        cap_trip = check_cost_caps(
+            Usage(input_tokens=total_input, output_tokens=total_output),
+            input_cap=_RUN_TOKEN_INPUT_HARD_CAP,
+            output_cap=_RUN_TOKEN_OUTPUT_HARD_CAP,
+        )
+        if cap_trip is not None:
+            print(f"{cap_trip}; aborting.", file=sys.stderr)
             return EXIT_SETUP_ERROR
 
     run_url = os.environ.get("GITHUB_SERVER_URL", "") and (

--- a/scripts/coldreader/runner.py
+++ b/scripts/coldreader/runner.py
@@ -14,6 +14,7 @@ the model declining to use the tool rather than masking it as content drift.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -21,6 +22,8 @@ from client import RotationCall, RotationClient, RotationResponse, Usage
 from fixtures import Fixture, Question, anchor_must_mention, iter_repo_fixtures
 from inventory import extract_index, extract_section
 from verifier import check_must_mention, verify_evidence
+
+_log = logging.getLogger("coldreader")
 
 # Failure-class tags. `CONTENT` failures mean the answer is wrong (drift).
 # `SETUP` failures mean the validator could not score this question at all
@@ -60,6 +63,7 @@ class RotationResult:
     failures: list[RotationFailure] = field(default_factory=list)
     usage: Usage = field(default_factory=Usage)
     telemetry: list[QuestionTelemetry] = field(default_factory=list)
+    low_confidence_count: int = 0
 
     @property
     def passed(self) -> bool:
@@ -272,6 +276,19 @@ def run_rotation(
         result.telemetry.append(telemetry)
         if failure is not None:
             result.failures.append(failure)
+            continue
+        # Question PASSED. Surface model-reported low confidence as a soft
+        # signal — observed-not-acted-on (the must_mention check is the
+        # objective gate). Log payload bounded to persona + question id +
+        # confidence enum value (issue #142): never answer or evidence text.
+        if response.confidence == "low":
+            result.low_confidence_count += 1
+            _log.warning(
+                "low-confidence pass: persona=%s question=%s confidence=%s",
+                fx.persona,
+                q.id,
+                response.confidence,
+            )
     return result
 
 
@@ -320,6 +337,28 @@ def _repo_root_from(start: Path) -> Path:
     raise RuntimeError("Could not locate repo root from runner module location")
 
 
+def check_cost_caps(usage: Usage, *, input_cap: int, output_cap: int) -> str | None:
+    """Return ``None`` if ``usage`` is under both caps; otherwise a reason string.
+
+    Defense-in-depth above the Anthropic-side $5/month organizational cap.
+    Input-trip takes precedence over output-trip for deterministic ordering
+    when both fire. The reason string is for human-readable stderr only —
+    callers must NOT branch on its text. The exit-code mapping
+    (``EXIT_SETUP_ERROR`` on trip) lives in ``run.py``.
+    """
+    if usage.input_tokens > input_cap:
+        return (
+            f"cost guardrail tripped: total uncached input tokens "
+            f"{usage.input_tokens} exceeds {input_cap}"
+        )
+    if usage.output_tokens > output_cap:
+        return (
+            f"cost guardrail tripped: total output tokens "
+            f"{usage.output_tokens} exceeds {output_cap}"
+        )
+    return None
+
+
 def render_summary_markdown(
     results: list[RotationResult],
     *,
@@ -355,6 +394,9 @@ def render_summary_markdown(
     lines.append(f"- Personas checked: {len(results)}")
     lines.append(f"- PASS: {len(pass_personas)} ({', '.join(pass_personas) or '—'})")
     lines.append(f"- FAIL: {len(fail_personas)} ({', '.join(fail_personas) or '—'})")
+    total_low_conf = sum(r.low_confidence_count for r in results)
+    if total_low_conf > 0:
+        lines.append(f"- Low-confidence passes: {total_low_conf}")
     lines.append("")
     # Telemetry section: per-question hit counts across all personas, PASS or FAIL.
     lines.append("### Per-question must_mention coverage")
@@ -381,6 +423,7 @@ __all__ = [
     "RotationFailure",
     "RotationResult",
     "TEXT_BLOCK_TRUNCATE_CHARS",
+    "check_cost_caps",
     "dry_run_smoke",
     "iter_repo_fixtures",
     "render_summary_markdown",

--- a/scripts/coldreader/tests/test_run_safety.py
+++ b/scripts/coldreader/tests/test_run_safety.py
@@ -8,6 +8,7 @@ distinguish the two and opened a false drift report.
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -47,3 +48,61 @@ def test_main_safe_treats_anthropic_error_as_setup_error() -> None:
 
     with patch.object(run, "main", side_effect=_FakeBadRequestError("400 invalid_request_error")):
         assert _main_safe() == EXIT_SETUP_ERROR
+
+
+# --- NIT 2 (issue #142): cost-cap trip end-to-end binding ---
+
+
+def test_main_returns_setup_error_when_runner_token_counts_exceed_input_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a runaway run that blows the input cap exits 2, not 1.
+
+    Critical: EXIT_DRIFT (1) opens a tracking issue; EXIT_SETUP_ERROR (2)
+    surfaces a setup-error message instead. Misclassifying a cost-cap trip
+    as drift would file false drift issues. Pins the exit-code contract.
+    """
+    from client import RotationCall, RotationResponse, Usage
+    from inventory import PERSONAS
+
+    class _RunawayClient:
+        def query_rotation(self, call: RotationCall) -> RotationResponse:
+            return RotationResponse(
+                answer="dashboard linked-client active-flag soft-revoke",
+                # Generic phrase present in every persona's section.
+                verbatim_evidence=("Family Member",),
+                confidence="high",
+                usage=Usage(input_tokens=300_000, output_tokens=100),
+            )
+
+    monkeypatch.setattr(run, "AnthropicRotationClient", lambda: _RunawayClient())
+    monkeypatch.setattr(sys, "argv", ["run.py", "--persona", PERSONAS[0]])
+
+    rc = run.main()
+    assert rc == EXIT_SETUP_ERROR, (
+        f"runaway input tokens must exit EXIT_SETUP_ERROR (2); got {rc}. "
+        f"If 1, the workflow would misclassify it as drift."
+    )
+
+
+def test_main_returns_setup_error_when_runner_token_counts_exceed_output_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Symmetric to the input case — output overage path is also covered."""
+    from client import RotationCall, RotationResponse, Usage
+    from inventory import PERSONAS
+
+    class _OutputRunawayClient:
+        def query_rotation(self, call: RotationCall) -> RotationResponse:
+            return RotationResponse(
+                answer="dashboard linked-client active-flag soft-revoke",
+                verbatim_evidence=("Family Member",),
+                confidence="high",
+                usage=Usage(input_tokens=100, output_tokens=50_000),
+            )
+
+    monkeypatch.setattr(run, "AnthropicRotationClient", lambda: _OutputRunawayClient())
+    monkeypatch.setattr(sys, "argv", ["run.py", "--persona", PERSONAS[0]])
+
+    rc = run.main()
+    assert rc == EXIT_SETUP_ERROR

--- a/scripts/coldreader/tests/test_runner.py
+++ b/scripts/coldreader/tests/test_runner.py
@@ -6,15 +6,19 @@ two-pass retry path on synthetic responses.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 import yaml
 
+from client import Usage
 from fixtures import Fixture, Question
 from runner import (
     RotationFailure,
     RotationResult,
+    check_cost_caps,
+    render_summary_markdown,
     run_rotation,
 )
 from tests.conftest import CannedResponse, FakeAnthropicClient
@@ -829,3 +833,225 @@ def test_yaml_round_trip_smoke(tmp_path: Path) -> None:
     p = tmp_path / "family-member.yaml"
     p.write_text(yaml.safe_dump(body), encoding="utf-8")
     assert yaml.safe_load(p.read_text(encoding="utf-8"))["persona"] == "family-member"
+
+
+# --- NIT 1 (issue #142): low-confidence telemetry ---
+
+
+def _all_three_pass_with_confidence(
+    client: FakeAnthropicClient, *, q1: str, q2: str, q3: str
+) -> None:
+    """Queue 3 canned answers that satisfy the default fixture's must_mention.
+
+    Confidence values per question come from the kwargs.
+    """
+    payloads = {
+        "q1": (
+            "They see Y on the dashboard, per linked client.",
+            "X sees Y on the dashboard",
+        ),
+        "q2": (
+            "No, gated linked-client only.",
+            "linked-client only via ClientFamilyMember",
+        ),
+        "q3": (
+            "v1 has no active-flag; v2 needs soft-revoke.",
+            "no active-flag on the link",
+        ),
+    }
+    for qid, conf in (("q1", q1), ("q2", q2), ("q3", q3)):
+        ans, ev = payloads[qid]
+        client.add_response(
+            "family-member",
+            qid,
+            CannedResponse(answer=ans, verbatim_evidence=(ev,), confidence=conf),
+        )
+
+
+def test_low_confidence_pass_emits_warning_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fx = _fixture()
+    client = FakeAnthropicClient()
+    _all_three_pass_with_confidence(client, q1="high", q2="low", q3="high")
+
+    with caplog.at_level(logging.WARNING, logger="coldreader"):
+        result = run_rotation(
+            fx, section=_section(), index=_index(), client=client, allow_retry=True
+        )
+
+    assert result.passed
+    assert result.failures == []
+    assert result.low_confidence_count == 1
+
+    warnings = [
+        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
+    ]
+    assert len(warnings) == 1
+    msg = warnings[0].getMessage()
+    assert "family-member" in msg
+    assert "q2" in msg
+    assert "low" in msg.lower()
+    # Security MUST-FIX (#142): never log answer/evidence text.
+    assert "linked-client only via ClientFamilyMember" not in msg
+    assert "No, gated linked-client only" not in msg
+
+
+def test_high_confidence_pass_emits_no_warning_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fx = _fixture()
+    client = FakeAnthropicClient()
+    _all_three_pass_with_confidence(client, q1="high", q2="high", q3="high")
+
+    with caplog.at_level(logging.WARNING, logger="coldreader"):
+        result = run_rotation(
+            fx, section=_section(), index=_index(), client=client, allow_retry=True
+        )
+
+    assert result.passed
+    assert result.low_confidence_count == 0
+    warnings = [
+        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
+    ]
+    assert warnings == []
+
+
+def test_low_confidence_failure_does_not_double_log(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A failing question with confidence='low' must NOT emit the warning.
+
+    The warning is for *passing* low-confidence answers — a failure already
+    speaks for itself via the failure path, no need to double-log.
+    """
+    fx = _fixture()
+    client = FakeAnthropicClient()
+    # q1 fails Pass A on evidence, retries on Pass B (still bad), confidence=low.
+    client.add_response(
+        "family-member",
+        "q1",
+        CannedResponse(
+            answer="They see Y on the dashboard.",
+            verbatim_evidence=("UNFINDABLE_PHRASE_A",),
+            confidence="low",
+        ),
+    )
+    client.add_response(
+        "family-member",
+        "q1",
+        CannedResponse(
+            answer="They see Y on the dashboard.",
+            verbatim_evidence=("UNFINDABLE_PHRASE_B",),
+            confidence="low",
+            used_extended_thinking=True,
+        ),
+    )
+    # q2/q3 pass with confidence=high.
+    client.add_response(
+        "family-member",
+        "q2",
+        CannedResponse(
+            answer="No, gated linked-client only.",
+            verbatim_evidence=("linked-client only via ClientFamilyMember",),
+            confidence="high",
+        ),
+    )
+    client.add_response(
+        "family-member",
+        "q3",
+        CannedResponse(
+            answer="v1 has no active-flag; v2 needs soft-revoke.",
+            verbatim_evidence=("no active-flag on the link",),
+            confidence="high",
+        ),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="coldreader"):
+        result = run_rotation(
+            fx, section=_section(), index=_index(), client=client, allow_retry=True
+        )
+
+    assert not result.passed
+    assert result.low_confidence_count == 0
+    warnings = [
+        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
+    ]
+    assert warnings == []
+
+
+def test_render_summary_includes_low_confidence_count_when_nonzero() -> None:
+    fx = _fixture()
+    client = FakeAnthropicClient()
+    _all_three_pass_with_confidence(client, q1="low", q2="low", q3="high")
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
+    assert "Low-confidence passes: 2" in md
+
+
+def test_render_summary_omits_low_confidence_line_when_zero() -> None:
+    fx = _fixture()
+    client = FakeAnthropicClient()
+    _all_three_pass_with_confidence(client, q1="high", q2="high", q3="high")
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
+    assert "Low-confidence" not in md
+
+
+# --- NIT 2 (issue #142): cost-cap helper testability ---
+
+
+def test_check_cost_caps_returns_none_when_under_caps() -> None:
+    assert (
+        check_cost_caps(
+            Usage(input_tokens=100, output_tokens=200),
+            input_cap=200_000,
+            output_cap=30_000,
+        )
+        is None
+    )
+
+
+def test_check_cost_caps_trips_on_input_overage() -> None:
+    reason = check_cost_caps(
+        Usage(input_tokens=300_000, output_tokens=200),
+        input_cap=200_000,
+        output_cap=30_000,
+    )
+    assert reason is not None
+    assert "input" in reason.lower()
+    assert "300000" in reason or "300,000" in reason
+
+
+def test_check_cost_caps_trips_on_output_overage() -> None:
+    reason = check_cost_caps(
+        Usage(input_tokens=100, output_tokens=50_000),
+        input_cap=200_000,
+        output_cap=30_000,
+    )
+    assert reason is not None
+    assert "output" in reason.lower()
+
+
+def test_check_cost_caps_input_takes_precedence_when_both_trip() -> None:
+    """Deterministic ordering: input-trip beats output-trip for log clarity."""
+    reason = check_cost_caps(
+        Usage(input_tokens=300_000, output_tokens=50_000),
+        input_cap=200_000,
+        output_cap=30_000,
+    )
+    assert reason is not None
+    assert "input" in reason.lower()
+    assert "output" not in reason.lower()
+
+
+def test_check_cost_caps_at_boundary_does_not_trip() -> None:
+    """Exactly at the cap is acceptable; only > cap trips."""
+    assert (
+        check_cost_caps(
+            Usage(input_tokens=200_000, output_tokens=30_000),
+            input_cap=200_000,
+            output_cap=30_000,
+        )
+        is None
+    )


### PR DESCRIPTION
Closes #142.

The original #142 design contemplated 4 NITs (1, 2, 3, 4); NITs 3 and 4 are now **moot** following the merge of PR #181 into \`main\` at commit \`e3dfb85\` — that PR replaced the cold-reader keyword-overlap soft-match heuristic (\`check_summary_match\` / \`_KEYWORD_RE\` / \`_keywords\`) with a \`must_mention\` oracle. The underlying machinery NITs 3 and 4 referenced no longer exists. NIT 5 remains deferred per design synthesis.

This PR delivers the two NITs that are **orthogonal** to the verifier rewrite.

## Summary

- **NIT 1** — wire model-reported \`confidence\` to telemetry as observation-only (does **not** gate retry — the objective \`must_mention\` check is the gate). New \`low_confidence_count\` aggregate on \`RotationResult\`, summary-markdown \`Low-confidence passes: N\` line when N>0, per-question \`WARNING\` log on stderr. Log payload bounded to persona slug + question id + confidence enum value (no answer / evidence text — security MUST-FIX scope from design pass). \`run.py::main()\` wires \`logging.basicConfig\` so the WARN actually surfaces in CI logs.
- **NIT 2** — extract cost-cap check from \`run.py::main()\` into \`runner.check_cost_caps\`. Caps (200K input / 30K output) and exit codes unchanged. Now exercised by L3 unit tests + L1 end-to-end binding pinning that runaway token usage exits \`EXIT_SETUP_ERROR\` (2), not \`EXIT_DRIFT\` (1) — the workflow's tracking-issue branch keys on exit code, so misclassifying would file false drift issues.

## Out of scope

- **NIT 3** (threshold) — moot. The threshold no longer exists in the verifier.
- **NIT 4** (regex ≥2 chars) — moot. The keyword regex no longer exists in the verifier.
- **NIT 5** (\`_INDEX_PARENT\` parser coupling) — deferred per design synthesis. Tied to #107 Phase-2A reproducibility contract.

## Verification

- \`uv run --frozen --project scripts/coldreader python -m pytest scripts/coldreader/tests\` — **108 passed** (96 baseline + 12 new).
- \`uvx ruff check scripts/coldreader/\` — clean.
- \`uvx ruff format --check scripts/coldreader/\` — clean (14/14 already formatted).
- \`uv run --frozen python run.py --dry-run\` — 7/7 fixtures loaded; 7/7 sections above floor; 0 errors.

## Workflow contract (verified)

\`.github/workflows/v1-inventory-coldreader.yml\` branches purely on exit code (\`'0'\` / \`'1'\` / \`'2'\`); does NOT parse stderr text. The new \`check_cost_caps\` reason string is human-readable only — not a stable contract.

## Test plan

- [ ] CI green on this PR.
- [ ] Post-merge: first 4 weekly scheduled rotations of the cold-reader.
  - [ ] \`Low-confidence passes\` count stays low across runs.
  - [ ] No \`EXIT_SETUP_ERROR\` from cost-cap trips.
  - [ ] No false-pass / false-fail observed.

If any false-pass or false-fail surfaces in the 4-week monitoring window, file a follow-up issue (do not reopen #142).

🤖 Generated with [Claude Code](https://claude.com/claude-code)