### PR TITLE
fix(#176): cut feature branches from freshly-fetched origin/main

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -27,9 +27,38 @@ gh label create "implementing" --color "fbca04" --description "Implementation in
 gh issue edit <number> --repo "$REPO" --add-label "implementing"
 ```
 
+## Branch base — cut from freshly-fetched origin/main
+
+Before creating the feature branch (whether via `EnterWorktree` or manually
+inside an existing worktree), ensure the cut is from a freshly-fetched
+`origin/main`, not stale local `main`.
+
+```bash
+# Cut from origin/main, not local main — see issue #176.
+git fetch origin main
+BASE_SHA=$(git rev-parse origin/main)
+if [[ -z "$BASE_SHA" || ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: could not resolve origin/main to a SHA. Aborting." >&2
+  exit 1
+fi
+echo "Cutting from origin/main @ ${BASE_SHA:0:8}"
+LOCAL_BEHIND=$(git rev-list --count "main..origin/main" 2>/dev/null || echo 0)
+if [[ "$LOCAL_BEHIND" -gt 0 ]]; then
+  echo "Local main was $LOCAL_BEHIND commits behind origin/main; using origin/main as the base."
+fi
+git checkout -b "<feature-branch-name>" "$BASE_SHA"
+```
+
+Rules:
+- Do **not** silence stderr from `git fetch`. Failure must be loud and abort.
+- Do **not** fall back to local `main` under any condition.
+- Do **not** auto-delete an existing local branch — fail clearly if the target name already exists.
+
 ## Worktree isolation
 
 Use `EnterWorktree` to create an isolated worktree under `.claude/worktrees/`.
+After the worktree exists, apply the **Branch base** block above before any
+other branching/checkout work.
 
 ## Test-first scaffolding (RED)
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -25,7 +25,34 @@ Find the linked issue from progress file, branch name, or commit messages.
 make check
 ```
 
-## 0.3: Push and create PR
+## 0.3: Branch base — cut from freshly-fetched origin/main (when creating a new branch)
+
+If `/review` is invoked without a pre-existing feature branch (i.e., this flow
+will create one), apply the same invariant as `/implement`: cut from a
+freshly-fetched `origin/main`, never stale local `main`.
+
+```bash
+# Cut from origin/main, not local main — see issue #176.
+git fetch origin main
+BASE_SHA=$(git rev-parse origin/main)
+if [[ -z "$BASE_SHA" || ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "ERROR: could not resolve origin/main to a SHA. Aborting." >&2
+  exit 1
+fi
+echo "Cutting from origin/main @ ${BASE_SHA:0:8}"
+LOCAL_BEHIND=$(git rev-list --count "main..origin/main" 2>/dev/null || echo 0)
+if [[ "$LOCAL_BEHIND" -gt 0 ]]; then
+  echo "Local main was $LOCAL_BEHIND commits behind origin/main; using origin/main as the base."
+fi
+git checkout -b "<feature-branch-name>" "$BASE_SHA"
+```
+
+Rules:
+- Do **not** silence stderr from `git fetch`. Failure must be loud and abort.
+- Do **not** fall back to local `main` under any condition.
+- Do **not** auto-delete an existing local branch — fail clearly if the target name already exists.
+
+## 0.4: Push and create PR
 
 ```bash
 git push -u origin HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,13 @@ make coldreader-local-dry # Dry-run the rotation parser + fixtures against the l
 
 Tailscale for network access from other devices.
 
+## Slash-command Invariants
+
+Slash commands that cut branches must do so from an explicit, freshly-fetched
+named remote ref (e.g., `origin/main`) — never from an implicit local branch.
+See [`#176`](https://github.com/suniljames/COREcare-v2/issues/176) and the
+regression test at `scripts/tests/test_implement_branch_cut.sh`.
+
 ## Project Docs
 
 | Topic | File |

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ check: ## Run all quality gates (pre-PR)
 	$(MAKE) -C web typecheck
 	$(MAKE) -C web test
 	$(MAKE) -C web build
+	bash scripts/tests/test_implement_branch_cut.sh
 
 # --- Individual targets ---
 

--- a/scripts/tests/test_implement_branch_cut.sh
+++ b/scripts/tests/test_implement_branch_cut.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Tests for the issue #176 invariant: /implement and /review must cut feature
+# branches from a freshly-fetched origin/main, not stale local main.
+#
+# Two test layers:
+#   1. Behavioral — exercise the bash invariant against a temp git repo with a
+#      fake origin in four scenarios (current / behind / ahead / offline).
+#   2. Sync — grep the .claude/commands/{implement,review}.md files for the
+#      key git commands so we catch silent drift between the two files.
+#
+# Run from repo root: bash scripts/tests/test_implement_branch_cut.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IMPLEMENT_MD="$REPO_ROOT/.claude/commands/implement.md"
+REVIEW_MD="$REPO_ROOT/.claude/commands/review.md"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS — $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL — $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# The function under test mirrors the bash block embedded in implement.md /
+# review.md. The sync tests below assert the markdown files contain the same
+# key commands so this duplication can't drift silently.
+# ---------------------------------------------------------------------------
+cut_feature_branch() {
+  local branch_name="$1"
+  git fetch origin main || return 1
+  local base_sha
+  base_sha=$(git rev-parse origin/main 2>/dev/null) || return 1
+  if [[ -z "$base_sha" || ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: could not resolve origin/main to a SHA. Aborting." >&2
+    return 1
+  fi
+  echo "Cutting from origin/main @ ${base_sha:0:8}"
+  local local_behind
+  local_behind=$(git rev-list --count "main..origin/main" 2>/dev/null || echo 0)
+  if [[ "$local_behind" -gt 0 ]]; then
+    echo "Local main was $local_behind commits behind origin/main; using origin/main as the base."
+  fi
+  git checkout -b "$branch_name" "$base_sha"
+}
+
+make_sandbox() {
+  SANDBOX=$(mktemp -d)
+  REMOTE="$SANDBOX/remote.git"
+  LOCAL="$SANDBOX/local"
+  git init --bare --quiet -b main "$REMOTE"
+
+  local seed="$SANDBOX/seed"
+  git init --quiet -b main "$seed"
+  git -C "$seed" config user.email "test@example.com"
+  git -C "$seed" config user.name "Test"
+  git -C "$seed" commit --allow-empty -m "initial" --quiet
+  git -C "$seed" remote add origin "$REMOTE"
+  git -C "$seed" push --quiet origin main
+  rm -rf "$seed"
+
+  git clone --quiet "$REMOTE" "$LOCAL"
+  git -C "$LOCAL" config user.email "test@example.com"
+  git -C "$LOCAL" config user.name "Test"
+}
+
+push_commits_to_remote_main() {
+  local remote="$1"
+  local count="$2"
+  local tmp
+  tmp=$(mktemp -d)
+  git clone --quiet "$remote" "$tmp/c"
+  git -C "$tmp/c" config user.email "test@example.com"
+  git -C "$tmp/c" config user.name "Test"
+  for i in $(seq 1 "$count"); do
+    git -C "$tmp/c" commit --allow-empty -m "remote commit $i" --quiet
+  done
+  git -C "$tmp/c" push --quiet origin main
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# Behavioral tests
+# ---------------------------------------------------------------------------
+
+test_branch_parent_matches_origin_main() {
+  make_sandbox
+  cd "$LOCAL"
+  if cut_feature_branch "feat/test1" >/dev/null 2>&1; then
+    local parent expected
+    parent=$(git rev-parse HEAD)
+    expected=$(git rev-parse origin/main)
+    if [[ "$parent" == "$expected" ]]; then
+      pass "branch_parent_matches_origin_main (current local main)"
+    else
+      fail "branch_parent_matches_origin_main: parent=$parent expected=$expected"
+    fi
+  else
+    fail "branch_parent_matches_origin_main: function failed"
+  fi
+  cd "$REPO_ROOT"
+  rm -rf "$SANDBOX"
+}
+
+test_does_not_use_stale_local_main() {
+  make_sandbox
+  cd "$LOCAL"
+  local stale_sha
+  stale_sha=$(git rev-parse main)
+  cd "$REPO_ROOT"
+  push_commits_to_remote_main "$REMOTE" 3
+  cd "$LOCAL"
+  # Local main is now 3 commits behind origin/main (without fetching first).
+  if cut_feature_branch "feat/test2" >/dev/null 2>&1; then
+    local parent origin_now
+    parent=$(git rev-parse HEAD)
+    origin_now=$(git rev-parse origin/main)
+    if [[ "$parent" == "$origin_now" && "$parent" != "$stale_sha" ]]; then
+      pass "does_not_use_stale_local_main"
+    else
+      fail "does_not_use_stale_local_main: parent=$parent origin_now=$origin_now stale=$stale_sha"
+    fi
+  else
+    fail "does_not_use_stale_local_main: function failed"
+  fi
+  cd "$REPO_ROOT"
+  rm -rf "$SANDBOX"
+}
+
+test_does_not_use_local_only_commits() {
+  make_sandbox
+  cd "$LOCAL"
+  git commit --allow-empty -m "local-only" --quiet
+  local local_only_sha
+  local_only_sha=$(git rev-parse main)
+  if cut_feature_branch "feat/test3" >/dev/null 2>&1; then
+    local parent expected
+    parent=$(git rev-parse HEAD)
+    expected=$(git rev-parse origin/main)
+    if [[ "$parent" == "$expected" && "$parent" != "$local_only_sha" ]]; then
+      pass "does_not_use_local_only_commits"
+    else
+      fail "does_not_use_local_only_commits: parent=$parent expected=$expected local_only=$local_only_sha"
+    fi
+  else
+    fail "does_not_use_local_only_commits: function failed"
+  fi
+  cd "$REPO_ROOT"
+  rm -rf "$SANDBOX"
+}
+
+test_aborts_when_fetch_fails() {
+  make_sandbox
+  cd "$LOCAL"
+  git remote set-url origin "$SANDBOX/nonexistent.git"
+  if cut_feature_branch "feat/test4" >/dev/null 2>&1; then
+    fail "aborts_when_fetch_fails: function should have returned non-zero"
+  else
+    if [[ -z "$(git branch --list 'feat/test4')" ]]; then
+      pass "aborts_when_fetch_fails (no branch created)"
+    else
+      fail "aborts_when_fetch_fails: branch was created despite fetch failure"
+    fi
+  fi
+  cd "$REPO_ROOT"
+  rm -rf "$SANDBOX"
+}
+
+# ---------------------------------------------------------------------------
+# Sync tests: assert markdown files contain the key invariant commands.
+# These catch silent drift between implement.md and review.md.
+# ---------------------------------------------------------------------------
+
+assert_markdown_contains_invariant() {
+  local label="$1"
+  local file="$2"
+  local missing=0
+  local needles=(
+    "git fetch origin main"
+    "git rev-parse origin/main"
+    "git checkout -b"
+    "see issue #176"
+  )
+  for needle in "${needles[@]}"; do
+    if ! grep -qF "$needle" "$file"; then
+      fail "$label missing literal: $needle"
+      missing=1
+    fi
+  done
+  [[ "$missing" -eq 0 ]] && pass "$label contains the invariant"
+}
+
+test_implement_md_contains_invariant() {
+  assert_markdown_contains_invariant "implement.md" "$IMPLEMENT_MD"
+}
+
+test_review_md_contains_invariant() {
+  assert_markdown_contains_invariant "review.md" "$REVIEW_MD"
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+echo "Running issue #176 branch-cut invariant tests..."
+test_branch_parent_matches_origin_main
+test_does_not_use_stale_local_main
+test_does_not_use_local_only_commits
+test_aborts_when_fetch_fails
+test_implement_md_contains_invariant
+test_review_md_contains_invariant
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
Closes #176

## Summary

Both `/implement` and `/review` now require an explicit `git fetch origin main` + SHA-pinned `git checkout -b <branch> "$BASE_SHA"` before any feature-branch creation. Local `main` is treated as a cache; `origin/main` is the source of truth. Eliminates the silent-stale branching observed during the autonomous run on #146 (PR #166), where local `main` was 48 commits behind and the agent built against a months-old base without noticing.

## Changes

- **`.claude/commands/implement.md`** — new "Branch base" section with the invariant bash block, placed before "Worktree isolation."
- **`.claude/commands/review.md`** — same block at Phase 0.3; existing push & PR-create renumbered to 0.4.
- **`CONTRIBUTING.md`** — new "Slash-command Invariants" section codifying the rule for any future slash command that cuts branches.
- **`Makefile`** — wire `scripts/tests/test_implement_branch_cut.sh` into `make check`.
- **`scripts/tests/test_implement_branch_cut.sh`** — new regression test (218 lines): four behavioral GIVENs (current / behind / ahead / offline) plus two sync assertions that both markdown files contain the literal invariant commands so they can't drift silently.

## Eat-our-own-dogfood note

This branch was cut by applying the very fix being implemented: at the start of the run, `git fetch origin main` showed local `main` was 48 commits behind `origin/main` (SHAs `0660b6a` → `e3dfb85`). The branch was deliberately cut from `origin/main` SHA `e3dfb85`, not local `main`.

## Test Plan
- [x] `make check` passed locally (API: ruff/format/mypy/338 pytest pass; Web: lint/prettier/tsc/7 vitest pass/build; new shell test 6/6 pass)
- [x] Behavioral tests cover all four GIVENs from the issue body
- [x] Sync tests assert both markdown files contain the literal invariant commands
- [ ] CI passes
- [ ] Manual regression: replay #146's first acceptance check (`test -f .github/workflows/v1-sha-bump-diff-report.yml`) on a freshly-cut branch — must pass first try
- [ ] Docker health check passes (post-merge)

## Out of scope (follow-ups to file post-merge)

1. Option B from the issue — nightly fast-forward of local `main` in `~/Code/dotfiles/scripts/cleanup_worktrees.py` as defense-in-depth.
2. Audit `EnterWorktree`'s internal base-resolution to ensure it cuts from `origin/main`.

## Intentional non-DRY

The bash block is deliberately duplicated across `implement.md` and `review.md` per the design synthesis ("no shared helper for four lines"). The sync tests in `scripts/tests/test_implement_branch_cut.sh` guard against silent drift.