### PR TITLE
docs(#217): doc-structure validation conventions + awk-quote gotcha

### DIFF
--- a/docs/developer/TESTING.md
+++ b/docs/developer/TESTING.md
@@ -118,3 +118,71 @@ Pull Requests:
 Push to main (additionally):
   E2E Tests     — Playwright against full Docker stack
 ```
+
+## Doc-structure validation conventions
+
+The bash + awk validators in `scripts/check-v1-doc-structure.sh` (and its sibling
+`scripts/check-v1-doc-hygiene.sh`) emit violation codes — short two-letter-prefix
+identifiers like `SL-1a`, `EL-2b`, `RR-4c` — that the test suite at
+`scripts/tests/test_check_v1_doc_structure.sh` exercises one at a time via fixture
+directories. The convention has been hardened over several issues; the rules below
+are the post-#196 final form.
+
+### 1. Sub-letter when ≥2 emit branches share a code
+
+Any code with two or more `print FILENAME ":" FNR ": <CODE>: ..."` emit branches
+is **sub-lettered** at the awk emit site (`SL-1a`, `SL-1b`, `SL-3a / SL-3b / SL-3c`,
+`EL-2a / EL-2b`, `CR-1a / CR-1b`, `GL-3a / GL-3b / GL-3c`, `RR-4a..d`). Single-emit
+codes (`SL-2`, `SL-4`, `EL-1`, `WF-1`, etc.) stay bare.
+
+Canonical reference shape: `^[A-Z]{2}-[0-9]+[a-z]?$`. At most one trailing
+sub-letter. No dots, no underscores, no multi-letter suffixes.
+
+### 2. Fixtures use `assert_exit_and_match` with shortest-unique substrings
+
+Every sub-lettered code's negative fixture asserts both the exit code AND a
+substring of the emit message that distinguishes its branch from siblings:
+
+```bash
+assert_exit_and_match "SL-3b: severity empty when v2_status=missing fails" 1 \
+  'SL-3b:.*severity is empty' \
+  "$STRUCTURE" --dir "$TEST_DIR/integrations-sl3-empty"
+```
+
+Bare `assert_exit` is forbidden for any sub-lettered code. Rationale: an exit-1
+from any other branch would silently pass an exit-only fixture. Positive
+fixtures (expecting exit 0) need no substring; their description token still
+uses the sub-letter so MT-1 sees the branch as covered.
+
+### 3. MT-1 enforces per-branch parity
+
+The meta-test at `scripts/tests/test_check_v1_doc_structure.sh:2685+` asserts
+that the set of distinct code references in the awk equals the set of fixture
+description tokens. The umbrella filter `_filter_umbrellas` drops bare `X-N`
+when `X-N<letter>` is also present, so umbrella mentions in headers and prose
+comments don't pollute parity.
+
+A fixture for every emit branch — not just every code — is required.
+
+### 4. MT-2 enforces canonical code shape
+
+A second meta-test at `scripts/tests/test_check_v1_doc_structure.sh:3055+`
+greps the structure script for any code-shaped reference and fails if any
+match doesn't conform to `^[A-Z]{2}-[0-9]+[a-z]?$`. Hard trip-wire on drift
+forms `SL-1.1`, `SL_1a`, `SL-1ab` — they would otherwise silently disappear
+from MT-1's set.
+
+### 5. Authoring inside the integrations awk block
+
+The awk script in `scripts/check-v1-doc-structure.sh` is enclosed in BASH
+single quotes. Inside the awk block, **literal `'` characters in comments or
+strings break the bash quoting** and surface as `awk: syntax error` at
+runtime. To include an apostrophe in an awk string, use the escape `'\''`
+(see existing emit lines for the pattern). For comments, rephrase without
+apostrophes.
+
+### Where the rule lives
+
+The authoritative convention comment is at `scripts/tests/test_check_v1_doc_structure.sh:577`.
+This section is a navigational pointer for new contributors; the comment in
+the test file is the source of truth.

--- a/scripts/check-v1-doc-structure.sh
+++ b/scripts/check-v1-doc-structure.sh
@@ -305,6 +305,15 @@ if [[ -f "$INTEGRATIONS" ]]; then
   # (1) builds an anchor-set from the inventory file, then
   # (2) walks entry tables in the integrations doc and emits a violation per
   #     bad cell, prefixed with file:line.
+  #
+  # AWK-AUTHORING GOTCHA: the awk script below is enclosed in BASH single
+  # quotes. Comments and strings INSIDE the awk block must NOT contain a
+  # literal `'` character — it would terminate the bash single-quote scope
+  # and surface as `awk: syntax error` at runtime (caught the hard way during
+  # PR #215). To include a literal apostrophe inside a string, use the
+  # bash-escaped form `'\''` (closing single-quote, escaped single-quote,
+  # reopening single-quote — see existing emit lines for the pattern).
+  # For COMMENTS, the cleanest fix is to rephrase without apostrophes.
   if [[ -f "$INVENTORY" ]]; then
     awk_violations=$(awk -v EXPECTED_HEADER="$INTEGRATIONS_SCHEMA_HEADER" '
       function trim(s) { sub(/^[ \t]+/, "", s); sub(/[ \t]+$/, "", s); return s }

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -3059,8 +3059,12 @@ assert_coverage_parity \
 # labeling drift: SL-1.1, SL_1a, SL-1ab all fail.
 #
 # Detection regex `[A-Z]{2}[-_][0-9]+[A-Za-z0-9_]*` is broader than canonical
-# so it captures plausible drift forms. Period is excluded from the trailing
-# class so prose punctuation ("CR-3.") doesn't false-positive.
+# so it captures plausible drift forms. Two non-obvious choices:
+#   - `[-_]` (not just `-`) catches underscored drift forms like `SL_1a` so
+#     they fail MT-2 instead of silently disappearing from MT-1's set (whose
+#     extractor only matches `[A-Z]{2}-[0-9]+...`).
+#   - Period is EXCLUDED from the trailing `[A-Za-z0-9_]*` class so prose
+#     punctuation ("CR-3.", "JL-7.") doesn't false-positive.
 
 _assert_canonical_code_shape() {
   local file="$1"


### PR DESCRIPTION
Closes #217.

## Summary

Three doc/comment-only follow-ups from PR #215 NITs. No behavioral change.

- **MT-2 detection-regex rationale** — comment explaining why `[-_]` (not just `-`) and why period is excluded from the trailing class. Both choices prevent silent gaps in MT-1's set.
- **AWK-authoring gotcha** — comment at the integrations awk block warning about literal `'` chars inside awk single-quoted comments/strings (the regression caught during PR #215).
- **TESTING.md "Doc-structure validation conventions" section** — pointer for new contributors at the cohort-wide sub-letter rule, substring discipline, MT-1/MT-2 enforcement, and the awk-quote gotcha. Source of truth remains the convention comment at `scripts/tests/test_check_v1_doc_structure.sh:577`; TESTING.md is navigational.

## Test plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` → **107 passed, 0 failed**
- [x] `bash scripts/check-v1-doc-structure.sh` → exit 0
- [x] `make -C api lint` → All checks passed
- [ ] CI green on this PR

## Skip rationale for committee review

Doc/comment-only — no logic change, no new fixtures, no shape-lint impact. Self-merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)