### PR TITLE
test(#174): SL-* substring assertions + SL-2 fixture purity

### DIFF
--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -608,6 +608,10 @@ rm -f "$TEST_DIR/integrations-sl1/v1-integrations-and-exports.md.bak"
 assert_exit_and_match "SL-1: drifted entry-table header fails" 1 'SL-1:' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl1"
 
 # --- SL-2: invalid v2_status token ---
+# Fixture purity (#174): the bad row's severity cell is intentionally empty.
+# v2_status='partial' (invalid) trips SL-2 alone. If severity were set, SL-3
+# ("severity set but v2_status != missing") would also fire, masking SL-2
+# regressions under exit-code-only assertions.
 mkdir -p "$TEST_DIR/integrations-sl2"
 write_integrations_inventory "$TEST_DIR/integrations-sl2/v1-pages-inventory.md"
 write_good_delta "$TEST_DIR/integrations-sl2/v1-functionality-delta.md"

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -574,6 +574,21 @@ sed -i.bak '/^### Payroll$/d' "$TEST_DIR/integrations-cl2/v1-integrations-and-ex
 rm "$TEST_DIR/integrations-cl2/v1-integrations-and-exports.md.bak"
 assert_exit "CL-2: External integrations missing locked H3 fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-cl2"
 
+# SL-* substring-assertion convention (#174)
+#
+# Each SL-* fixture below uses assert_exit_and_match instead of bare assert_exit.
+# Rationale: exit-code-only assertions cannot distinguish "the right rule fired"
+# from "some rule fired" — a regression that swapped which rule trips first
+# would still produce exit 1 and silently pass the fixture.
+#
+# Pattern grain: rule code only ('SL-1:', 'SL-2:', 'SL-4:') for mono-emit rules;
+# rule code plus shortest-unique-substring of the sub-branch ('SL-3:.*set but…',
+# etc.) for SL-3, which has three distinct emit branches. See the architect's
+# review on issue #174 for the discipline.
+#
+# This convention applies to the SL-* cohort only. Whether to extend to JL-*,
+# CR-*, EL-*, CL-*, GL-*, RR-*, WF-* is a separate per-cohort decision.
+
 # --- SL-1: entry-table header column drift ---
 mkdir -p "$TEST_DIR/integrations-sl1"
 write_integrations_inventory "$TEST_DIR/integrations-sl1/v1-pages-inventory.md"
@@ -590,7 +605,7 @@ awk -v drift="$DRIFTED_HEADER" '
 ' "$TEST_DIR/integrations-sl1/v1-integrations-and-exports.md" > "$TEST_DIR/integrations-sl1/_tmp" && \
   mv "$TEST_DIR/integrations-sl1/_tmp" "$TEST_DIR/integrations-sl1/v1-integrations-and-exports.md"
 rm -f "$TEST_DIR/integrations-sl1/v1-integrations-and-exports.md.bak"
-assert_exit "SL-1: drifted entry-table header fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl1"
+assert_exit_and_match "SL-1: drifted entry-table header fails" 1 'SL-1:' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl1"
 
 # --- SL-2: invalid v2_status token ---
 mkdir -p "$TEST_DIR/integrations-sl2"
@@ -609,7 +624,7 @@ table.
 
 $INTEGRATIONS_HEADER
 $INTEGRATIONS_SEP
-| Bad row | Vendor | Trigger | outbound; sync | [/quickbooks/](v1-pages-inventory.md#quickbooks_integration) | Sees: thing. | partial | H |
+| Bad row | Vendor | Trigger | outbound; sync | [/quickbooks/](v1-pages-inventory.md#quickbooks_integration) | Sees: thing. | partial |  |
 
 ### Payroll
 ### Accounting
@@ -623,7 +638,7 @@ $INTEGRATIONS_SEP
 
 ## Cross-references
 EOF
-assert_exit "SL-2: invalid v2_status token fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl2"
+assert_exit_and_match "SL-2: invalid v2_status token fails" 1 'SL-2:' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl2"
 
 # --- SL-3 (set): severity set but v2_status is not "missing" ---
 mkdir -p "$TEST_DIR/integrations-sl3-set"
@@ -656,7 +671,7 @@ $INTEGRATIONS_SEP
 
 ## Cross-references
 EOF
-assert_exit "SL-3: severity set when v2_status != missing fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-set"
+assert_exit_and_match "SL-3: severity set when v2_status != missing fails" 1 'SL-3:.*set but v2_status' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-set"
 
 # --- SL-3 (empty): severity empty but v2_status is "missing" ---
 mkdir -p "$TEST_DIR/integrations-sl3-empty"
@@ -689,7 +704,7 @@ $INTEGRATIONS_SEP
 
 ## Cross-references
 EOF
-assert_exit "SL-3: severity empty when v2_status=missing fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-empty"
+assert_exit_and_match "SL-3: severity empty when v2_status=missing fails" 1 'SL-3:.*severity is empty' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-empty"
 
 # --- SL-3 (bad-token): invalid severity token in {H, M, L, D} set ---
 mkdir -p "$TEST_DIR/integrations-sl3-bad-token"
@@ -722,7 +737,7 @@ $INTEGRATIONS_SEP
 
 ## Cross-references
 EOF
-assert_exit "SL-3: invalid severity token fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-bad-token"
+assert_exit_and_match "SL-3: invalid severity token fails" 1 'SL-3:.*not in \{H, M, L, D' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-bad-token"
 
 # --- SL-4: invalid direction_and_sync token ---
 mkdir -p "$TEST_DIR/integrations-sl4"
@@ -755,7 +770,7 @@ $INTEGRATIONS_SEP
 
 ## Cross-references
 EOF
-assert_exit "SL-4: invalid direction_and_sync fails" 1 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl4"
+assert_exit_and_match "SL-4: invalid direction_and_sync fails" 1 'SL-4:' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl4"
 
 # --- EL-1: surfaces_at_routes points at a non-existent inventory anchor ---
 mkdir -p "$TEST_DIR/integrations-el1"


### PR DESCRIPTION
## Summary

- Converts the six SL-* fixtures in `scripts/tests/test_check_v1_doc_structure.sh` from `assert_exit` to `assert_exit_and_match`, anchored at the rule code (`'SL-N:'`) — with shortest-unique-substring sub-branch anchors for SL-3's three emit branches.
- Fixes the SL-2 fixture's pre-existing impurity: the bad row `severity=H, v2_status=partial` tripped **both** SL-2 and SL-3, allowing exit-code-only assertions to mask SL-2 regressions. Severity cell zeroed → fixture is single-rule.
- Adds a convention comment block above the SL-* fixtures documenting the substring-assertion discipline and the explicit scope-limit to SL-* (JL-*, CR-*, EL-*, CL-*, GL-*, RR-*, WF-* are out of scope here, per issue #174).

Closes #174.

## Why this matters

`assert_exit` checks the linter's exit code only. As QA flagged on #128, exit 1 means *some rule fired*, not *the rule we wanted*. The SL-2 fixture demonstrates the bug concretely today: its row trips both SL-2 and SL-3, so SL-2 could break and CI would still go green.

## Pre-change RED demo

Mutation: comment out the SL-2 emit at `scripts/check-v1-doc-structure.sh:363`.

```
        # SL-2: v2_status token validity.
        if (v2_status !~ /^(implemented|scaffolded|missing)$/) {
# MUT:    print FILENAME ":" FNR ": SL-2: v2_status='..."
```

Test result on the unmodified fixture suite:
```
PASS — SL-2: invalid v2_status token fails (exit 1)
```
SL-2 is broken, fixture passes via SL-3 cross-trip — silent regression.

## Post-change negative-control (6/6)

Each SL-N emit branch in the linter, when commented out, causes the matching fixture to FAIL with the expected pattern miss. Pristine linter is restored after each mutation.

```
==================================================================
Mutation: comment out linter line 327
Fixture: SL-1: drifted entry-table header fails
  FAIL — SL-1: drifted entry-table header fails (expected exit 1 matching /SL-1:/, got exit 0)

Mutation: comment out linter line 363
Fixture: SL-2: invalid v2_status token fails
  FAIL — SL-2: invalid v2_status token fails (expected exit 1 matching /SL-2:/, got exit 0)

Mutation: comment out linter line 367
Fixture: SL-3: invalid severity token fails
  FAIL — SL-3: invalid severity token fails (expected exit 1 matching /SL-3:.*not in \{H, M, L, D/, got exit 0)

Mutation: comment out linter line 370
Fixture: SL-3: severity empty when v2_status=missing fails
  FAIL — SL-3: severity empty when v2_status=missing fails (expected exit 1 matching /SL-3:.*severity is empty/, got exit 0)

Mutation: comment out linter line 373
Fixture: SL-3: severity set when v2_status != missing fails
  FAIL — SL-3: severity set when v2_status != missing fails (expected exit 1 matching /SL-3:.*set but v2_status/, got exit 0)

Mutation: comment out linter line 377
Fixture: SL-4: invalid direction_and_sync fails
  FAIL — SL-4: invalid direction_and_sync fails (expected exit 1 matching /SL-4:/, got exit 0)
==================================================================
```

## What this PR does NOT do

- Does **not** modify `scripts/check-v1-doc-structure.sh`. The linter is unchanged.
- Does **not** change MT-1 or its fixtures. The regex `assert_exit(_and_match)?` at `test_check_v1_doc_structure.sh:2641` already treats both helpers symmetrically, so coverage parity is unperturbed.
- Does **not** generalize the convention to other cohorts. Per-cohort decisions for JL-*, CR-*, EL-*, CL-*, GL-*, RR-*, WF-* are explicitly out of scope.
- Does **not** add a fixture for SL-1's cell-count branch. Per `test_check_v1_doc_structure.sh:2620`, per-emit-branch parity is a known limitation tracked separately.

## Test plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` — 98 passed / 0 failed (was 98/0 before too).
- [x] All six converted fixtures show `(exit 1, matched /SL-N…/)` in PASS output.
- [x] `make test-v1-docs` (the v1-doc-hygiene aggregate) — 7 scripts, 221 fixtures total, 0 failures.
- [x] Negative-control: 6 mutations × 6 fixtures = 6 expected FAILs, all observed.
- [x] MT-1 coverage parity (`assert_coverage_parity` at `test_check_v1_doc_structure.sh:2723`) — PASS.
- [ ] CI green via `.github/workflows/v1-doc-hygiene.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)