### PR TITLE
test(#221): harden constant-vs-doc drift guard — encoding + uniqueness

### DIFF
--- a/scripts/coldreader/tests/test_client.py
+++ b/scripts/coldreader/tests/test_client.py
@@ -194,18 +194,19 @@ def test_log_max_constant_matches_readme_documented_value() -> None:
     chars to bound log-line length"; the runtime enforces this via
     `_MALFORMED_CONFIDENCE_LOG_MAX = 64`. This test fails loudly if either
     side is updated without the other (issue #203 security mitigation;
-    issue #209 NIT 4).
+    issue #209 NIT 4; issue #221 hardened encoding + uniqueness check).
     """
     from client import _MALFORMED_CONFIDENCE_LOG_MAX
 
     readme_path = Path(__file__).resolve().parents[1] / "README.md"
-    readme_text = readme_path.read_text()
-    match = re.search(r"capped at (\d+) chars", readme_text)
-    assert match is not None, (
-        "README must document the log-line cap as 'capped at N chars' "
-        "for the constant-vs-doc drift guard to anchor."
+    readme_text = readme_path.read_text(encoding="utf-8")
+    matches = re.findall(r"capped at (\d+) chars", readme_text)
+    assert len(matches) == 1, (
+        f"README must document the log-line cap as 'capped at N chars' "
+        f"exactly once for this drift guard to anchor unambiguously; "
+        f"found {len(matches)} occurrences."
     )
-    assert int(match.group(1)) == _MALFORMED_CONFIDENCE_LOG_MAX, (
-        f"README documents 'capped at {match.group(1)} chars' but "
+    assert int(matches[0]) == _MALFORMED_CONFIDENCE_LOG_MAX, (
+        f"README documents 'capped at {matches[0]} chars' but "
         f"_MALFORMED_CONFIDENCE_LOG_MAX = {_MALFORMED_CONFIDENCE_LOG_MAX}."
     )


### PR DESCRIPTION
Closes #221.

Two NITs deferred from the [PR #218 SE code-review](https://github.com/suniljames/COREcare-v2/pull/218#issuecomment-4408756232) — both in the same function (`test_log_max_constant_matches_readme_documented_value` at `scripts/coldreader/tests/test_client.py`).

## Summary

- **Encoding:** added explicit `encoding="utf-8"` to `Path.read_text()`. The README contains UTF-8 multibyte characters (em-dashes, ellipses, `≥` glyphs); today this worked via `locale.getpreferredencoding()` on macOS/Linux CI, but the explicit form is deterministic.
- **Uniqueness:** replaced `re.search` with `re.findall` and assert exactly one match. Makes the test self-documenting about the README's single-occurrence invariant — if a future PR mentions "capped at N chars" anywhere else (a runbook example, a back-reference), the test fails loudly with `found 2 occurrences` rather than silently picking the first match.

No semantic change to what the test pins. Suite stays at 130 tests; the guarded surface is unchanged.

## Test plan

- [x] `make coldreader-test` — 130 passed
- [x] `uv run --frozen mypy --strict` — clean (14 source files)
- [x] `uv run --frozen ruff check` — clean
- [x] `uv run --frozen ruff format --check` — clean (15 files)
- [x] `uv run --frozen pytest tests/test_client.py::test_log_max_constant_matches_readme_documented_value -v` — passes against `_MALFORMED_CONFIDENCE_LOG_MAX = 64` and the README's single occurrence of `capped at 64 chars`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
