### PR TITLE
docs(#184): PR 1/6 — author super-admin/001-kill-all caption

### DIFF
--- a/docs/legacy/v1-ui-catalog/super-admin/001-kill-all.md
+++ b/docs/legacy/v1-ui-catalog/super-admin/001-kill-all.md
@@ -7,4 +7,7 @@ seed_state: populated
 v1_commit: 9738412a6e41064203fc253d9dd2a5c6a9c2e231
 generated: 2026-05-08
 ---
-<!-- TODO: author CTAs + interaction notes per CAPTION-STYLE.md (Phase 3) -->
+**CTAs visible:** "none" — POST-only endpoint with no GET handler; the captured screenshot is the empty 405 response.
+
+**Interaction notes:**
+- ⚠ destructive: POST to this URL → expires every active `ViewAsSession` row, audit-logs a warning (`View As emergency kill switch activated`), and redirects to the Django admin index. The trigger lives on [agency-admin/013-audit-log](../agency-admin/013-audit-log.md) as a red `Kill All Active Sessions` button gated by `is_superuser`; the button form uses a JavaScript `confirm()` dialog before submitting. Skipped by crawler — the route is GET-405.

--- a/tools/v1-screenshot-catalog/AUTHORING-LOG.md
+++ b/tools/v1-screenshot-catalog/AUTHORING-LOG.md
@@ -18,6 +18,7 @@ Forensic ground truth for "which session, which fixture state, which persona sec
 
 | Date | Start–end (PT) | Persona section | Captions touched | Fixture sha256 (precheck) | Operator | Notes |
 |------|----------------|-----------------|------------------|---------------------------|----------|-------|
+| 2026-05-08 | 18:30–18:55 | super-admin | 001 | `03b4148003d67bc8c98129f1d1a8e3bf8f5935d367d5d8b27776bf9ef3afdf92` | suniljames | **Source-archaeology methodology** (no v1 server run): caption authored from WebP + v1 source at pinned commit `9738412a` (URL conf, view function, service method, template). Fixture sha verified against `RUN-MANIFEST.md` directly without invoking the precheck script (no localhost involved). Route `/admin/view-as/kill-all/` is POST-only with no GET handler — captured screenshots are the empty 405 response, so no UI to observe; behavior derived from `core/view_as_views.py:259` + `core/services/view_as_service.py:284`. |
 
 ## Session-start checklist
 


### PR DESCRIPTION
## Summary

- **PR 1 of 6** for issue #184: authored body for the single Super-Admin caption (`docs/legacy/v1-ui-catalog/super-admin/001-kill-all.md`).
- Methodology: source-archaeology against v1 pinned commit `9738412a` (no live v1 server) — the route `/admin/view-as/kill-all/` is POST-only with no GET handler, so the captured WebPs are the empty 405 response. There is no rendered UI at any viewport to observe; behavior derived from URL conf + view + service + trigger template.

## Authoring methodology

Per the locked Phase 3 preconditions, sessions normally bring up v1 locally and observe by clicking. This caption is unusual: a POST-only endpoint has nothing to observe via GET. Instead I read v1 source at the pinned commit:

| Source | Purpose |
|--------|---------|
| `elitecare/urls.py:108` | URL pattern → `view_as_kill_all` |
| `core/view_as_views.py:259` | View function (`@require_http_methods(["POST"])`, `is_superuser`-gated) |
| `core/services/view_as_service.py:284` | `ViewAsService.kill_all_sessions()` — expires every active `ViewAsSession`, audit-logs warning |
| `templates/core/view_as_audit_log.html:36` | Trigger form: red `Kill All Active Sessions` button, JS-confirm, posts here |

Fixture sha verified directly against `RUN-MANIFEST.md` (no localhost-precheck-script invocation, since no localhost was involved). The session row in `AUTHORING-LOG.md` documents the methodology so it's visible in the forensic record.

## Caption shape

The CTA list uses a single quoted-`"none"` payload because the route has no rendered UI; the rule's `none — read-only view.` literal exception didn't apply (this isn't read-only — it's destructive POST). The interaction note is `⚠ destructive:` prefixed and notes "Skipped by crawler — the route is GET-405", which both satisfies the destructive-interaction format and explains why the WebPs are blank.

Cross-reference: links to `agency-admin/013-audit-log` (the page where the trigger button lives) using canonical_id link text per CAPTION-STYLE.md.

## Test Plan

- [x] `bash scripts/check-v1-doc-hygiene.sh` — exit 0
- [x] `bash scripts/check-v1-caption-phi.sh` — exit 0
- [x] `bash scripts/check-v1-caption-voice.sh` — exit 0
- [x] `bash scripts/check-v1-catalog-coverage.sh` — exit 0 (matched 84, unmatched 0, orphans 0, coverage 100%)
- [x] `grep -rl '<!-- TODO: author CTAs' docs/legacy/v1-ui-catalog/super-admin/` — empty (persona dir TODO-free)
- [x] `make test-v1-docs` — 8 test files, all assertions pass (no regression from PR 0 tooling)
- [x] File size check: 821 bytes < 1 KB threshold
- [ ] CI green
- [ ] Committee code review

## What remains on issue #184

- PR 2: care-manager (3 captions, ~0.75h)
- PR 3: family-member (4 captions, ~1h, mobile-lead)
- PR 4: caregiver (15 captions, ~4h, mobile-lead)
- PR 5: agency-admin (61 captions, ~15h)
- PR 6: T7 cold smoke + post-PHI audit + flip CI soft-gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)