### PR TITLE
feat(#212): CR-5 tripwire — fail precheck on second canonical column in xref index

### DIFF
--- a/scripts/check-v1-doc-structure.sh
+++ b/scripts/check-v1-doc-structure.sh
@@ -43,6 +43,12 @@
 #        CR-3  `phi_displayed` value disagreement between index row and
 #              canonical row.
 #        CR-4  `phi_displayed` value outside `{true, false}` on either side.
+#        CR-5  Cross-reference index header contains a canonical-row column
+#              other than `route` (the join key) or `phi_displayed` (the only
+#              currently-handled mirrored column). Tripwire — fires before
+#              CR-1..CR-4 evaluation and points the developer at #145's design.
+#              Issue #212 — guarantees the deferred N-column generalization
+#              (#145) gets executed when its trigger condition is met.
 #      Issue #124 — drift in this column would silently mis-scope v2's
 #      operator-portal HIPAA-minimum-necessary controls.
 #   9. docs/migration/README.md `## Refresh runbook` section invariants.
@@ -812,6 +818,9 @@ if [[ -f "$INVENTORY" ]]; then
           for (i = 2; i < n_cells; i++) {
             col = trim(cells[i])
             header_cols[col] = i
+            # Global accumulator across all canonical-table headers — feeds
+            # the CR-5 tripwire in pass 2 (issue #212).
+            CANONICAL_COL_NAMES[col] = 1
           }
           in_canon_table = 1
           next
@@ -862,13 +871,29 @@ if [[ -f "$INVENTORY" ]]; then
 
       n_cells = split($0, cells, /\|/)
       if (!xref_header_seen) {
+        # CR-5 tripwire (#212): collect any canonical-row column other than
+        # the join key (route) or the only currently-handled mirrored column
+        # (phi_displayed). The comparator below only handles phi_displayed;
+        # any other mirrored column would silently truncate on '\''|'\'' in its
+        # value. Fail loud and point the developer at #145.
+        extras = ""
         for (i = 2; i < n_cells; i++) {
           col = trim(cells[i])
           if (col == "phi_displayed") xref_phi_col = i
           if (col == "row location") xref_loc_col = i
+          if ((col in CANONICAL_COL_NAMES) && col != "route" && col != "phi_displayed") {
+            if (extras == "") {
+              extras = "'\''" col "'\''"
+            } else {
+              extras = extras ", '\''" col "'\''"
+            }
+          }
         }
         xref_header_seen = 1
-        # Header-intersection rule: only fire when both columns are present.
+        if (extras != "") {
+          print FILENAME ":" FNR ": CR-5: cross-reference index now mirrors column(s) " extras " beyond phi_displayed. The comparator currently only handles phi_displayed correctly; values containing '\''|'\'' in any other mirrored column would be silently truncated. Generalize the comparator per the design in #145 (https://github.com/suniljames/COREcare-v2/issues/145) before adding this column to the index."
+        }
+        # Header-intersection rule: only fire CR-1..CR-4 when both columns are present.
         if (xref_phi_col == 0 || xref_loc_col == 0) {
           in_xref = 0
         }

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -2289,6 +2289,52 @@ assert_exit_and_match \
   1 'CR-3:' \
   "$STRUCTURE" --dir "$TEST_DIR/xref-anchor-alias-skip"
 
+# --- CR-5 tripwire — Issue #212 -------------------------------------------------
+# What this fixture proves: when a cross-reference index header includes any
+# canonical-row column other than `route` (the join key) or `phi_displayed`
+# (the only currently-handled mirrored column), the precheck fails with the
+# CR-5 tripwire pointing at issue #145's design. Both `CR-5:` and `#145` must
+# appear in the diagnostic so a future contributor adding a second mirrored
+# column lands directly on the design doc.
+#
+# Header here adds `multi_tenant_refactor` (a real canonical column from the
+# inventory schema) to the index. The phi_displayed values agree, so CR-3 and
+# CR-4 are silent and the CR-5 emit is the only failure surface under test.
+mkdir -p "$TEST_DIR/xref-second-column-tripwire"
+cat > "$TEST_DIR/xref-second-column-tripwire/v1-pages-inventory.md" <<'EOF'
+# v1 Pages Inventory
+
+## Super-Admin
+
+### Cross-reference index
+
+| route | also reachable by | content branches by role | phi_displayed | multi_tenant_refactor | row location |
+|-------|-------------------|--------------------------|---------------|-----------------------|--------------|
+| `/admin/expenses/review/` | Agency Admin | no | true | yes | [Agency Admin → top-level](#agency-admin-top-level) |
+
+## Agency Admin
+
+<a id="agency-admin-top-level"></a>
+### top-level
+
+| route | phi_displayed | multi_tenant_refactor |
+|-------|---------------|-----------------------|
+| `/admin/expenses/review/` | true | yes |
+
+## Care Manager
+
+## Caregiver
+
+## Client
+
+## Family Member
+EOF
+write_good_delta "$TEST_DIR/xref-second-column-tripwire/v1-functionality-delta.md"
+assert_exit_and_match \
+  "CR-5: second canonical column in xref index header → fail with #145 link" \
+  1 'CR-5:.*#145' \
+  "$STRUCTURE" --dir "$TEST_DIR/xref-second-column-tripwire"
+
 # === Refresh-runbook rule group (RR-N) — Issue #132 =========================
 #
 # RR-1 — `## Refresh runbook` H2 exists in README.md.

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -1917,14 +1917,17 @@ write_authored_glossary "$TEST_DIR/gl3-all-good/v1-glossary.md"
 assert_exit "GL-3: valid anchors across inventory + journeys + integrations passes" 0 "$STRUCTURE" --dir "$TEST_DIR/gl3-all-good"
 
 # =============================================================================
-# Cross-reference index phi_displayed consistency tests (#124)
+# Cross-reference index phi_displayed consistency tests (#124, #212)
 # CR-1: route at index not found at linked anchor (or no anchor link in row location)
 # CR-2: route slug duplicated under linked anchor (canonical lookup ambiguous)
 # CR-3: phi_displayed value disagreement between index row and canonical row
 # CR-4: phi_displayed value outside {true, false} on either side
+# CR-5: xref index header contains a canonical-row column other than route or
+#       phi_displayed — tripwire pointing at #145's deferred generalization.
 #
-# Trigger: only when the cross-reference-index table header contains BOTH
-# `phi_displayed` and `row location` columns (header-intersection rule).
+# Trigger: CR-1..CR-4 fire only when the cross-reference-index table header
+# contains BOTH `phi_displayed` and `row location` columns (header-intersection
+# rule). CR-5 fires independently on header detection alone (#212).
 # =============================================================================
 
 # Helper: write a six-persona inventory with a Super-Admin cross-reference index
@@ -2330,8 +2333,10 @@ cat > "$TEST_DIR/xref-second-column-tripwire/v1-pages-inventory.md" <<'EOF'
 ## Family Member
 EOF
 write_good_delta "$TEST_DIR/xref-second-column-tripwire/v1-functionality-delta.md"
-assert_exit_and_match \
-  "CR-5: second canonical column in xref index header → fail with #145 link" \
+# Description on same line as assert_exit_and_match so MT-1's regex picks up
+# the CR-5 code (the regex matches description-after-helper, not across line
+# continuations).
+assert_exit_and_match "CR-5: second canonical column in xref index header → fail with #145 link" \
   1 'CR-5:.*#145' \
   "$STRUCTURE" --dir "$TEST_DIR/xref-second-column-tripwire"
 


### PR DESCRIPTION
## Summary
- Adds invariant **CR-5** to `scripts/check-v1-doc-structure.sh`: fails the precheck the moment a `### Cross-reference index` table header contains any canonical-row column other than `route` or `phi_displayed`, with a diagnostic that contains both the `#145` shorthand and the verbatim URL to the deferred-generalization design.
- Pass 1 accumulates a global `CANONICAL_COL_NAMES` set across every canonical-table header. Pass 2 intersects each xref-index header against that set and emits CR-5 before CR-1..CR-4 evaluation.
- Closes #212. Guards #145's deferred design from quietly going stale: the next column-addition PR will fail loud with a clickable link to the design.

## Why this PR
Issue #145 captured a design for generalizing the cross-reference comparator to N mirrored columns, but committee consensus was YAGNI — ship the generalization in the same PR that introduces the second mirrored column, not before. That left a load-bearing-on-memory gap: a future contributor adding a column to a cross-reference index might land their PR on top of a comparator that silently truncates `|`-containing values.

CR-5 turns that memory gap into a CI-level safety net. The next column-addition PR cannot land without seeing the failure message and following the `#145` link to the design.

## Verification
- `bash scripts/tests/test_check_v1_doc_structure.sh` → **101 passed, 0 failed**
- New fixture `xref-second-column-tripwire/` asserts both `CR-5:` and `#145` in the diagnostic via `assert_exit_and_match` with pattern `'CR-5:.*#145'`.
- MT-1 coverage parity holds (CR-5 has matching awk emit + test).
- Smoke test against the real `docs/migration/v1-pages-inventory.md` passes — no false positive on current state.

## Sample diagnostic
```
FAIL: …/v1-pages-inventory.md:7: CR-5: cross-reference index now mirrors column(s) 'multi_tenant_refactor' beyond phi_displayed. The comparator currently only handles phi_displayed correctly; values containing '|' in any other mirrored column would be silently truncated. Generalize the comparator per the design in #145 (https://github.com/suniljames/COREcare-v2/issues/145) before adding this column to the index.
```

## Test plan
- [x] All existing self-tests pass
- [x] New fixture exercises the trigger condition end-to-end
- [x] Diagnostic contains the verbatim URL `https://github.com/suniljames/COREcare-v2/issues/145`
- [x] Smoke test against the real inventory does not produce false positives
- [x] MT-1 real-state coverage parity still holds (CR-5 paired)
- [x] CR rule list comment block updated in both the script and the test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)