### PR TITLE
fix(#189): coldreader NITs from #142 review

### DIFF
--- a/scripts/coldreader/run.py
+++ b/scripts/coldreader/run.py
@@ -20,7 +20,7 @@ import os
 import sys
 from pathlib import Path
 
-from client import MODEL, AnthropicRotationClient, Usage
+from client import MODEL, AnthropicRotationClient
 from fixtures import iter_repo_fixtures, load_fixture
 from inventory import PERSONAS, extract_index, extract_section
 from runner import (
@@ -70,12 +70,14 @@ def _print_summary_to_step_summary(markdown: str) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    # WARNING goes to stderr → workflow run log. Without basicConfig the
-    # runner's "low-confidence pass" log line would be silently dropped in CI.
+    # WARNING goes to stderr → workflow run log. force=True ensures we re-apply
+    # our format/level even if a prior caller already configured logging — keeps
+    # the "low-confidence pass" line consistent across CI and programmatic paths.
     logging.basicConfig(
         level=logging.WARNING,
         format="%(levelname)s coldreader: %(message)s",
         stream=sys.stderr,
+        force=True,
     )
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
@@ -104,7 +106,9 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    inv_path = args.inventory or _repo_root() / "docs" / "migration" / "v1-pages-inventory.md"
+    inv_path = (
+        args.inventory or _repo_root() / "docs" / "migration" / "v1-pages-inventory.md"
+    )
 
     if args.dry_run:
         smoke = dry_run_smoke(inv_path)
@@ -140,7 +144,9 @@ def main(argv: list[str] | None = None) -> int:
     total_output = 0
     for fx in fixtures:
         try:
-            section_text = extract_section(inv_path, fx.persona, min_bytes=fx.min_section_bytes)
+            section_text = extract_section(
+                inv_path, fx.persona, min_bytes=fx.min_section_bytes
+            )
         except Exception as e:  # noqa: BLE001
             print(f"error extracting section for {fx.persona}: {e}", file=sys.stderr)
             return EXIT_SETUP_ERROR
@@ -157,7 +163,8 @@ def main(argv: list[str] | None = None) -> int:
         total_output += result.usage.output_tokens
 
         cap_trip = check_cost_caps(
-            Usage(input_tokens=total_input, output_tokens=total_output),
+            input_tokens=total_input,
+            output_tokens=total_output,
             input_cap=_RUN_TOKEN_INPUT_HARD_CAP,
             output_cap=_RUN_TOKEN_OUTPUT_HARD_CAP,
         )

--- a/scripts/coldreader/run.py
+++ b/scripts/coldreader/run.py
@@ -106,9 +106,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    inv_path = (
-        args.inventory or _repo_root() / "docs" / "migration" / "v1-pages-inventory.md"
-    )
+    inv_path = args.inventory or _repo_root() / "docs" / "migration" / "v1-pages-inventory.md"
 
     if args.dry_run:
         smoke = dry_run_smoke(inv_path)
@@ -144,9 +142,7 @@ def main(argv: list[str] | None = None) -> int:
     total_output = 0
     for fx in fixtures:
         try:
-            section_text = extract_section(
-                inv_path, fx.persona, min_bytes=fx.min_section_bytes
-            )
+            section_text = extract_section(inv_path, fx.persona, min_bytes=fx.min_section_bytes)
         except Exception as e:  # noqa: BLE001
             print(f"error extracting section for {fx.persona}: {e}", file=sys.stderr)
             return EXIT_SETUP_ERROR

--- a/scripts/coldreader/runner.py
+++ b/scripts/coldreader/runner.py
@@ -227,7 +227,9 @@ def _evaluate(
             QuestionTelemetry(question_id=q.id, hits=0, total=len(q.must_mention)),
         )
 
-    mention_check = check_must_mention(response.answer, q.must_mention, tolerance=q.tolerance)
+    mention_check = check_must_mention(
+        response.answer, q.must_mention, tolerance=q.tolerance
+    )
     telemetry = QuestionTelemetry(
         question_id=q.id, hits=mention_check.hits, total=mention_check.total
     )
@@ -337,8 +339,14 @@ def _repo_root_from(start: Path) -> Path:
     raise RuntimeError("Could not locate repo root from runner module location")
 
 
-def check_cost_caps(usage: Usage, *, input_cap: int, output_cap: int) -> str | None:
-    """Return ``None`` if ``usage`` is under both caps; otherwise a reason string.
+def check_cost_caps(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    input_cap: int,
+    output_cap: int,
+) -> str | None:
+    """Return ``None`` if token totals are under both caps; otherwise a reason string.
 
     Defense-in-depth above the Anthropic-side $5/month organizational cap.
     Input-trip takes precedence over output-trip for deterministic ordering
@@ -346,15 +354,15 @@ def check_cost_caps(usage: Usage, *, input_cap: int, output_cap: int) -> str | N
     callers must NOT branch on its text. The exit-code mapping
     (``EXIT_SETUP_ERROR`` on trip) lives in ``run.py``.
     """
-    if usage.input_tokens > input_cap:
+    if input_tokens > input_cap:
         return (
             f"cost guardrail tripped: total uncached input tokens "
-            f"{usage.input_tokens} exceeds {input_cap}"
+            f"{input_tokens} exceeds {input_cap}"
         )
-    if usage.output_tokens > output_cap:
+    if output_tokens > output_cap:
         return (
             f"cost guardrail tripped: total output tokens "
-            f"{usage.output_tokens} exceeds {output_cap}"
+            f"{output_tokens} exceeds {output_cap}"
         )
     return None
 

--- a/scripts/coldreader/runner.py
+++ b/scripts/coldreader/runner.py
@@ -227,9 +227,7 @@ def _evaluate(
             QuestionTelemetry(question_id=q.id, hits=0, total=len(q.must_mention)),
         )
 
-    mention_check = check_must_mention(
-        response.answer, q.must_mention, tolerance=q.tolerance
-    )
+    mention_check = check_must_mention(response.answer, q.must_mention, tolerance=q.tolerance)
     telemetry = QuestionTelemetry(
         question_id=q.id, hits=mention_check.hits, total=mention_check.total
     )
@@ -360,10 +358,7 @@ def check_cost_caps(
             f"{input_tokens} exceeds {input_cap}"
         )
     if output_tokens > output_cap:
-        return (
-            f"cost guardrail tripped: total output tokens "
-            f"{output_tokens} exceeds {output_cap}"
-        )
+        return f"cost guardrail tripped: total output tokens {output_tokens} exceeds {output_cap}"
     return None
 
 

--- a/scripts/coldreader/tests/test_run_safety.py
+++ b/scripts/coldreader/tests/test_run_safety.py
@@ -46,7 +46,9 @@ def test_main_safe_treats_anthropic_error_as_setup_error() -> None:
     class _FakeBadRequestError(Exception):
         """Stand-in for anthropic.BadRequestError — same exit-path semantics."""
 
-    with patch.object(run, "main", side_effect=_FakeBadRequestError("400 invalid_request_error")):
+    with patch.object(
+        run, "main", side_effect=_FakeBadRequestError("400 invalid_request_error")
+    ):
         assert _main_safe() == EXIT_SETUP_ERROR
 
 
@@ -67,6 +69,12 @@ def test_main_returns_setup_error_when_runner_token_counts_exceed_input_cap(
 
     class _RunawayClient:
         def query_rotation(self, call: RotationCall) -> RotationResponse:
+            # The answer + verbatim_evidence values are intentionally orthogonal to the
+            # real fixture's must_mention list. This test exercises the cost-cap-trip
+            # exit-code path (run.py:159-166) which short-circuits before scoring, so
+            # answer/evidence correctness is irrelevant to the contract. Do NOT "fix"
+            # them to match a real fixture — the test would still pass, but a future
+            # reader might mistakenly believe must_mention satisfaction matters here.
             return RotationResponse(
                 answer="dashboard linked-client active-flag soft-revoke",
                 # Generic phrase present in every persona's section.
@@ -94,6 +102,12 @@ def test_main_returns_setup_error_when_runner_token_counts_exceed_output_cap(
 
     class _OutputRunawayClient:
         def query_rotation(self, call: RotationCall) -> RotationResponse:
+            # The answer + verbatim_evidence values are intentionally orthogonal to the
+            # real fixture's must_mention list. This test exercises the cost-cap-trip
+            # exit-code path (run.py:159-166) which short-circuits before scoring, so
+            # answer/evidence correctness is irrelevant to the contract. Do NOT "fix"
+            # them to match a real fixture — the test would still pass, but a future
+            # reader might mistakenly believe must_mention satisfaction matters here.
             return RotationResponse(
                 answer="dashboard linked-client active-flag soft-revoke",
                 verbatim_evidence=("Family Member",),

--- a/scripts/coldreader/tests/test_run_safety.py
+++ b/scripts/coldreader/tests/test_run_safety.py
@@ -46,9 +46,7 @@ def test_main_safe_treats_anthropic_error_as_setup_error() -> None:
     class _FakeBadRequestError(Exception):
         """Stand-in for anthropic.BadRequestError — same exit-path semantics."""
 
-    with patch.object(
-        run, "main", side_effect=_FakeBadRequestError("400 invalid_request_error")
-    ):
+    with patch.object(run, "main", side_effect=_FakeBadRequestError("400 invalid_request_error")):
         assert _main_safe() == EXIT_SETUP_ERROR
 
 

--- a/scripts/coldreader/tests/test_runner.py
+++ b/scripts/coldreader/tests/test_runner.py
@@ -101,9 +101,7 @@ def test_rotation_passes_when_evidence_grounded(tmp_path: Path) -> None:
         ),
     )
 
-    result = run_rotation(
-        fx, section=section, index=index, client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=section, index=index, client=client, allow_retry=True)
     assert isinstance(result, RotationResult)
     assert result.passed
     assert len(result.failures) == 0
@@ -174,9 +172,7 @@ def test_rotation_fails_when_verbatim_evidence_not_in_section(tmp_path: Path) ->
         ),
     )
 
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
     assert not result.passed
     assert len(result.failures) == 1
     f = result.failures[0]
@@ -213,9 +209,7 @@ def test_rotation_evidence_can_match_in_either_section_or_index(tmp_path: Path) 
             verbatim_evidence=("no active-flag on the link",),
         ),
     )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     assert result.passed
 
 
@@ -256,9 +250,7 @@ def test_rotation_fails_when_answer_is_null(tmp_path: Path) -> None:
             verbatim_evidence=("no active-flag on the link",),
         ),
     )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
     assert not result.passed
     assert any(f.question_id == "q1" for f in result.failures)
 
@@ -307,9 +299,7 @@ def test_rotation_retries_failing_question_with_extended_thinking(
         ),
     )
 
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
     assert result.passed, "second-pass retry should rescue q1"
     # The retry call has use_extended_thinking=True
     retry_calls = [c for c in client.calls if c.use_extended_thinking]
@@ -345,9 +335,7 @@ def test_rotation_skips_retry_when_disabled(tmp_path: Path) -> None:
             verbatim_evidence=("no active-flag on the link",),
         ),
     )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     assert not result.passed
     # No retry call recorded
     assert all(not c.use_extended_thinking for c in client.calls)
@@ -389,9 +377,7 @@ def test_rotation_aggregates_token_usage(tmp_path: Path) -> None:
                 cache_creation_tokens=500,
             ),
         )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     assert result.usage.input_tokens == 300
     assert result.usage.output_tokens == 600
     assert result.usage.cache_read_input_tokens == 6000
@@ -413,9 +399,7 @@ def test_rotation_cache_hit_ratio_helper() -> None:
                 cache_read_tokens=900,
             ),
         )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     # 900 cached vs 100 uncached input per call → ratio 0.9
     assert abs(result.usage.cache_hit_ratio - 0.9) < 1e-6
 
@@ -481,9 +465,7 @@ def test_failure_message_includes_persona_question_text_and_missing_evidence(
             verbatim_evidence=("no active-flag on the link",),
         ),
     )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
     assert not result.passed
     f = result.failures[0]
     msg = result.format_failure(f)
@@ -602,9 +584,7 @@ def test_fake_client_records_calls_in_order(tmp_path: Path) -> None:
             qid,
             CannedResponse(answer=answer, verbatim_evidence=(evidence,)),
         )
-    run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     assert [c.question_id for c in client.calls] == ["q1", "q2", "q3"]
 
 
@@ -628,9 +608,7 @@ def test_render_tracking_issue_body_for_failures(tmp_path: Path) -> None:
     client.add_response(
         "family-member",
         "q2",
-        CannedResponse(
-            answer="No, gated linked-client only.", verbatim_evidence=("not there",)
-        ),
+        CannedResponse(answer="No, gated linked-client only.", verbatim_evidence=("not there",)),
     )
     client.add_response(
         "family-member",
@@ -649,9 +627,7 @@ def test_render_tracking_issue_body_for_failures(tmp_path: Path) -> None:
             verbatim_evidence=("v1 has no active-flag",),
         ),
     )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
     md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
     assert "claude-haiku-4-5-20251001" in md
     assert "FAIL" in md or "fail" in md
@@ -705,9 +681,7 @@ def test_pass_b_tool_refusal_surfaces_text_block_as_setup_failure(
         ),
     )
 
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
     assert not result.passed
     assert result.has_setup_error
     f = result.failures[0]
@@ -723,9 +697,7 @@ def test_text_block_content_truncated_in_failure_message(tmp_path: Path) -> None
     fx = _fixture()
     long_text = "X" * (TEXT_BLOCK_TRUNCATE_CHARS + 200)
     client = FakeAnthropicClient()
-    client.add_response(
-        "family-member", "q1", CannedResponse(answer="", verbatim_evidence=())
-    )
+    client.add_response("family-member", "q1", CannedResponse(answer="", verbatim_evidence=()))
     client.add_response(
         "family-member",
         "q1",
@@ -753,9 +725,7 @@ def test_text_block_content_truncated_in_failure_message(tmp_path: Path) -> None
         ),
     )
 
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
     f = result.failures[0]
     # Truncated to bound; no full-length echo.
     assert "X" * (TEXT_BLOCK_TRUNCATE_CHARS + 50) not in f.message
@@ -765,9 +735,7 @@ def test_text_block_phi_scrubbed_in_failure_message(tmp_path: Path) -> None:
     """PHI-shaped strings in text-block content are scrubbed before logging."""
     fx = _fixture()
     client = FakeAnthropicClient()
-    client.add_response(
-        "family-member", "q1", CannedResponse(answer="", verbatim_evidence=())
-    )
+    client.add_response("family-member", "q1", CannedResponse(answer="", verbatim_evidence=()))
     client.add_response(
         "family-member",
         "q1",
@@ -775,9 +743,7 @@ def test_text_block_phi_scrubbed_in_failure_message(tmp_path: Path) -> None:
             answer="",
             verbatim_evidence=(),
             used_extended_thinking=True,
-            text_block_content=(
-                "I would normally cite jane.doe@example.com but cannot here."
-            ),
+            text_block_content=("I would normally cite jane.doe@example.com but cannot here."),
         ),
     )
     client.add_response(
@@ -797,9 +763,7 @@ def test_text_block_phi_scrubbed_in_failure_message(tmp_path: Path) -> None:
         ),
     )
 
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=True
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
     f = result.failures[0]
     assert "jane.doe@example.com" not in f.message
     assert "PHI-REDACTED" in f.message
@@ -821,9 +785,7 @@ def test_render_summary_includes_per_question_hit_counts(tmp_path: Path) -> None
             qid,
             CannedResponse(answer=answer, verbatim_evidence=(evidence,)),
         )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
     # Each question line shows N of M hit counts.
     assert "q1: 1 of 1" in md
@@ -843,9 +805,7 @@ def test_rotation_records_telemetry_for_passing_questions(tmp_path: Path) -> Non
             qid,
             CannedResponse(answer=answer, verbatim_evidence=(evidence,)),
         )
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     assert result.passed
     assert len(result.telemetry) == 3
     # All entries report the actual N-of-M, regardless of pass status.
@@ -924,9 +884,7 @@ def test_low_confidence_pass_emits_warning_log(
     assert result.low_confidence_count == 1
 
     warnings = [
-        r
-        for r in caplog.records
-        if r.name == "coldreader" and r.levelno == logging.WARNING
+        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
     ]
     assert len(warnings) == 1
     msg = warnings[0].getMessage()
@@ -953,9 +911,7 @@ def test_high_confidence_pass_emits_no_warning_log(
     assert result.passed
     assert result.low_confidence_count == 0
     warnings = [
-        r
-        for r in caplog.records
-        if r.name == "coldreader" and r.levelno == logging.WARNING
+        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
     ]
     assert warnings == []
 
@@ -1018,9 +974,7 @@ def test_low_confidence_failure_does_not_double_log(
     assert not result.passed
     assert result.low_confidence_count == 0
     warnings = [
-        r
-        for r in caplog.records
-        if r.name == "coldreader" and r.levelno == logging.WARNING
+        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
     ]
     assert warnings == []
 
@@ -1029,9 +983,7 @@ def test_render_summary_includes_low_confidence_count_when_nonzero() -> None:
     fx = _fixture()
     client = FakeAnthropicClient()
     _all_three_pass_with_confidence(client, q1="low", q2="low", q3="high")
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
     assert "Low-confidence passes: 2" in md
 
@@ -1040,9 +992,7 @@ def test_render_summary_omits_low_confidence_line_when_zero() -> None:
     fx = _fixture()
     client = FakeAnthropicClient()
     _all_three_pass_with_confidence(client, q1="high", q2="high", q3="high")
-    result = run_rotation(
-        fx, section=_section(), index=_index(), client=client, allow_retry=False
-    )
+    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
     md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
     assert "Low-confidence" not in md
 

--- a/scripts/coldreader/tests/test_runner.py
+++ b/scripts/coldreader/tests/test_runner.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import pytest
 import yaml
 
-from client import Usage
 from fixtures import Fixture, Question
 from runner import (
     RotationFailure,
@@ -102,7 +101,9 @@ def test_rotation_passes_when_evidence_grounded(tmp_path: Path) -> None:
         ),
     )
 
-    result = run_rotation(fx, section=section, index=index, client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=section, index=index, client=client, allow_retry=True
+    )
     assert isinstance(result, RotationResult)
     assert result.passed
     assert len(result.failures) == 0
@@ -173,7 +174,9 @@ def test_rotation_fails_when_verbatim_evidence_not_in_section(tmp_path: Path) ->
         ),
     )
 
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=True
+    )
     assert not result.passed
     assert len(result.failures) == 1
     f = result.failures[0]
@@ -210,7 +213,9 @@ def test_rotation_evidence_can_match_in_either_section_or_index(tmp_path: Path) 
             verbatim_evidence=("no active-flag on the link",),
         ),
     )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     assert result.passed
 
 
@@ -251,7 +256,9 @@ def test_rotation_fails_when_answer_is_null(tmp_path: Path) -> None:
             verbatim_evidence=("no active-flag on the link",),
         ),
     )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=True
+    )
     assert not result.passed
     assert any(f.question_id == "q1" for f in result.failures)
 
@@ -300,7 +307,9 @@ def test_rotation_retries_failing_question_with_extended_thinking(
         ),
     )
 
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=True
+    )
     assert result.passed, "second-pass retry should rescue q1"
     # The retry call has use_extended_thinking=True
     retry_calls = [c for c in client.calls if c.use_extended_thinking]
@@ -336,7 +345,9 @@ def test_rotation_skips_retry_when_disabled(tmp_path: Path) -> None:
             verbatim_evidence=("no active-flag on the link",),
         ),
     )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     assert not result.passed
     # No retry call recorded
     assert all(not c.use_extended_thinking for c in client.calls)
@@ -378,7 +389,9 @@ def test_rotation_aggregates_token_usage(tmp_path: Path) -> None:
                 cache_creation_tokens=500,
             ),
         )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     assert result.usage.input_tokens == 300
     assert result.usage.output_tokens == 600
     assert result.usage.cache_read_input_tokens == 6000
@@ -400,7 +413,9 @@ def test_rotation_cache_hit_ratio_helper() -> None:
                 cache_read_tokens=900,
             ),
         )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     # 900 cached vs 100 uncached input per call → ratio 0.9
     assert abs(result.usage.cache_hit_ratio - 0.9) < 1e-6
 
@@ -466,7 +481,9 @@ def test_failure_message_includes_persona_question_text_and_missing_evidence(
             verbatim_evidence=("no active-flag on the link",),
         ),
     )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=True
+    )
     assert not result.passed
     f = result.failures[0]
     msg = result.format_failure(f)
@@ -585,7 +602,9 @@ def test_fake_client_records_calls_in_order(tmp_path: Path) -> None:
             qid,
             CannedResponse(answer=answer, verbatim_evidence=(evidence,)),
         )
-    run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     assert [c.question_id for c in client.calls] == ["q1", "q2", "q3"]
 
 
@@ -609,7 +628,9 @@ def test_render_tracking_issue_body_for_failures(tmp_path: Path) -> None:
     client.add_response(
         "family-member",
         "q2",
-        CannedResponse(answer="No, gated linked-client only.", verbatim_evidence=("not there",)),
+        CannedResponse(
+            answer="No, gated linked-client only.", verbatim_evidence=("not there",)
+        ),
     )
     client.add_response(
         "family-member",
@@ -628,7 +649,9 @@ def test_render_tracking_issue_body_for_failures(tmp_path: Path) -> None:
             verbatim_evidence=("v1 has no active-flag",),
         ),
     )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=True
+    )
     md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
     assert "claude-haiku-4-5-20251001" in md
     assert "FAIL" in md or "fail" in md
@@ -682,7 +705,9 @@ def test_pass_b_tool_refusal_surfaces_text_block_as_setup_failure(
         ),
     )
 
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=True
+    )
     assert not result.passed
     assert result.has_setup_error
     f = result.failures[0]
@@ -698,7 +723,9 @@ def test_text_block_content_truncated_in_failure_message(tmp_path: Path) -> None
     fx = _fixture()
     long_text = "X" * (TEXT_BLOCK_TRUNCATE_CHARS + 200)
     client = FakeAnthropicClient()
-    client.add_response("family-member", "q1", CannedResponse(answer="", verbatim_evidence=()))
+    client.add_response(
+        "family-member", "q1", CannedResponse(answer="", verbatim_evidence=())
+    )
     client.add_response(
         "family-member",
         "q1",
@@ -726,7 +753,9 @@ def test_text_block_content_truncated_in_failure_message(tmp_path: Path) -> None
         ),
     )
 
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=True
+    )
     f = result.failures[0]
     # Truncated to bound; no full-length echo.
     assert "X" * (TEXT_BLOCK_TRUNCATE_CHARS + 50) not in f.message
@@ -736,7 +765,9 @@ def test_text_block_phi_scrubbed_in_failure_message(tmp_path: Path) -> None:
     """PHI-shaped strings in text-block content are scrubbed before logging."""
     fx = _fixture()
     client = FakeAnthropicClient()
-    client.add_response("family-member", "q1", CannedResponse(answer="", verbatim_evidence=()))
+    client.add_response(
+        "family-member", "q1", CannedResponse(answer="", verbatim_evidence=())
+    )
     client.add_response(
         "family-member",
         "q1",
@@ -744,7 +775,9 @@ def test_text_block_phi_scrubbed_in_failure_message(tmp_path: Path) -> None:
             answer="",
             verbatim_evidence=(),
             used_extended_thinking=True,
-            text_block_content=("I would normally cite jane.doe@example.com but cannot here."),
+            text_block_content=(
+                "I would normally cite jane.doe@example.com but cannot here."
+            ),
         ),
     )
     client.add_response(
@@ -764,7 +797,9 @@ def test_text_block_phi_scrubbed_in_failure_message(tmp_path: Path) -> None:
         ),
     )
 
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=True)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=True
+    )
     f = result.failures[0]
     assert "jane.doe@example.com" not in f.message
     assert "PHI-REDACTED" in f.message
@@ -786,7 +821,9 @@ def test_render_summary_includes_per_question_hit_counts(tmp_path: Path) -> None
             qid,
             CannedResponse(answer=answer, verbatim_evidence=(evidence,)),
         )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
     # Each question line shows N of M hit counts.
     assert "q1: 1 of 1" in md
@@ -806,7 +843,9 @@ def test_rotation_records_telemetry_for_passing_questions(tmp_path: Path) -> Non
             qid,
             CannedResponse(answer=answer, verbatim_evidence=(evidence,)),
         )
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     assert result.passed
     assert len(result.telemetry) == 3
     # All entries report the actual N-of-M, regardless of pass status.
@@ -885,7 +924,9 @@ def test_low_confidence_pass_emits_warning_log(
     assert result.low_confidence_count == 1
 
     warnings = [
-        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
+        r
+        for r in caplog.records
+        if r.name == "coldreader" and r.levelno == logging.WARNING
     ]
     assert len(warnings) == 1
     msg = warnings[0].getMessage()
@@ -912,7 +953,9 @@ def test_high_confidence_pass_emits_no_warning_log(
     assert result.passed
     assert result.low_confidence_count == 0
     warnings = [
-        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
+        r
+        for r in caplog.records
+        if r.name == "coldreader" and r.levelno == logging.WARNING
     ]
     assert warnings == []
 
@@ -975,7 +1018,9 @@ def test_low_confidence_failure_does_not_double_log(
     assert not result.passed
     assert result.low_confidence_count == 0
     warnings = [
-        r for r in caplog.records if r.name == "coldreader" and r.levelno == logging.WARNING
+        r
+        for r in caplog.records
+        if r.name == "coldreader" and r.levelno == logging.WARNING
     ]
     assert warnings == []
 
@@ -984,7 +1029,9 @@ def test_render_summary_includes_low_confidence_count_when_nonzero() -> None:
     fx = _fixture()
     client = FakeAnthropicClient()
     _all_three_pass_with_confidence(client, q1="low", q2="low", q3="high")
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
     assert "Low-confidence passes: 2" in md
 
@@ -993,7 +1040,9 @@ def test_render_summary_omits_low_confidence_line_when_zero() -> None:
     fx = _fixture()
     client = FakeAnthropicClient()
     _all_three_pass_with_confidence(client, q1="high", q2="high", q3="high")
-    result = run_rotation(fx, section=_section(), index=_index(), client=client, allow_retry=False)
+    result = run_rotation(
+        fx, section=_section(), index=_index(), client=client, allow_retry=False
+    )
     md = render_summary_markdown([result], model="claude-haiku-4-5-20251001")
     assert "Low-confidence" not in md
 
@@ -1004,7 +1053,8 @@ def test_render_summary_omits_low_confidence_line_when_zero() -> None:
 def test_check_cost_caps_returns_none_when_under_caps() -> None:
     assert (
         check_cost_caps(
-            Usage(input_tokens=100, output_tokens=200),
+            input_tokens=100,
+            output_tokens=200,
             input_cap=200_000,
             output_cap=30_000,
         )
@@ -1014,7 +1064,8 @@ def test_check_cost_caps_returns_none_when_under_caps() -> None:
 
 def test_check_cost_caps_trips_on_input_overage() -> None:
     reason = check_cost_caps(
-        Usage(input_tokens=300_000, output_tokens=200),
+        input_tokens=300_000,
+        output_tokens=200,
         input_cap=200_000,
         output_cap=30_000,
     )
@@ -1025,7 +1076,8 @@ def test_check_cost_caps_trips_on_input_overage() -> None:
 
 def test_check_cost_caps_trips_on_output_overage() -> None:
     reason = check_cost_caps(
-        Usage(input_tokens=100, output_tokens=50_000),
+        input_tokens=100,
+        output_tokens=50_000,
         input_cap=200_000,
         output_cap=30_000,
     )
@@ -1036,7 +1088,8 @@ def test_check_cost_caps_trips_on_output_overage() -> None:
 def test_check_cost_caps_input_takes_precedence_when_both_trip() -> None:
     """Deterministic ordering: input-trip beats output-trip for log clarity."""
     reason = check_cost_caps(
-        Usage(input_tokens=300_000, output_tokens=50_000),
+        input_tokens=300_000,
+        output_tokens=50_000,
         input_cap=200_000,
         output_cap=30_000,
     )
@@ -1049,7 +1102,8 @@ def test_check_cost_caps_at_boundary_does_not_trip() -> None:
     """Exactly at the cap is acceptable; only > cap trips."""
     assert (
         check_cost_caps(
-            Usage(input_tokens=200_000, output_tokens=30_000),
+            input_tokens=200_000,
+            output_tokens=30_000,
             input_cap=200_000,
             output_cap=30_000,
         )


### PR DESCRIPTION
Closes #189

## Summary

Three quality-of-implementation NITs flagged by the engineering committee on PR #182 (issue #142). All three within `scripts/coldreader/`. No behavior change.

- **NIT A (`run.py:75-79`)** — `logging.basicConfig(force=True)`. Without `force=True`, a programmatic re-invocation through tests/orchestration with pre-existing handlers would silently drop the runner's `WARNING coldreader: low-confidence pass …` line — the only non-failure breadcrumb for spotting model-confidence drift after a model upgrade. `force=True` extends the runner's existing aggressive-normalization posture (exit codes, stderr text, log shape) to log handlers. Comment updated to name the *why* explicitly.
- **NIT B (`runner.py::check_cost_caps`)** — refactored signature from `(usage: Usage, *, input_cap, output_cap)` to keyword-only ints `(*, input_tokens, output_tokens, input_cap, output_cap)`. The call site at `run.py:159-163` was constructing a synthetic `Usage` from two ints purely to satisfy the helper signature; `Usage` is otherwise an API-aggregation shape (input/output/cache_read/cache_creation tokens) — the cap predicate only cares about two of those four. Decouples the predicate from the API shape; cleans up 5 unit tests at `tests/test_runner.py:1004-1057`. Drops now-unused `Usage` imports from `run.py` and `tests/test_runner.py`.
- **NIT C (`tests/test_run_safety.py`)** — added 6-line intent comment above each `_RunawayClient`/`_OutputRunawayClient` `RotationResponse` so a future reader does not "fix" the canned answer to satisfy a real fixture's `must_mention`. The cap-trip path at `run.py:159-166` short-circuits before scoring, so answer/evidence correctness is intentionally orthogonal to the contract. Without the comment, a "fix" would still pass — but on a wrong mental model.

## Committee review

[Design synthesis](https://github.com/suniljames/COREcare-v2/issues/189#issuecomment-4402275567) (Engineering Manager) — unanimous on NIT shape: `force=True` over handler-check guard; keyword-only ints over `Usage` transient; longer intent comment over single-line.

[Fresh-Eyes Validation](https://github.com/suniljames/COREcare-v2/issues/189#issuecomment-4402288054) — PASS. Body is self-contained.

## Behavior change

**None.** Exit codes (`EXIT_PASS`/`EXIT_DRIFT`/`EXIT_SETUP_ERROR`), log format, stderr text, and `$GITHUB_STEP_SUMMARY` content are all unchanged.

## Test Plan

- [x] Coldreader pytest — **108 passed** (no new tests; existing coverage pins the contract for all three NITs)
- [x] Coldreader mypy strict — clean on 4 touched files
- [x] Coldreader ruff lint — clean on 4 touched files
- [x] `make check` → api lint (ruff + format + mypy 116 source files) — pass
- [x] `make check` → api test (338 passed, 3 skipped) — pass
- [x] `make check` → web lint (next lint + prettier) — pass
- [x] `make check` → web typecheck (`tsc --noEmit`) — pass
- [x] `make check` → web test (vitest, 7 passed) — pass
- [ ] `make check` → web build — fails locally on missing `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`. Pre-existing local-env issue (no `.env.local` in main checkout either); CI sets the env. **Not a regression of this branch.**
- [ ] CI passes
- [ ] Docker health check passes

## Out of scope

AI/ML noted (in [design comment](https://github.com/suniljames/COREcare-v2/issues/189#issuecomment-4402265226)) that `_log.warning` at `runner.py:286-291` logs `confidence=%s` as an unvalidated string — file a separate small ticket if a malformed value is ever observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)