### PR TITLE
test(#227): MT-3.C/D — synthetic-only self-tests for stronger isolation

### DIFF
--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -3157,9 +3157,20 @@ fi
 #   no rule-emit string to substring-match. The detection regex is scoped to
 #   expected-exit-1 lines only. MT-3.C guards this.
 #
+# Self-test construction asymmetry (load-bearing — see #227):
+#   MT-3.B uses `cat <source> + appended violation` because B's claim is
+#   detection-in-context: realism (a full-file shape) is part of what it
+#   guards. MT-3.C and MT-3.D use synthetic-only files (only the appended
+#   line, no `cat`) because their claims are *negative* — that an exempt
+#   pattern is NOT flagged. Synthetic-only construction isolates the
+#   negative claim from any source-file state, so a real-state violation in
+#   the live source cannot masquerade as a regression in the exemption guard
+#   (e.g., during a local mutation experiment by a contributor).
+#
 # See: https://github.com/suniljames/COREcare-v2/issues/201 (this rule),
 #      https://github.com/suniljames/COREcare-v2/issues/174 (convention origin),
-#      https://github.com/suniljames/COREcare-v2/issues/196 (per-branch parity).
+#      https://github.com/suniljames/COREcare-v2/issues/196 (per-branch parity),
+#      https://github.com/suniljames/COREcare-v2/issues/227 (C/D synthetic isolation).
 
 _extract_sl_loose_fixtures() {
   # Three-condition filter on each line of $1 (test file):
@@ -3233,29 +3244,30 @@ assert_sl_substring_discipline \
   "${mt3_sl_code}: synthetic violation"
 
 # C. Self-test — positive-fixture exemption holds.
-# An appended SL-* fixture with expected exit 0 is correctly exempted. Load-
-# bearing: if MT-3's regex were ever narrowed to drop the exit-code-1 filter,
-# this test would fail and signal the regression.
+# The synthetic file contains *only* an appended SL-* fixture with expected
+# exit 0 — no `cat` of the live source. This isolates C from any source-state
+# confounders: a real-state SL-* violation in the live source cannot
+# masquerade as a regression here, because the synthetic file has none of the
+# live source's content. Load-bearing: if MT-3's regex were ever narrowed to
+# drop the exit-code-1 filter, the appended exit-0 line would be flagged and
+# this test would fail.
 mkdir -p "$TEST_DIR/mt-3-positive"
-{
-  cat "$REPO_ROOT/scripts/tests/test_check_v1_doc_structure.sh"
-  printf 'assert_exit "%s: positive sentinel" 0 "$STRUCTURE" --dir /nonexistent\n' "$mt3_sl_code"
-} > "$TEST_DIR/mt-3-positive/test.sh"
+printf 'assert_exit "%s: positive sentinel" 0 "$STRUCTURE" --dir /nonexistent\n' \
+  "$mt3_sl_code" > "$TEST_DIR/mt-3-positive/test.sh"
 assert_sl_substring_discipline \
   "MT-3 self-test: positive (exit 0) SL-* fixture is exempted" \
   "$TEST_DIR/mt-3-positive/test.sh" \
   0
 
 # D. Self-test — out-of-cohort exemption holds.
-# An appended JL-* fixture using bare assert_exit is correctly exempted (per
-# #174's cohort scope-limit). Load-bearing: if MT-3's regex were ever
-# broadened (cohort prefix dropped or generalized), this test would fail and
-# signal the regression.
+# The synthetic file contains *only* an appended JL-* fixture using bare
+# assert_exit (per #174's cohort scope-limit) — no `cat` of the live source,
+# for the same isolation reason as C. Load-bearing: if MT-3's regex were ever
+# broadened beyond `SL-` (cohort prefix dropped or generalized), the appended
+# JL-99 line would be flagged and this test would fail.
 mkdir -p "$TEST_DIR/mt-3-out-of-cohort"
-{
-  cat "$REPO_ROOT/scripts/tests/test_check_v1_doc_structure.sh"
-  printf 'assert_exit "%s: synthetic non-SL fixture" 1 "$STRUCTURE" --dir /nonexistent\n' "$mt3_jl_code"
-} > "$TEST_DIR/mt-3-out-of-cohort/test.sh"
+printf 'assert_exit "%s: synthetic non-SL fixture" 1 "$STRUCTURE" --dir /nonexistent\n' \
+  "$mt3_jl_code" > "$TEST_DIR/mt-3-out-of-cohort/test.sh"
 assert_sl_substring_discipline \
   "MT-3 self-test: out-of-cohort (JL-*) bare-assert_exit fixture is exempted" \
   "$TEST_DIR/mt-3-out-of-cohort/test.sh" \


### PR DESCRIPTION
Closes #227.

## Summary

- Drops `cat <live source> +` prefix from MT-3.C and MT-3.D's synthetic file construction; both now write only the appended `printf` line. MT-3.B unchanged.
- Refreshes inline documentation: new asymmetry paragraph in the MT-3 header block, refreshed per-test comments at C and D, see-also list extended with #227.
- Resolves the QA NIT from PR #225 round-1 review (https://github.com/suniljames/COREcare-v2/pull/225#issuecomment-4408930459): C and D used to fail for confounding reasons during local mutation experiments because the source mutation propagated into the `cat`-prefixed synthetic files. Synthetic-only construction isolates C/D's *negative* claims from source-file state.

## Why MT-3.B remains `cat + append`

B's claim is detection-in-context: "MT-3 surfaces a violation in a realistic file shape." Realism is part of the guard, so retaining `cat + append` is principled, not accidental. The asymmetry between B (cat+append, positive claim about detection) and C/D (synthetic-only, negative claim about non-detection) is now documented in the MT-3 header block.

## Verification matrix

Executed all four steps of the locked Test Specification on #227 in this branch:

| Step | Perturbation                          | MT-3.A | MT-3.B | MT-3.C   | MT-3.D   |
|------|---------------------------------------|--------|--------|----------|----------|
| 1    | none (baseline)                       | pass   | pass   | pass     | pass     |
| 2    | mutate `:625` → bare `assert_exit`    | **FAIL** | pass | **pass** ← | **pass** ← |
| 3    | drop `[[:space:]]+1[[:space:]]+` clause | **FAIL** | pass | **FAIL** ← | pass     |
| 4    | broaden cohort to `[A-Z]{2}-`         | **FAIL** | pass | pass     | **FAIL** ← |

`←` marks the load-bearing post-refactor signal for each step. C and D pass under the source-mutation perturbation (Step 2) — this is the property the refactor was designed to deliver. C fails under regex narrowing (Step 3) and D fails under cohort broadening (Step 4), confirming both negative-claim guards still load-bear in pure isolation.

**Step-2 deviation from locked spec wording:** the spec hedged that B "may fail (propagation)" under Step 2; in practice B passes because its pass condition is "exit 1 AND output contains the synthesized `SL-9: synthetic violation` substring" — both hold even when the source mutation is also flagged (MT-3 emits both, exit 1, substring still found). The deviation does not undermine any load-bearing claim. Documenting here for completeness; locked spec language can be refined in future MT-3 work.

After each perturbation, the regex / source was reverted and `Results: 111 passed, 0 failed` confirmed.

## Test Plan

- [x] `bash scripts/tests/test_check_v1_doc_structure.sh` → `Results: 111 passed, 0 failed` (post-refactor)
- [x] Step 2 — mutation experiment (`:625` → bare `assert_exit`)
- [x] Step 3 — regex-narrowing perturbation
- [x] Step 4 — cohort-broadening perturbation
- [x] `bash scripts/tests/test_check_v1_doc_hygiene.sh` → `21 passed, 0 failed`
- [x] `bash scripts/tests/test_check_v1_inventory_mount_prefixes.sh` → `13 passed, 0 failed`
- [ ] CI `v1-doc-hygiene.yml` `scripts-self-test` job passes
- [ ] Eng-committee code review approved

## Files changed

`scripts/tests/test_check_v1_doc_structure.sh` only (+28 / −16). Two `printf`-only blocks at C and D, plus three inline-comment refreshes (header block, C, D) and see-also list extension. No external doc impact (per Documentation Impact Assessment on #227).

## Out of scope

- Generalizing MT-3 to JL/CR/EL/CL/GL/RR/WF cohorts (per #174 cohort scope-limit).
- Any change to MT-3.B (intentional — realism is part of B's claim).
- Any permanent change to the MT-3 detection regex (perturbations are revert-after-verification only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)