### PR TITLE
docs(#184): clean up two PR 5 EM-synthesis NITs

### DIFF
--- a/docs/legacy/v1-ui-catalog/agency-admin/003-data-health.md
+++ b/docs/legacy/v1-ui-catalog/agency-admin/003-data-health.md
@@ -14,4 +14,3 @@ generated: 2026-05-08
 - "Verified" timestamp → marks when the integrity audit last ran.
 - "Core Entities" section → groups counts and flagged-record lists by model; each row drills to the affected record so an admin can fix it.
 - Role usage → operational health-check landing for the Agency Admin; surfaces v1 schedule + chart gaps that the v2 migration must reconcile.
-

--- a/docs/legacy/v1-ui-catalog/agency-admin/037-orders.md
+++ b/docs/legacy/v1-ui-catalog/agency-admin/037-orders.md
@@ -14,4 +14,4 @@ generated: 2026-05-08
 - "Active Orders" tab → currently the only state shown; the populated render adds an "Inactive" tab gated on a `?status=inactive` query.
 - Per-order row drill-in → opens the single-order detail (out of catalog scope).
 - Empty state → fixture has no active orders for the client; populated render renders one row per order with the prescriber's name and a refill / discontinue per-row action.
-- Permissions → renders for caregivers, care managers, and admins on the agency role; mutating actions are gated by the `manage_medication_orders` capability.
+- Permissions → guarded by Django's `@staff_member_required` decorator; the v1 view does not apply a finer-grained capability check.

--- a/docs/legacy/v1-ui-catalog/agency-admin/041-clinical.md
+++ b/docs/legacy/v1-ui-catalog/agency-admin/041-clinical.md
@@ -14,4 +14,4 @@ generated: 2026-05-08
 - Plain-text fallback → returned when `DailyChart` rows for the client + window are empty; the response body is the literal "No health data found for the selected date range." string captured in the WebP.
 - ⚠ Crawler note → Playwright treats normal-data responses as downloads (`Content-Disposition: attachment`) and intercepts them without paint; the captured WebP only renders when the fallback fires.
 - Reached from → [agency-admin/040-generate](040-generate.md) when the Clinical report-type radio is selected and the form posts directly to this URL with the `?days=` query.
-- Permissions → `manage_health_reports` capability + per-client view permission; auditing fires for both successful PDF and fallback responses.
+- Permissions → guarded by Django's `@staff_member_required` decorator (the v1 view applies no finer-grained capability check); auditing fires for both successful PDF and fallback responses.

--- a/docs/legacy/v1-ui-catalog/agency-admin/042-preview.md
+++ b/docs/legacy/v1-ui-catalog/agency-admin/042-preview.md
@@ -14,4 +14,4 @@ generated: 2026-05-08
 - Bare GET → redirects back to [agency-admin/040-generate](040-generate.md) so the operator can compose the parameters; the captured WebP is that redirect target.
 - Sibling routes → [agency-admin/040-generate](040-generate.md) (form), [agency-admin/041-clinical](041-clinical.md) (direct PDF), [agency-admin/043-email](043-email.md) (email send).
 - Used by → the operator's "preview before sending" workflow when finalizing a health report; the rendered preview applies the formatting options (orientation, font size, detail level) selected on [agency-admin/045-templates](045-templates.md).
-- Security → consumed inside the staff-only domain; PHI in the preview body is rendered server-side and gated on the `view_health_reports` capability.
+- Security → consumed inside the staff-only domain; the v1 view applies Django's `@staff_member_required` decorator to gate access, with no finer-grained capability check.

--- a/docs/legacy/v1-ui-catalog/agency-admin/044-batch.md
+++ b/docs/legacy/v1-ui-catalog/agency-admin/044-batch.md
@@ -12,6 +12,6 @@ generated: 2026-05-08
 **Interaction notes:**
 - Page load → `health_report_batch` (`charting/batch_health_report.html`) renders the batch-generate form (multi-select clients, report type, date range).
 - "Generate Batch" → ⚠ destructive: POSTs the form to render PDFs for each selected client and stream a zip download; partial-success warnings surface as a flash on redirect when one or more clients failed. Skipped by crawler.
-- "Select All" / "Clear All" → toggle the client multi-select; the picker is gated by `view_health_reports` per-client.
+- "Select All" / "Clear All" → toggle the client multi-select; the v1 view applies Django's `@staff_member_required` decorator with no finer-grained per-client capability gate.
 - Empty state → fixture has no clients with chart access enabled; populated render shows a checkbox per visible client.
 - Sibling routes → [agency-admin/040-generate](040-generate.md) (single), [agency-admin/041-clinical](041-clinical.md) (direct PDF), [agency-admin/042-preview](042-preview.md) (preview), [agency-admin/043-email](043-email.md) (email).

--- a/docs/legacy/v1-ui-catalog/agency-admin/049-add.md
+++ b/docs/legacy/v1-ui-catalog/agency-admin/049-add.md
@@ -14,4 +14,4 @@ generated: 2026-05-08
 - ⚠ destructive: form POST → writes the override, audit-logs the actor + override target + section delta, and redirects back to [agency-admin/045-templates](045-templates.md) with a success or error flash. Skipped by crawler.
 - Override scope → per-(caregiver, client) is most specific; per-caregiver and per-client overrides are also accepted; the resolver in v1 picks the most specific match per "Most specific rule wins" rendered on [agency-admin/045-templates](045-templates.md).
 - Validation → rejects overrides that drop required sections per the parent template's required-sections set; surfaces as a per-field error on redirect.
-- Permissions → guarded by the `manage_report_templates` capability.
+- Permissions → guarded by Django's `@staff_member_required` decorator; the v1 view does not apply a finer-grained capability check.


### PR DESCRIPTION
Follow-up to merged PR #220 (caption authoring for the v1 UI catalog agency-admin section). Cleans up the two NITs called out in the PR 5 Engineering Manager synthesis that were noted as future work but never filed.

## NIT 1 — invented capability names corrected (5 files)

The Security review on PR #220 noted that capability names mentioned in agency-admin caption bodies (`manage_medication_orders`, `view_health_reports`, `manage_health_reports`, `manage_report_templates`) should be spot-checked against `core/permissions.py` for accuracy.

Doing the spot-check revealed **these capability names do not exist in v1's source at the pinned commit (`9738412a`)**. The actual gate on every referenced view in `charting/views.py` is Django's built-in `@staff_member_required` decorator with no finer-grained capability check.

Updated five caption bullets to describe the real gate honestly:

| File | View function |
|------|---------------|
| `037-orders.md` | `medication_orders_list` |
| `041-clinical.md` | `clinical_health_report` |
| `042-preview.md` | `health_report_preview` |
| `044-batch.md` | `health_report_batch` |
| `049-add.md` | report-access-override add endpoint |

Verification:

```bash
$ cd ~/Code/COREcare-access  # pinned at 9738412a
$ grep -rn "manage_medication_orders\|view_health_reports\|manage_health_reports\|manage_report_templates" --include="*.py" .
# (no output — none of these names exist in v1)
$ grep -B1 "def medication_orders_list" charting/views.py
@staff_member_required
def medication_orders_list(request, client_id):
```

## NIT 2 — trailing-blank-line normalization (1 file)

The Writer review on PR #220 noted that `003-data-health.md` ended with one extra trailing blank line vs the rest of the agency-admin section. Removed the extra newline so all 61 files terminate uniformly on the last bullet (`2e0a` = `.\n`).

## Test Plan

- [x] `bash scripts/check-v1-doc-hygiene.sh docs/legacy/v1-ui-catalog/agency-admin/*.md` exits 0
- [x] `bash scripts/check-v1-caption-phi.sh docs/legacy/v1-ui-catalog/agency-admin/*.md` exits 0
- [x] `bash scripts/check-v1-caption-voice.sh docs/legacy/v1-ui-catalog/agency-admin/*.md` exits 0
- [x] `bash scripts/check-v1-captions-authored.sh` exits 0 (whole catalog)
- [x] All 61 agency-admin caption files terminate with `2e0a` (period + newline)
- [ ] CI v1-catalog-gate workflow passes
- [ ] CI v1-catalog-coverage workflow passes

No new code, no behavioral changes. The catalog acceptance milestone (#184) is already closed; this is a small accuracy + style cleanup.