### PR TITLE
test(#175): SL-3a edge-case fixtures — lowercase severity + abnormal trailing whitespace

### DIFF
--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -743,6 +743,77 @@ $INTEGRATIONS_SEP
 EOF
 assert_exit_and_match "SL-3: invalid severity token fails" 1 'SL-3:.*not in \{H, M, L, D' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-bad-token"
 
+# --- SL-3a (lowercase): regex is case-sensitive — 'h' rejected ---
+mkdir -p "$TEST_DIR/integrations-sl3-lowercase"
+write_integrations_inventory "$TEST_DIR/integrations-sl3-lowercase/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/integrations-sl3-lowercase/v1-functionality-delta.md"
+cat > "$TEST_DIR/integrations-sl3-lowercase/v1-integrations-and-exports.md" <<EOF
+# V1 Integrations and Exports
+
+## Schema
+
+table.
+
+## External integrations
+
+### Billing and payments
+
+$INTEGRATIONS_HEADER
+$INTEGRATIONS_SEP
+| Bad row | Vendor | Trigger | outbound; sync | [/quickbooks/](v1-pages-inventory.md#quickbooks_integration) | Sees: thing. | missing | h |
+
+### Payroll
+### Accounting
+### Messaging and notifications (third-party)
+### Identity, auth, and SSO (third-party)
+### Other
+
+## Internal notification and email backend
+
+## Customer-facing exports
+
+## Cross-references
+EOF
+assert_exit_and_match "SL-3: lowercase severity token fails (case-sensitive regex)" 1 'SL-3:.*not in \{H, M, L, D' "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-lowercase"
+
+# --- SL-3a (padded): trim() runs before regex — abnormal trailing whitespace accepted ---
+# The data row's severity cell has TWO spaces between 'H' and the closing '|' — extra,
+# non-standard whitespace. trim() at scripts/check-v1-doc-structure.sh:320 strips it
+# before the regex check, so the row passes. Removing trim() would flip this to fail.
+# Editor whitespace-stripping should leave this alone (interior, between non-whitespace
+# tokens). If this fixture starts failing, first verify the second space survived.
+mkdir -p "$TEST_DIR/integrations-sl3-padded"
+write_integrations_inventory "$TEST_DIR/integrations-sl3-padded/v1-pages-inventory.md"
+write_good_delta "$TEST_DIR/integrations-sl3-padded/v1-functionality-delta.md"
+cat > "$TEST_DIR/integrations-sl3-padded/v1-integrations-and-exports.md" <<EOF
+# V1 Integrations and Exports
+
+## Schema
+
+table.
+
+## External integrations
+
+### Billing and payments
+
+$INTEGRATIONS_HEADER
+$INTEGRATIONS_SEP
+| Bad row | Vendor | Trigger | outbound; sync | [/quickbooks/](v1-pages-inventory.md#quickbooks_integration) | Sees: thing. | missing | H  |
+
+### Payroll
+### Accounting
+### Messaging and notifications (third-party)
+### Identity, auth, and SSO (third-party)
+### Other
+
+## Internal notification and email backend
+
+## Customer-facing exports
+
+## Cross-references
+EOF
+assert_exit "SL-3: trailing-space severity token passes (trim-then-validate)" 0 "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-padded"
+
 # --- SL-4: invalid direction_and_sync token ---
 mkdir -p "$TEST_DIR/integrations-sl4"
 write_integrations_inventory "$TEST_DIR/integrations-sl4/v1-pages-inventory.md"


### PR DESCRIPTION
## Summary

Closes #175.

Adds two fixtures to `scripts/tests/test_check_v1_doc_structure.sh`, modeled on `integrations-sl3-bad-token` (#128):

- **`integrations-sl3-lowercase`** — `severity=h`, `v2_status=missing` → asserts exit 1. Pins case-sensitivity of `/^(H|M|L|D)$/` at `scripts/check-v1-doc-structure.sh:366`.
- **`integrations-sl3-padded`** — severity cell has TWO spaces between `H` and the closing `|` (abnormal trailing whitespace), `v2_status=missing` → asserts exit 0. Pins `trim()`-before-validate ordering at `scripts/check-v1-doc-structure.sh:359`.

No production-code change. 100/100 tests pass. `make test-v1-docs` and `make scan-v1-docs` both green.

## Why two fixtures and not one

After #128, SL-3a (the regex check) was partially pinned. Two adjacent invariants were still implicit in code:

- **Case sensitivity.** A contributor adding an `i` flag (or an equivalent loosening) would not break any existing test.
- **Normalization-before-validation ordering.** A contributor removing the `trim()` wrapper from the severity cell would not break any existing test that *requires* abnormal whitespace to pass.

Each new fixture catches exactly one of those mutations. Demonstrated below via negative controls.

## Negative-control evidence

Each fixture was paired with a specific code mutation, run locally, output captured, mutation reverted before commit. These are the proof-of-binding artifacts.

### Mutation 1 — case-insensitive regex (must break `lowercase`)

**Diff applied locally then reverted:**

```
-          if (severity != "" && severity !~ /^(H|M|L|D)$/) {
+          if (severity != "" && severity !~ /^([HhMmLlDd])$/) {
```

**Test run output (filtered to SL-3 group):**

```
PASS — SL-3: severity set when v2_status != missing fails (exit 1, matched /SL-3:.*set but v2_status/)
PASS — SL-3: severity empty when v2_status=missing fails (exit 1, matched /SL-3:.*severity is empty/)
PASS — SL-3: invalid severity token fails (exit 1, matched /SL-3:.*not in \{H, M, L, D/)
FAIL — SL-3: lowercase severity token fails (case-sensitive regex) (expected exit 1 matching /SL-3:.*not in \{H, M, L, D/, got exit 0)
PASS — SL-3: trailing-space severity token passes (trim-then-validate) (exit 0)
Results: 99 passed, 1 failed
```

Only the `lowercase` fixture flipped — proves it specifically binds case sensitivity, independent of `bad-token`'s broader class assertion. The other three SL-3 fixtures are insensitive to this mutation (which is why we needed the `lowercase` fixture in the first place).

### Mutation 2 — drop `trim()` from severity assignment (must break `padded`)

**Diff applied locally then reverted:**

```
-          severity  = trim(cells[9])
+          severity  = cells[9]
```

**Test run output (key lines):**

```
FAIL — SL-3: trailing-space severity token passes (trim-then-validate) (expected exit 0, got 1)
  output: FAIL: …/integrations-sl3-padded/v1-integrations-and-exports.md:13:
          SL-3: severity=' H  ' not in {H, M, L, D, empty}
Results: 93 passed, 7 failed
```

The error message literally shows `severity=' H  '` (leading space, H, two trailing spaces) — confirming the cell contains the abnormal whitespace and only `trim()` was making it pass. Six other fixtures collapsed too (any fixture that relied on standard `| H |` padding), but the `padded` row's failure mode is the diagnostic one. Reverted.

## Notes on convention

- Both new `assert_exit*` descriptions use the `SL-3:` prefix to match the awk's emit code (per the `MT-1` coverage-parity meta-test from #173). The "SL-3a" architectural sub-rule label appears in the comment headers, where MT-1 doesn't extract from on the test side.
- The padded fixture's data row uses **two** spaces between `H` and the closing `|`, not one, so it's visibly distinct from any normally-padded row (e.g., line 475 in the same file). One-space padding would not have differentiated it from the existing `good` fixture.

## Out of scope (per QA, in issue #175)

- Multi-char invalid tokens (`HH`, `H1`, `1H`) — covered by `bad-token`'s class assertion.
- Unicode lookalikes — file follow-up only on real bug.
- Tab-padded variant — same `trim()` path.
- Leading-whitespace variant — same `trim()` invariant.
- Refactor of `trim()` itself.

## Test plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` → 100/100 pass
- [x] `make test-v1-docs` → all runners green
- [x] `make scan-v1-docs` → real docs validate cleanly
- [x] Negative control 1 (case-insensitive regex) flips `lowercase` fixture to FAIL — verified, reverted
- [x] Negative control 2 (drop `trim()`) flips `padded` fixture to FAIL — verified, reverted
- [x] Final diff: only `scripts/tests/test_check_v1_doc_structure.sh` changed (+71 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)