### PR TITLE
test(#144): cover pass-1 xref-skip in CR check self-tests

### DIFF
--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -29,6 +29,28 @@ assert_exit() {
   fi
 }
 
+# Like assert_exit, plus asserts that combined stdout+stderr matches a
+# bash-regex pattern. Use when exit code alone cannot distinguish a
+# correct failure from a near-miss regression (e.g., one rule code firing
+# instead of another within the same script).
+assert_exit_and_match() {
+  local description="$1"
+  local expected_code="$2"
+  local pattern="$3"
+  shift 3
+  local actual_output
+  actual_output=$("$@" 2>&1)
+  local actual_code=$?
+  if [[ "$actual_code" == "$expected_code" ]] && [[ "$actual_output" =~ $pattern ]]; then
+    echo "  PASS — $description (exit $actual_code, matched /$pattern/)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description (expected exit $expected_code matching /$pattern/, got exit $actual_code)"
+    echo "    output: $actual_output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
 write_good_inventory() {
   local path="$1"
   cat > "$path" <<'EOF'
@@ -2132,6 +2154,50 @@ cat > "$TEST_DIR/xref-two-indexes/v1-pages-inventory.md" <<'EOF'
 EOF
 write_good_delta "$TEST_DIR/xref-two-indexes/v1-functionality-delta.md"
 assert_exit "two cross-ref indexes; second has CR-3 violation → fail" 1 "$STRUCTURE" --dir "$TEST_DIR/xref-two-indexes"
+
+# --- Test 13: pass-1 xref-skip is load-bearing — explicit `<a id>` anchor
+#              aliasing pre-binds an xref-index sub-section to the same
+#              anchor as a canonical persona section. With the skip, only
+#              the canonical row lands in the pass-1 map, so pass 2 emits
+#              CR-3 (phi disagreement). WITHOUT the skip, both rows would
+#              hit the same key, triggering CANONICAL_DUP → CR-2 instead.
+#              Exit-code-only assertion would not distinguish the two —
+#              hence the rule-code match in `assert_exit_and_match`. ---
+mkdir -p "$TEST_DIR/xref-anchor-alias-skip"
+cat > "$TEST_DIR/xref-anchor-alias-skip/v1-pages-inventory.md" <<'EOF'
+# v1 Pages Inventory
+
+## Super-Admin
+
+<a id="agency-admin-top-level"></a>
+### Cross-reference index
+
+| route | also reachable by | content branches by role | phi_displayed | row location |
+|-------|-------------------|--------------------------|---------------|--------------|
+| `/admin/foo/` | Agency Admin | no | false | [Agency Admin → top-level](#agency-admin-top-level) |
+
+## Agency Admin
+
+<a id="agency-admin-top-level"></a>
+### top-level
+
+| route | phi_displayed |
+|-------|---------------|
+| `/admin/foo/` | true |
+
+## Care Manager
+
+## Caregiver
+
+## Client
+
+## Family Member
+EOF
+write_good_delta "$TEST_DIR/xref-anchor-alias-skip/v1-functionality-delta.md"
+assert_exit_and_match \
+  "CR-3 (not CR-2) fires when xref index aliases canonical anchor — pass 1 skip is load-bearing" \
+  1 'CR-3:' \
+  "$STRUCTURE" --dir "$TEST_DIR/xref-anchor-alias-skip"
 
 # === Refresh-runbook rule group (RR-N) — Issue #132 =========================
 #


### PR DESCRIPTION
## Summary

- Adds `assert_exit_and_match` helper (exit code + bash-regex match on combined stdout+stderr) to `scripts/tests/test_check_v1_doc_structure.sh`.
- Adds Test 13 (`xref-anchor-alias-skip` fixture) — exercises pass-1's xref-skip in `scripts/check-v1-doc-structure.sh` via explicit `<a id>` anchor aliasing.
- Suite goes from **85 → 86** self-tests. Test-only; the production shell script is untouched.

Closes #144.

## Why this is needed

Test #12 (`xref-two-indexes`) verifies that pass 2 walks every cross-reference index sub-section, but it does not exercise pass 1's `if (in_xref_skip) next` guard. Without that guard, the proposed fixture's mirrored xref-index row would land in the canonical-row map at the same `(anchor, slug)` key as the real canonical row — triggering `CR-2` (CANONICAL_DUP) in pass 2 instead of `CR-3` (phi disagreement). Both regressions exit 1, so `assert_exit` cannot tell them apart.

The new helper asserts the **rule-code prefix** (`'CR-3:'`) on combined stdout+stderr in addition to exit code. That makes the test specific enough to catch the wrong-rule-fires-but-still-fails-correctly case the existing harness misses.

## Test plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` → `Results: 86 passed, 0 failed`.
- [x] **Manual regression check:** comment out `scripts/check-v1-doc-structure.sh:785` (`if (in_xref_skip) next`); re-run suite. Test 13 FAILs with output containing `CR-2:` and not `CR-3:`. Restored after verification.
- [x] `make -C api lint` ✅
- [x] `make -C api test` ✅ (338 passed, 3 skipped)
- [x] `make -C web lint` ✅
- [x] `make -C web typecheck` ✅
- [x] `make -C web test` ✅ (7 passed)
- [ ] `make -C web build` — skipped locally (fresh worktree lacks `.env.local`; CI will run with real Clerk secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)