### PR TITLE
test(#194): MT-1 meta-test grooming — 2 of 3 actionable NITs

### DIFF
--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -2631,7 +2631,7 @@ fi
 # See: https://github.com/suniljames/COREcare-v2/issues/173 (this issue),
 #      https://github.com/suniljames/COREcare-v2/issues/128 (architectural source).
 
-_extract_src_codes() {
+_extract_source_codes() {
   # Distinct two-letter-prefix codes referenced anywhere in the source script.
   grep -hoE '[A-Z]{2}-[0-9]+[a-z]*' "$1" | sort -u
 }
@@ -2664,7 +2664,7 @@ _compute_coverage_parity() {
   local awk_path="$1"
   local test_path="$2"
   local src_codes test_codes
-  src_codes=$(_filter_umbrellas "$(_extract_src_codes "$awk_path")")
+  src_codes=$(_filter_umbrellas "$(_extract_source_codes "$awk_path")")
   test_codes=$(_filter_umbrellas "$(_extract_test_codes "$test_path")")
 
   local prefixes
@@ -2672,7 +2672,8 @@ _compute_coverage_parity() {
 
   local violations=""
   local prefix
-  for prefix in $prefixes; do
+  while IFS= read -r prefix; do
+    [[ -z "$prefix" ]] && continue
     local src_prefix test_prefix src_only test_only
     src_prefix=$(echo "$src_codes" | grep -E "^${prefix}-" || true)
     test_prefix=$(echo "$test_codes" | grep -E "^${prefix}-" || true)
@@ -2684,7 +2685,7 @@ _compute_coverage_parity() {
       violations+="  ${prefix}: codes in awk only: ${src_only}"$'\n'
       violations+="      codes in tests only: ${test_only}"$'\n'
     fi
-  done
+  done <<< "$prefixes"
 
   if [[ -n "$violations" ]]; then
     echo "coverage parity (MT-1)"
@@ -2728,6 +2729,22 @@ assert_coverage_parity \
   0
 
 # B. Self-test — synthesized awk-side gap (all SL-3 references stripped) is detected.
+# `sed '/SL-3/d'` removes every SL-3 mention (emit lines, dedicated comment
+# lines, AND the multi-code header at line 285). This works because:
+# 1. _extract_source_codes is a line-anywhere grep that picks up codes from
+#    comments AND emit lines indistinguishably — so for the gap to register,
+#    BOTH must go.
+# 2. The line-285 multi-code header (`# SL-1, SL-2, SL-3, SL-4 ...`) gets
+#    removed too, but SL-1/SL-2/SL-4 each have their own dedicated emit and
+#    comment lines elsewhere; they survive.
+#
+# A future refactor that consolidates ALL code mentions onto fewer multi-code
+# comment lines could mask gaps. Two options when that becomes a real concern:
+# (a) tighten this sed to emit-line-only AND tighten _extract_source_codes
+#     to match (handles 3 emit styles in the structure script — awk-print,
+#     fail-with-code-suffix, fail-without-code), or (b) construct the
+#     synthesized fixture from scratch instead of stripping. Either is a
+#     bigger lift than this self-test warrants today.
 mkdir -p "$TEST_DIR/mt-1-awk-gap"
 sed '/SL-3/d' "$STRUCTURE" > "$TEST_DIR/mt-1-awk-gap/check.sh"
 assert_coverage_parity \


### PR DESCRIPTION
Closes #194 (NITs 1 + 2; NIT 3 documented as deferred).

## Summary

NIT 1 + NIT 2 from #194 applied. NIT 3 turned out to need a deeper extractor refactor than the issue body suggested; deferred with documentation.

## What changed

**NIT 1 — bash idiom** (defensive against future whitespace-bearing prefix values)
```bash
# Before
for prefix in $prefixes; do
  ...
done

# After
while IFS= read -r prefix; do
  [[ -z "$prefix" ]] && continue
  ...
done <<< "$prefixes"
```

**NIT 2 — helper rename** (align with full-word convention)
```bash
_extract_src_codes  →  _extract_source_codes
```

## Why NIT 3 is deferred

NIT 3 proposed `sed '/SL-3/d'` → `sed '/print FILENAME.*SL-3:/d'` (emit-line-only). I applied that locally and the test failed: stripping only emit lines for SL-3 doesn't make the orphan-fixture self-test trip, because `_extract_source_codes` is a **line-anywhere** grep that also picks up SL-3 in comment lines elsewhere in the script. So SL-3 stays in `src_codes` even after the surgical sed, and the gap is invisible.

To make NIT 3 work as written, `_extract_source_codes` also needs to be emit-only. But the structure script emits via three different styles:

1. **awk-print:** `print FILENAME ":" FNR ": SL-3:` (used for SL-, EL-, CR-, RR-4a..d, WF-1)
2. **fail with code suffix:** `fail "... (CL-1)"` (used for CL-, RR-1..3)
3. **fail without code in message:** `fail "...missing **Status:** header line"` — code appears only in the comment above (used for GL-1, GL-2, JL-1..5)

A single regex that captures all three doesn't exist. Either tighten the extractor with multi-style logic + uniform-emit-convention enforcement (a bigger refactor that would also need a fix to the script's fail-without-code messages), or construct the gap fixture from scratch (also bigger). Both are outside this NIT's polish scope.

A comment at the sed call site documents the trade-off so a future maintainer doesn't re-encounter the same investigation.

## Test plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` — **98/98 PASS preserved**
- [ ] CI passes