### PR TITLE
feat(#213): add Gate: issue state to /define, /design, /implement, /review

### DIFF
--- a/.claude/commands/define.md
+++ b/.claude/commands/define.md
@@ -24,6 +24,78 @@ If `$ARGUMENTS` contains an issue number, use it. Otherwise, infer the issue
 from the current conversation context. If you cannot confidently identify the
 issue, resolve the ambiguity yourself using product judgment.
 
+## Gate: issue state
+
+> Mirrors the gate in `define.md` / `design.md` / `implement.md` / `review.md`.
+> When editing this gate, update all four files in lockstep.
+
+This gate **aborts** the skill if the GitHub issue is CLOSED, unless the
+operator passes `--force-on-closed`. It runs **after** issue determination
+and **before** any side-effecting step (label adds, comment posts, worktree
+creation, branch cuts).
+
+### Parse `$ARGUMENTS`
+
+```bash
+ARGS=( $ARGUMENTS )
+FORCE_ON_CLOSED=false
+ISSUE_NUMBER=""
+for arg in "${ARGS[@]}"; do
+  case "$arg" in
+    --force-on-closed) FORCE_ON_CLOSED=true ;;
+    *)
+      stripped="${arg##\#}"
+      if [[ "$stripped" =~ ^[0-9]+$ ]]; then
+        ISSUE_NUMBER="$stripped"
+      fi
+      ;;
+  esac
+done
+```
+
+If `ISSUE_NUMBER` is empty after parsing, fall back to the context-inferred
+issue from "Determine the issue" above.
+
+### State + closed-by lookup (single call)
+
+```bash
+ISSUE_META=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+  --json state,title,closedByPullRequestsReferences)
+ISSUE_STATE=$(echo "$ISSUE_META" | jq -r '.state')
+ISSUE_TITLE=$(echo "$ISSUE_META" | jq -r '.title')
+CLOSED_BY_PR=$(echo "$ISSUE_META" | jq -r '.closedByPullRequestsReferences[0].number // empty')
+CLOSED_BY_TITLE=$(echo "$ISSUE_META" | jq -r '.closedByPullRequestsReferences[0].title // empty')
+```
+
+### Gate behavior
+
+- If `ISSUE_STATE == "CLOSED"` and `FORCE_ON_CLOSED == false`:
+  - Print the canonical abort message (below).
+  - Perform **no further actions** — do not add labels, post comments, create
+    worktrees, or cut branches.
+  - Stop the skill (return non-zero).
+- Else: proceed to the next section.
+
+### Canonical abort message
+
+```
+Issue #<n> "<title>" is CLOSED.
+
+Pipeline commands abort on closed issues by default — this prevents
+post-hoc design or implementation runs (the failure mode that
+surfaced this gate; see issue #213).
+
+  Closed by: PR #<pr> "<pr-title>"        ← shown when discoverable
+
+To proceed:
+  • Reopen the issue:
+        gh issue reopen <n> --repo <repo>
+  • Or override on this run:
+        /<command> <n> --force-on-closed
+```
+
+The `Closed by:` line is shown only when `CLOSED_BY_PR` is non-empty.
+
 ## Step 1: Check idempotency
 
 Check if the `pm-reviewed` label already exists on the issue:

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -16,6 +16,78 @@ Use `--repo "$REPO"` on every `gh` command.
 If `$ARGUMENTS` contains an issue number, use it. Otherwise, infer the issue
 from the current conversation context.
 
+## Gate: issue state
+
+> Mirrors the gate in `define.md` / `design.md` / `implement.md` / `review.md`.
+> When editing this gate, update all four files in lockstep.
+
+This gate **aborts** the skill if the GitHub issue is CLOSED, unless the
+operator passes `--force-on-closed`. It runs **after** issue determination
+and **before** any side-effecting step (label adds, comment posts, worktree
+creation, branch cuts).
+
+### Parse `$ARGUMENTS`
+
+```bash
+ARGS=( $ARGUMENTS )
+FORCE_ON_CLOSED=false
+ISSUE_NUMBER=""
+for arg in "${ARGS[@]}"; do
+  case "$arg" in
+    --force-on-closed) FORCE_ON_CLOSED=true ;;
+    *)
+      stripped="${arg##\#}"
+      if [[ "$stripped" =~ ^[0-9]+$ ]]; then
+        ISSUE_NUMBER="$stripped"
+      fi
+      ;;
+  esac
+done
+```
+
+If `ISSUE_NUMBER` is empty after parsing, fall back to the context-inferred
+issue from "Determine the issue" above.
+
+### State + closed-by lookup (single call)
+
+```bash
+ISSUE_META=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+  --json state,title,closedByPullRequestsReferences)
+ISSUE_STATE=$(echo "$ISSUE_META" | jq -r '.state')
+ISSUE_TITLE=$(echo "$ISSUE_META" | jq -r '.title')
+CLOSED_BY_PR=$(echo "$ISSUE_META" | jq -r '.closedByPullRequestsReferences[0].number // empty')
+CLOSED_BY_TITLE=$(echo "$ISSUE_META" | jq -r '.closedByPullRequestsReferences[0].title // empty')
+```
+
+### Gate behavior
+
+- If `ISSUE_STATE == "CLOSED"` and `FORCE_ON_CLOSED == false`:
+  - Print the canonical abort message (below).
+  - Perform **no further actions** — do not add labels, post comments, create
+    worktrees, or cut branches.
+  - Stop the skill (return non-zero).
+- Else: proceed to the next section.
+
+### Canonical abort message
+
+```
+Issue #<n> "<title>" is CLOSED.
+
+Pipeline commands abort on closed issues by default — this prevents
+post-hoc design or implementation runs (the failure mode that
+surfaced this gate; see issue #213).
+
+  Closed by: PR #<pr> "<pr-title>"        ← shown when discoverable
+
+To proceed:
+  • Reopen the issue:
+        gh issue reopen <n> --repo <repo>
+  • Or override on this run:
+        /<command> <n> --force-on-closed
+```
+
+The `Closed by:` line is shown only when `CLOSED_BY_PR` is non-empty.
+
 ## Lifecycle check: pm-reviewed
 
 Check if the `pm-reviewed` label exists on the issue:

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -15,6 +15,79 @@ Use `--repo "$REPO"` on every `gh` command.
 
 Parse `$ARGUMENTS` for:
 - **Issue number** — a `#`-prefixed or bare number
+- **`--force-on-closed`** — see "Gate: issue state" below
+
+## Gate: issue state
+
+> Mirrors the gate in `define.md` / `design.md` / `implement.md` / `review.md`.
+> When editing this gate, update all four files in lockstep.
+
+This gate **aborts** the skill if the GitHub issue is CLOSED, unless the
+operator passes `--force-on-closed`. It runs **after** argument parsing and
+**before** any side-effecting step — specifically before adding the
+`implementing` label, before `EnterWorktree`, and before the branch base cut.
+
+### Parse `$ARGUMENTS`
+
+```bash
+ARGS=( $ARGUMENTS )
+FORCE_ON_CLOSED=false
+ISSUE_NUMBER=""
+for arg in "${ARGS[@]}"; do
+  case "$arg" in
+    --force-on-closed) FORCE_ON_CLOSED=true ;;
+    *)
+      stripped="${arg##\#}"
+      if [[ "$stripped" =~ ^[0-9]+$ ]]; then
+        ISSUE_NUMBER="$stripped"
+      fi
+      ;;
+  esac
+done
+```
+
+If `ISSUE_NUMBER` is empty after parsing, fall back to the context-inferred
+issue (per "Parse arguments" above).
+
+### State + closed-by lookup (single call)
+
+```bash
+ISSUE_META=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+  --json state,title,closedByPullRequestsReferences)
+ISSUE_STATE=$(echo "$ISSUE_META" | jq -r '.state')
+ISSUE_TITLE=$(echo "$ISSUE_META" | jq -r '.title')
+CLOSED_BY_PR=$(echo "$ISSUE_META" | jq -r '.closedByPullRequestsReferences[0].number // empty')
+CLOSED_BY_TITLE=$(echo "$ISSUE_META" | jq -r '.closedByPullRequestsReferences[0].title // empty')
+```
+
+### Gate behavior
+
+- If `ISSUE_STATE == "CLOSED"` and `FORCE_ON_CLOSED == false`:
+  - Print the canonical abort message (below).
+  - Perform **no further actions** — do not add the `implementing` label, do
+    not create a worktree, do not cut a branch.
+  - Stop the skill (return non-zero).
+- Else: proceed to the next section.
+
+### Canonical abort message
+
+```
+Issue #<n> "<title>" is CLOSED.
+
+Pipeline commands abort on closed issues by default — this prevents
+post-hoc design or implementation runs (the failure mode that
+surfaced this gate; see issue #213).
+
+  Closed by: PR #<pr> "<pr-title>"        ← shown when discoverable
+
+To proceed:
+  • Reopen the issue:
+        gh issue reopen <n> --repo <repo>
+  • Or override on this run:
+        /<command> <n> --force-on-closed
+```
+
+The `Closed by:` line is shown only when `CLOSED_BY_PR` is non-empty.
 
 ## Lifecycle check: design-complete
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -19,6 +19,85 @@ Use `--repo "$REPO"` on every `gh` command.
 
 Find the linked issue from progress file, branch name, or commit messages.
 
+Also parse `$ARGUMENTS` for the `--force-on-closed` flag:
+
+```bash
+ARGS=( $ARGUMENTS )
+FORCE_ON_CLOSED=false
+PARSED_ISSUE=""
+for arg in "${ARGS[@]}"; do
+  case "$arg" in
+    --force-on-closed) FORCE_ON_CLOSED=true ;;
+    *)
+      stripped="${arg##\#}"
+      if [[ "$stripped" =~ ^[0-9]+$ ]]; then
+        PARSED_ISSUE="$stripped"
+      fi
+      ;;
+  esac
+done
+ISSUE_NUMBER="${PARSED_ISSUE:-$DERIVED_ISSUE_NUMBER}"  # context-derived takes second place
+```
+
+## 0.1a: Gate: issue state
+
+> Mirrors the gate in `define.md` / `design.md` / `implement.md` / `review.md`.
+> When editing this gate, update all four files in lockstep.
+
+This gate **aborts** the skill if the linked GitHub issue is CLOSED, unless
+the operator passes `--force-on-closed`. It runs **after** issue-context
+detection (0.1) and **before** any side-effecting step (0.2 onward — make
+check, branch cuts, push, PR creation, label changes, merge).
+
+### `/review`-specific clause: skip silently when no issue is derivable
+
+If 0.1 produced no `ISSUE_NUMBER` (no progress file, no `Closes #N` in PR
+body, no inferable issue from branch/commits), **skip this gate silently** —
+no abort, no warning. This preserves today's behavior for issue-less
+reviews. Proceed directly to 0.2.
+
+### State + closed-by lookup (single call)
+
+When `ISSUE_NUMBER` is non-empty:
+
+```bash
+ISSUE_META=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" \
+  --json state,title,closedByPullRequestsReferences)
+ISSUE_STATE=$(echo "$ISSUE_META" | jq -r '.state')
+ISSUE_TITLE=$(echo "$ISSUE_META" | jq -r '.title')
+CLOSED_BY_PR=$(echo "$ISSUE_META" | jq -r '.closedByPullRequestsReferences[0].number // empty')
+CLOSED_BY_TITLE=$(echo "$ISSUE_META" | jq -r '.closedByPullRequestsReferences[0].title // empty')
+```
+
+### Gate behavior
+
+- If `ISSUE_STATE == "CLOSED"` and `FORCE_ON_CLOSED == false`:
+  - Print the canonical abort message (below).
+  - Perform **no further actions** — do not run `make check`, do not push,
+    do not create a PR, do not change labels, do not merge.
+  - Stop the skill (return non-zero).
+- Else: proceed to 0.2.
+
+### Canonical abort message
+
+```
+Issue #<n> "<title>" is CLOSED.
+
+Pipeline commands abort on closed issues by default — this prevents
+post-hoc design or implementation runs (the failure mode that
+surfaced this gate; see issue #213).
+
+  Closed by: PR #<pr> "<pr-title>"        ← shown when discoverable
+
+To proceed:
+  • Reopen the issue:
+        gh issue reopen <n> --repo <repo>
+  • Or override on this run:
+        /<command> <n> --force-on-closed
+```
+
+The `Closed by:` line is shown only when `CLOSED_BY_PR` is non-empty.
+
 ## 0.2: Verify pre-PR gate
 
 ```bash

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -18,6 +18,14 @@ Use `--repo "$REPO"` on every `gh` command.
 ## 0.1: Detect issue context
 
 Find the linked issue from progress file, branch name, or commit messages.
+Store the result in `DERIVED_ISSUE_NUMBER` (empty string if none found):
+
+```bash
+DERIVED_ISSUE_NUMBER=""  # set this to the issue number you derived above, or leave empty
+```
+
+This variable is consumed by the parser block below to resolve the final
+`ISSUE_NUMBER` when the user invokes `/review` without arguments.
 
 Also parse `$ARGUMENTS` for the `--force-on-closed` flag:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,10 @@ named remote ref (e.g., `origin/main`) — never from an implicit local branch.
 See [`#176`](https://github.com/suniljames/COREcare-v2/issues/176) and the
 regression test at `scripts/tests/test_implement_branch_cut.sh`.
 
+Pipeline commands (`/define`, `/design`, `/implement`, `/review`) abort on
+closed issues by default. Pass `--force-on-closed` to override on a single
+run. See [`#213`](https://github.com/suniljames/COREcare-v2/issues/213).
+
 ## Project Docs
 
 | Topic | File |

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ check: ## Run all quality gates (pre-PR)
 	$(MAKE) -C web test
 	$(MAKE) -C web build
 	bash scripts/tests/test_implement_branch_cut.sh
+	bash scripts/tests/test_pipeline_state_gate.sh
 
 # --- Individual targets ---
 

--- a/scripts/tests/test_pipeline_state_gate.sh
+++ b/scripts/tests/test_pipeline_state_gate.sh
@@ -159,6 +159,50 @@ test_parser_negative_token_rejected() {
 }
 
 # ---------------------------------------------------------------------------
+# Layer 1b: review.md two-stage resolution — covers QA test cases R1/R3
+# where /review must merge ARGUMENTS-parsed issue with context-derived issue.
+# ---------------------------------------------------------------------------
+
+# Mirrors the resolution shape from review.md 0.1:
+#   ISSUE_NUMBER="${PARSED_ISSUE:-$DERIVED_ISSUE_NUMBER}"
+# PARSED_ISSUE wins; falls back to DERIVED_ISSUE_NUMBER when empty.
+resolve_review_issue() {
+  local parsed="$1"
+  local derived="$2"
+  echo "${parsed:-$derived}"
+}
+
+test_review_resolves_derived_when_no_args() {
+  local got
+  got=$(resolve_review_issue "" "213")
+  if [[ "$got" == "213" ]]; then
+    pass "review-resolution: PARSED='', DERIVED='213' → ISSUE='213'"
+  else
+    fail "review-resolution: PARSED='', DERIVED='213' → ISSUE='$got'"
+  fi
+}
+
+test_review_prefers_parsed_over_derived() {
+  local got
+  got=$(resolve_review_issue "999" "213")
+  if [[ "$got" == "999" ]]; then
+    pass "review-resolution: PARSED='999', DERIVED='213' → ISSUE='999' (parsed wins)"
+  else
+    fail "review-resolution: PARSED='999', DERIVED='213' → ISSUE='$got'"
+  fi
+}
+
+test_review_empty_when_neither_set() {
+  local got
+  got=$(resolve_review_issue "" "")
+  if [[ "$got" == "" ]]; then
+    pass "review-resolution: PARSED='', DERIVED='' → ISSUE='' (gate skips silently)"
+  else
+    fail "review-resolution: PARSED='', DERIVED='' → ISSUE='$got'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Layer 2: Gate decision tests — covers QA test cases 1-5 (decisions only).
 # ---------------------------------------------------------------------------
 
@@ -360,6 +404,11 @@ test_parser_empty
 test_parser_garbage_token
 test_parser_garbage_token_with_flag
 test_parser_negative_token_rejected
+
+echo "Layer 1b: review.md two-stage resolution"
+test_review_resolves_derived_when_no_args
+test_review_prefers_parsed_over_derived
+test_review_empty_when_neither_set
 
 echo "Layer 2: gate decision"
 test_gate_open_proceeds

--- a/scripts/tests/test_pipeline_state_gate.sh
+++ b/scripts/tests/test_pipeline_state_gate.sh
@@ -205,7 +205,9 @@ assert_skill_contains_gate() {
   local file="$2"
   local missing=0
   local needles=(
-    "## Gate: issue state"
+    # Heading may be prefixed (e.g. review.md uses phase-numbered headings),
+    # so we don't anchor to '## ' — substring is enough to catch drift.
+    "Gate: issue state"
     "Mirrors the gate in"
     "FORCE_ON_CLOSED"
     "ISSUE_NUMBER"

--- a/scripts/tests/test_pipeline_state_gate.sh
+++ b/scripts/tests/test_pipeline_state_gate.sh
@@ -1,0 +1,389 @@
+#!/usr/bin/env bash
+# Tests for the issue #213 invariant: /define, /design, /implement, /review
+# must abort on CLOSED issues unless --force-on-closed is passed.
+#
+# Three test layers:
+#   1. Parser — exercise the position-independent argument parser against
+#      multiple input shapes including the integer regex tightening.
+#   2. Gate decision — exercise the OPEN/CLOSED × FORCE/NO-FORCE matrix
+#      against a function that mirrors the gate body in the four skill
+#      markdown files.
+#   3. Sync — grep each of the four .claude/commands/{define,design,
+#      implement,review}.md files for the canonical gate strings so we
+#      catch silent drift between them.
+#
+# Run from repo root: bash scripts/tests/test_pipeline_state_gate.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DEFINE_MD="$REPO_ROOT/.claude/commands/define.md"
+DESIGN_MD="$REPO_ROOT/.claude/commands/design.md"
+IMPLEMENT_MD="$REPO_ROOT/.claude/commands/implement.md"
+REVIEW_MD="$REPO_ROOT/.claude/commands/review.md"
+CONTRIBUTING_MD="$REPO_ROOT/CONTRIBUTING.md"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS — $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL — $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Functions under test mirror the bash blocks embedded in the four skill
+# markdown files. The sync tests below assert the markdown files contain the
+# same key strings so this duplication can't drift silently.
+# ---------------------------------------------------------------------------
+
+# Parses positional + --force-on-closed flag from a string of arguments.
+# Sets globals: ISSUE_NUMBER, FORCE_ON_CLOSED.
+parse_pipeline_args() {
+  local input_args="$1"
+  FORCE_ON_CLOSED=false
+  ISSUE_NUMBER=""
+  # Empty input → both fields stay at defaults (bash 3.2 + set -u
+  # errors on empty array expansion, so short-circuit).
+  [[ -z "$input_args" ]] && return
+  ARGS=( $input_args )
+  for arg in "${ARGS[@]}"; do
+    case "$arg" in
+      --force-on-closed) FORCE_ON_CLOSED=true ;;
+      *)
+        local stripped="${arg##\#}"
+        if [[ "$stripped" =~ ^[0-9]+$ ]]; then
+          ISSUE_NUMBER="$stripped"
+        fi
+        ;;
+    esac
+  done
+}
+
+# Returns 0 if the gate would proceed; 1 if it would abort.
+# Inputs: $1=ISSUE_STATE ("OPEN"|"CLOSED"), $2=FORCE_ON_CLOSED ("true"|"false")
+evaluate_state_gate() {
+  local issue_state="$1"
+  local force="$2"
+  if [[ "$issue_state" == "CLOSED" && "$force" == "false" ]]; then
+    return 1  # abort
+  fi
+  return 0    # proceed
+}
+
+# ---------------------------------------------------------------------------
+# Layer 1: Parser tests — covers QA test cases 1-5 and 8.
+# ---------------------------------------------------------------------------
+
+test_parser_positional_only() {
+  parse_pipeline_args "213"
+  if [[ "$ISSUE_NUMBER" == "213" && "$FORCE_ON_CLOSED" == "false" ]]; then
+    pass "parser: '213' → ISSUE=213, FORCE=false"
+  else
+    fail "parser: '213' → ISSUE=$ISSUE_NUMBER, FORCE=$FORCE_ON_CLOSED"
+  fi
+}
+
+test_parser_hash_prefix() {
+  parse_pipeline_args "#213"
+  if [[ "$ISSUE_NUMBER" == "213" && "$FORCE_ON_CLOSED" == "false" ]]; then
+    pass "parser: '#213' → ISSUE=213 (hash stripped)"
+  else
+    fail "parser: '#213' → ISSUE=$ISSUE_NUMBER, FORCE=$FORCE_ON_CLOSED"
+  fi
+}
+
+test_parser_trailing_flag() {
+  parse_pipeline_args "213 --force-on-closed"
+  if [[ "$ISSUE_NUMBER" == "213" && "$FORCE_ON_CLOSED" == "true" ]]; then
+    pass "parser: '213 --force-on-closed' → ISSUE=213, FORCE=true"
+  else
+    fail "parser: trailing-flag: ISSUE=$ISSUE_NUMBER, FORCE=$FORCE_ON_CLOSED"
+  fi
+}
+
+test_parser_leading_flag() {
+  parse_pipeline_args "--force-on-closed 213"
+  if [[ "$ISSUE_NUMBER" == "213" && "$FORCE_ON_CLOSED" == "true" ]]; then
+    pass "parser: '--force-on-closed 213' → ISSUE=213, FORCE=true"
+  else
+    fail "parser: leading-flag: ISSUE=$ISSUE_NUMBER, FORCE=$FORCE_ON_CLOSED"
+  fi
+}
+
+test_parser_flag_only() {
+  parse_pipeline_args "--force-on-closed"
+  if [[ "$ISSUE_NUMBER" == "" && "$FORCE_ON_CLOSED" == "true" ]]; then
+    pass "parser: '--force-on-closed' → ISSUE empty (context-inferred), FORCE=true"
+  else
+    fail "parser: flag-only: ISSUE=$ISSUE_NUMBER, FORCE=$FORCE_ON_CLOSED"
+  fi
+}
+
+test_parser_empty() {
+  parse_pipeline_args ""
+  if [[ "$ISSUE_NUMBER" == "" && "$FORCE_ON_CLOSED" == "false" ]]; then
+    pass "parser: '' → ISSUE empty, FORCE=false"
+  else
+    fail "parser: empty: ISSUE=$ISSUE_NUMBER, FORCE=$FORCE_ON_CLOSED"
+  fi
+}
+
+test_parser_garbage_token() {
+  parse_pipeline_args "12abc"
+  # Per QA case 8: regex ^[0-9]+$ rejects mixed tokens; ISSUE_NUMBER stays empty.
+  if [[ "$ISSUE_NUMBER" == "" && "$FORCE_ON_CLOSED" == "false" ]]; then
+    pass "parser: '12abc' → rejected by regex, ISSUE empty"
+  else
+    fail "parser: garbage: ISSUE=$ISSUE_NUMBER, FORCE=$FORCE_ON_CLOSED"
+  fi
+}
+
+test_parser_garbage_token_with_flag() {
+  parse_pipeline_args "12abc --force-on-closed"
+  # Garbage rejected; flag still parsed.
+  if [[ "$ISSUE_NUMBER" == "" && "$FORCE_ON_CLOSED" == "true" ]]; then
+    pass "parser: '12abc --force-on-closed' → ISSUE empty, FORCE=true"
+  else
+    fail "parser: garbage+flag: ISSUE=$ISSUE_NUMBER, FORCE=$FORCE_ON_CLOSED"
+  fi
+}
+
+test_parser_negative_token_rejected() {
+  parse_pipeline_args "-5"
+  # Defensive: '-5' is not a valid issue number; regex rejects.
+  if [[ "$ISSUE_NUMBER" == "" ]]; then
+    pass "parser: '-5' → rejected (no negative issue numbers)"
+  else
+    fail "parser: '-5' → unexpectedly parsed as ISSUE=$ISSUE_NUMBER"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Layer 2: Gate decision tests — covers QA test cases 1-5 (decisions only).
+# ---------------------------------------------------------------------------
+
+test_gate_open_proceeds() {
+  if evaluate_state_gate "OPEN" "false"; then
+    pass "gate: OPEN + force=false → proceed"
+  else
+    fail "gate: OPEN + force=false should proceed"
+  fi
+}
+
+test_gate_closed_aborts() {
+  if evaluate_state_gate "CLOSED" "false"; then
+    fail "gate: CLOSED + force=false should abort"
+  else
+    pass "gate: CLOSED + force=false → abort"
+  fi
+}
+
+test_gate_closed_force_proceeds() {
+  if evaluate_state_gate "CLOSED" "true"; then
+    pass "gate: CLOSED + force=true → proceed (override)"
+  else
+    fail "gate: CLOSED + force=true should proceed"
+  fi
+}
+
+test_gate_open_force_proceeds() {
+  # Defensive: --force-on-closed on an open issue is a no-op, must not abort.
+  if evaluate_state_gate "OPEN" "true"; then
+    pass "gate: OPEN + force=true → proceed (force is no-op)"
+  else
+    fail "gate: OPEN + force=true should proceed"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Layer 3: Sync tests — assert all four skill files contain canonical gate
+# strings. Catches silent drift between the four files.
+# ---------------------------------------------------------------------------
+
+assert_skill_contains_gate() {
+  local label="$1"
+  local file="$2"
+  local missing=0
+  local needles=(
+    "## Gate: issue state"
+    "Mirrors the gate in"
+    "FORCE_ON_CLOSED"
+    "ISSUE_NUMBER"
+    "--force-on-closed"
+    'closedByPullRequestsReferences'
+    "see issue #213"
+    "Pipeline commands abort on closed issues by default"
+  )
+  for needle in "${needles[@]}"; do
+    if ! grep -qF -- "$needle" "$file"; then
+      fail "$label missing literal: $needle"
+      missing=1
+    fi
+  done
+  [[ "$missing" -eq 0 ]] && pass "$label contains the gate"
+}
+
+test_define_md_contains_gate() {
+  assert_skill_contains_gate "define.md" "$DEFINE_MD"
+}
+
+test_design_md_contains_gate() {
+  assert_skill_contains_gate "design.md" "$DESIGN_MD"
+}
+
+test_implement_md_contains_gate() {
+  assert_skill_contains_gate "implement.md" "$IMPLEMENT_MD"
+}
+
+test_review_md_contains_gate() {
+  assert_skill_contains_gate "review.md" "$REVIEW_MD"
+}
+
+# ---------------------------------------------------------------------------
+# Layer 3b: Position tests — gate must precede side-effecting steps in each
+# file. We verify by line-number ordering of well-known anchors.
+# ---------------------------------------------------------------------------
+
+line_of() {
+  # First-match line number for a literal needle. Empty string if missing.
+  grep -nF "$1" "$2" | head -1 | cut -d: -f1
+}
+
+test_define_gate_before_label_add() {
+  local gate label
+  gate=$(line_of "## Gate: issue state" "$DEFINE_MD")
+  label=$(line_of 'gh label create "pm-reviewed"' "$DEFINE_MD")
+  if [[ -n "$gate" && -n "$label" && "$gate" -lt "$label" ]]; then
+    pass "define.md: gate ($gate) precedes pm-reviewed label add ($label)"
+  else
+    fail "define.md: gate=$gate, label=$label (gate must precede label)"
+  fi
+}
+
+test_design_gate_before_label_add() {
+  local gate label
+  gate=$(line_of "## Gate: issue state" "$DESIGN_MD")
+  label=$(line_of 'gh label create "design-complete"' "$DESIGN_MD")
+  if [[ -n "$gate" && -n "$label" && "$gate" -lt "$label" ]]; then
+    pass "design.md: gate ($gate) precedes design-complete label add ($label)"
+  else
+    fail "design.md: gate=$gate, label=$label (gate must precede label)"
+  fi
+}
+
+test_implement_gate_before_worktree() {
+  local gate label worktree branch
+  gate=$(line_of "## Gate: issue state" "$IMPLEMENT_MD")
+  label=$(line_of 'gh label create "implementing"' "$IMPLEMENT_MD")
+  worktree=$(line_of "EnterWorktree" "$IMPLEMENT_MD")
+  branch=$(line_of "git fetch origin main" "$IMPLEMENT_MD")
+  if [[ -n "$gate" && -n "$label" && "$gate" -lt "$label" ]]; then
+    pass "implement.md: gate ($gate) precedes implementing label add ($label)"
+  else
+    fail "implement.md gate-vs-label: gate=$gate, label=$label"
+  fi
+  if [[ -n "$gate" && -n "$worktree" && "$gate" -lt "$worktree" ]]; then
+    pass "implement.md: gate ($gate) precedes EnterWorktree ($worktree)"
+  else
+    fail "implement.md gate-vs-worktree: gate=$gate, worktree=$worktree"
+  fi
+  if [[ -n "$gate" && -n "$branch" && "$gate" -lt "$branch" ]]; then
+    pass "implement.md: gate ($gate) precedes branch cut ($branch)"
+  else
+    fail "implement.md gate-vs-branch: gate=$gate, branch=$branch"
+  fi
+}
+
+test_review_gate_before_make_check() {
+  local gate make_check pr_create merge
+  gate=$(line_of "Gate: issue state" "$REVIEW_MD")
+  make_check=$(line_of "make check" "$REVIEW_MD")
+  pr_create=$(line_of "gh pr create" "$REVIEW_MD")
+  merge=$(line_of "gh pr merge" "$REVIEW_MD")
+  if [[ -n "$gate" && -n "$make_check" && "$gate" -lt "$make_check" ]]; then
+    pass "review.md: gate ($gate) precedes make check ($make_check)"
+  else
+    fail "review.md gate-vs-make-check: gate=$gate, make_check=$make_check"
+  fi
+  if [[ -n "$gate" && -n "$pr_create" && "$gate" -lt "$pr_create" ]]; then
+    pass "review.md: gate ($gate) precedes gh pr create ($pr_create)"
+  else
+    fail "review.md gate-vs-pr-create: gate=$gate, pr_create=$pr_create"
+  fi
+  if [[ -n "$gate" && -n "$merge" && "$gate" -lt "$merge" ]]; then
+    pass "review.md: gate ($gate) precedes gh pr merge ($merge)"
+  else
+    fail "review.md gate-vs-merge: gate=$gate, merge=$merge"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Layer 3c: /review-specific clause — must skip silently when no issue is
+# derivable (per QA case R2).
+# ---------------------------------------------------------------------------
+
+test_review_md_has_skip_silently_clause() {
+  if grep -qF -- "skip this gate silently" "$REVIEW_MD"; then
+    pass "review.md: contains 'skip this gate silently' clause for issue-less reviews"
+  else
+    fail "review.md: missing 'skip this gate silently' clause (per QA R2)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Layer 4: Documentation — CONTRIBUTING.md must reference the override.
+# ---------------------------------------------------------------------------
+
+test_contributing_documents_override() {
+  if grep -qF -- "force-on-closed" "$CONTRIBUTING_MD" \
+     && grep -qF -- "#213" "$CONTRIBUTING_MD"; then
+    pass "CONTRIBUTING.md: documents --force-on-closed override and links #213"
+  else
+    fail "CONTRIBUTING.md: missing --force-on-closed override docs or #213 link"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+echo "Running issue #213 closed-issue-gate tests..."
+echo "Layer 1: parser"
+test_parser_positional_only
+test_parser_hash_prefix
+test_parser_trailing_flag
+test_parser_leading_flag
+test_parser_flag_only
+test_parser_empty
+test_parser_garbage_token
+test_parser_garbage_token_with_flag
+test_parser_negative_token_rejected
+
+echo "Layer 2: gate decision"
+test_gate_open_proceeds
+test_gate_closed_aborts
+test_gate_closed_force_proceeds
+test_gate_open_force_proceeds
+
+echo "Layer 3: skill markdown sync"
+test_define_md_contains_gate
+test_design_md_contains_gate
+test_implement_md_contains_gate
+test_review_md_contains_gate
+
+echo "Layer 3b: gate position (must precede side effects)"
+test_define_gate_before_label_add
+test_design_gate_before_label_add
+test_implement_gate_before_worktree
+test_review_gate_before_make_check
+
+echo "Layer 3c: /review-specific clause"
+test_review_md_has_skip_silently_clause
+
+echo "Layer 4: CONTRIBUTING.md"
+test_contributing_documents_override
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
Closes #213

## Summary

Adds a CLOSED-issue abort gate to the four pipeline commands (`/define`, `/design`, `/implement`, `/review`). Prevents the failure mode that surfaced this issue (the #204 incident: full committee review on already-shipped work).

- **Behavior** — if the linked GitHub issue is CLOSED and `--force-on-closed` is not passed, the skill aborts with a canonical message **before** any side-effecting step (no labels added, no comments posted, no worktree created, no branch cut).
- **`/summarize` is intentionally excluded** — it documents shipped work and legitimately runs on closed issues.
- **`/review`-specific clause** — skips the gate silently when no issue is derivable from progress file / branch / commits, preserving today's behavior for issue-less reviews (per QA case R2).
- **Argument parser** — position-independent; handles `--force-on-closed` before, after, or without an issue number; integer regex `^[0-9]+$` rejects mixed tokens like `12abc`.
- **Sync test** — `scripts/tests/test_pipeline_state_gate.sh` mirrors the `test_implement_branch_cut.sh` pattern: parser + gate-decision functions are unit-tested; sync layer greps each `.claude/commands/*.md` for canonical strings; position layer asserts the gate appears before each file's side-effecting steps.

## Test Plan

- [x] `bash scripts/tests/test_pipeline_state_gate.sh` — **27/27 passing** (parser, gate decision, skill markdown sync, gate position, /review skip-silently clause, CONTRIBUTING.md docs)
- [x] `bash scripts/tests/test_implement_branch_cut.sh` — 6/6 still passing (no regression)
- [x] `make -C api lint` — passed (ruff + ruff format + mypy)
- [x] `make -C api test` — 338 passed / 3 skipped
- [x] `make -C web lint` — passed
- [x] `make -C web typecheck` — passed
- [x] `make -C web test` — 7/7 vitest passing
- [ ] `make -C web build` — blocked locally on missing `CLERK_PUBLISHABLE_KEY`, expected to pass in CI (env issue, unrelated to this change — markdown-only)
- [ ] CI passes
- [ ] Docker health check passes

## Files changed

- `.claude/commands/define.md` — new `## Gate: issue state` section
- `.claude/commands/design.md` — new `## Gate: issue state` section
- `.claude/commands/implement.md` — new `## Gate: issue state` section, positioned before label add / EnterWorktree / branch cut
- `.claude/commands/review.md` — new `## 0.1a: Gate: issue state` section with skip-silently clause
- `CONTRIBUTING.md` — one sentence under "Slash-command Invariants"
- `scripts/tests/test_pipeline_state_gate.sh` — new regression test (mirrors `test_implement_branch_cut.sh`)
- `Makefile` — wires the new test into `make check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)