### PR TITLE
infra(#191): pin worktree.baseRef and verify the cut-from-origin/main contract

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
   "_comment": "Hooks are sourced from suniljames/dotfiles via ~/.claude/hooks/. Each command guards with [ -x ... ] so missing hooks gracefully no-op rather than erroring. Install dotfiles to activate hooks.",
+  "_comment_worktree": "Pin EnterWorktree's base ref to `fresh` (origin/<default-branch>) so worktrees are not silently cut from local HEAD if the harness default ever changes. See issues #146 / #176 / #191; regression test: scripts/tests/test_worktree_base_setting.sh.",
+  "worktree": {
+    "baseRef": "fresh"
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ check: ## Run all quality gates (pre-PR)
 	$(MAKE) -C web test
 	$(MAKE) -C web build
 	bash scripts/tests/test_implement_branch_cut.sh
+	bash scripts/tests/test_worktree_base_setting.sh
 	bash scripts/tests/test_pipeline_state_gate.sh
 
 # --- Individual targets ---

--- a/docs/developer/SAFETY.md
+++ b/docs/developer/SAFETY.md
@@ -23,3 +23,10 @@ This file covers COREcare project-specific safety only.
 2. If stashing, use `git stash push -m "descriptive message"`
 3. Never drop a stash after failed pop
 4. Verify restoration after switching back
+
+## Branch-cut invariants
+
+Every feature branch must be cut from a freshly-fetched `origin/<default-branch>` SHA — never from stale local `main` (see issues #146 / #176 / #191).
+
+- Bash invariant lives in [`.claude/commands/implement.md`](../../.claude/commands/implement.md) (Branch base block) and the mirror copy in [`.claude/commands/review.md`](../../.claude/commands/review.md), with regression coverage in [`scripts/tests/test_implement_branch_cut.sh`](../../scripts/tests/test_implement_branch_cut.sh).
+- Harness contract pin: `worktree.baseRef: "fresh"` in [`.claude/settings.json`](../../.claude/settings.json), with regression coverage in [`scripts/tests/test_worktree_base_setting.sh`](../../scripts/tests/test_worktree_base_setting.sh).

--- a/scripts/tests/test_worktree_base_setting.sh
+++ b/scripts/tests/test_worktree_base_setting.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Tests for the issue #191 invariant: project .claude/settings.json must pin
+# worktree.baseRef = "fresh" so EnterWorktree (provided by the Claude Code
+# harness, not this repo) cuts new worktrees from origin/<default-branch>
+# instead of the local HEAD.
+#
+# Two test layers:
+#   1. Settings-pin assertion — read .claude/settings.json and assert that
+#      .worktree.baseRef == "fresh", plus literal-string grep so a renamed
+#      key is also caught.
+#   2. Contract-analog sandbox — exercise the documented `fresh` behavior
+#      against a temp git repo with a fake origin in four scenarios
+#      (current / behind / ahead / offline) using `git fetch origin main &&
+#      git worktree add -b <name> <dir> origin/main` as the closest
+#      mechanical analog of EnterWorktree's `worktree.baseRef: fresh` mode.
+#
+# This is a sibling test to test_implement_branch_cut.sh — the latter tests
+# the bash invariant in implement.md/review.md (the project's defense-in-
+# depth guard); this one tests the harness contract surface we depend on.
+#
+# Run from repo root: bash scripts/tests/test_worktree_base_setting.sh
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SETTINGS_JSON="$REPO_ROOT/.claude/settings.json"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS — $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL — $1"; FAIL=$((FAIL + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP — jq not installed; tests require jq for JSON assertions"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Layer 1 — settings-pin assertions
+# ---------------------------------------------------------------------------
+
+test_settings_file_present() {
+  if [[ -f "$SETTINGS_JSON" ]]; then
+    pass "settings_file_present"
+  else
+    fail "settings_file_present: $SETTINGS_JSON not found"
+  fi
+}
+
+test_settings_parses_as_json() {
+  if jq empty "$SETTINGS_JSON" 2>/dev/null; then
+    pass "settings_parses_as_json"
+  else
+    fail "settings_parses_as_json: jq could not parse $SETTINGS_JSON"
+  fi
+}
+
+test_worktree_base_ref_pinned_to_fresh() {
+  local actual
+  actual=$(jq -r '.worktree.baseRef // "<missing>"' "$SETTINGS_JSON" 2>/dev/null)
+  if [[ "$actual" == "fresh" ]]; then
+    pass "worktree_base_ref_pinned_to_fresh"
+  else
+    fail "worktree_base_ref_pinned_to_fresh: got '$actual', expected 'fresh'. Set \"worktree\": {\"baseRef\": \"fresh\"} in .claude/settings.json — see issue #191."
+  fi
+}
+
+test_worktree_base_ref_literal_string_present() {
+  # Defensive: if a future schema rename moves the key elsewhere, jq might
+  # still pass on a refactored shape. Grep for the literal string to catch
+  # silent removals during settings cleanup.
+  if grep -qF '"baseRef"' "$SETTINGS_JSON" && grep -qF '"fresh"' "$SETTINGS_JSON"; then
+    pass "worktree_base_ref_literal_string_present"
+  else
+    fail "worktree_base_ref_literal_string_present: '\"baseRef\"' or '\"fresh\"' literal not found in $SETTINGS_JSON"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Layer 2 — contract-analog sandbox
+#
+# These tests do NOT drive EnterWorktree itself (out of reach without the
+# Claude Code runtime). They exercise the documented `worktree.baseRef:
+# fresh` contract using its closest mechanical analog: a fetch followed by
+# `git worktree add -b <name> <dir> origin/main`. If the documented contract
+# ever silently changes shape, these tests fail and we know to revisit.
+# ---------------------------------------------------------------------------
+
+cut_worktree_from_origin_main() {
+  # Mirror of EnterWorktree's documented `fresh` behavior: fetch, then
+  # branch from origin/<default-branch>.
+  local branch_name="$1"
+  local worktree_dir="$2"
+  git fetch origin main || return 1
+  local base_sha
+  base_sha=$(git rev-parse origin/main 2>/dev/null) || return 1
+  if [[ -z "$base_sha" || ! "$base_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: could not resolve origin/main to a SHA. Aborting." >&2
+    return 1
+  fi
+  git worktree add -b "$branch_name" "$worktree_dir" "$base_sha"
+}
+
+make_sandbox() {
+  SANDBOX=$(mktemp -d)
+  REMOTE="$SANDBOX/remote.git"
+  LOCAL="$SANDBOX/local"
+  git init --bare --quiet -b main "$REMOTE"
+
+  local seed="$SANDBOX/seed"
+  git init --quiet -b main "$seed"
+  git -C "$seed" config user.email "test@example.com"
+  git -C "$seed" config user.name "Test"
+  git -C "$seed" commit --allow-empty -m "initial" --quiet
+  git -C "$seed" remote add origin "$REMOTE"
+  git -C "$seed" push --quiet origin main
+  rm -rf "$seed"
+
+  git clone --quiet "$REMOTE" "$LOCAL"
+  git -C "$LOCAL" config user.email "test@example.com"
+  git -C "$LOCAL" config user.name "Test"
+}
+
+push_commits_to_remote_main() {
+  local remote="$1"
+  local count="$2"
+  local tmp
+  tmp=$(mktemp -d)
+  git clone --quiet "$remote" "$tmp/c"
+  git -C "$tmp/c" config user.email "test@example.com"
+  git -C "$tmp/c" config user.name "Test"
+  for i in $(seq 1 "$count"); do
+    git -C "$tmp/c" commit --allow-empty -m "remote commit $i" --quiet
+  done
+  git -C "$tmp/c" push --quiet origin main
+  rm -rf "$tmp"
+}
+
+test_contract_current_local_main() {
+  make_sandbox
+  cd "$LOCAL"
+  if cut_worktree_from_origin_main "feat/wt1" "$SANDBOX/wt1" >/dev/null 2>&1; then
+    local parent expected
+    parent=$(git -C "$SANDBOX/wt1" rev-parse HEAD)
+    expected=$(git rev-parse origin/main)
+    if [[ "$parent" == "$expected" ]]; then
+      pass "contract_current_local_main"
+    else
+      fail "contract_current_local_main: parent=$parent expected=$expected"
+    fi
+  else
+    fail "contract_current_local_main: cut function failed"
+  fi
+  cd "$REPO_ROOT"
+  rm -rf "$SANDBOX"
+}
+
+test_contract_stale_local_main() {
+  make_sandbox
+  cd "$LOCAL"
+  local stale_sha
+  stale_sha=$(git rev-parse main)
+  cd "$REPO_ROOT"
+  push_commits_to_remote_main "$REMOTE" 3
+  cd "$LOCAL"
+  # Local main is now 3 commits behind origin/main (without fetching first).
+  if cut_worktree_from_origin_main "feat/wt2" "$SANDBOX/wt2" >/dev/null 2>&1; then
+    local parent origin_now
+    parent=$(git -C "$SANDBOX/wt2" rev-parse HEAD)
+    origin_now=$(git rev-parse origin/main)
+    if [[ "$parent" == "$origin_now" && "$parent" != "$stale_sha" ]]; then
+      pass "contract_stale_local_main"
+    else
+      fail "contract_stale_local_main: parent=$parent origin_now=$origin_now stale=$stale_sha"
+    fi
+  else
+    fail "contract_stale_local_main: cut function failed"
+  fi
+  cd "$REPO_ROOT"
+  rm -rf "$SANDBOX"
+}
+
+test_contract_ignores_local_only_commits() {
+  make_sandbox
+  cd "$LOCAL"
+  git commit --allow-empty -m "local-only" --quiet
+  local local_only_sha
+  local_only_sha=$(git rev-parse main)
+  if cut_worktree_from_origin_main "feat/wt3" "$SANDBOX/wt3" >/dev/null 2>&1; then
+    local parent expected
+    parent=$(git -C "$SANDBOX/wt3" rev-parse HEAD)
+    expected=$(git rev-parse origin/main)
+    if [[ "$parent" == "$expected" && "$parent" != "$local_only_sha" ]]; then
+      pass "contract_ignores_local_only_commits"
+    else
+      fail "contract_ignores_local_only_commits: parent=$parent expected=$expected local_only=$local_only_sha"
+    fi
+  else
+    fail "contract_ignores_local_only_commits: cut function failed"
+  fi
+  cd "$REPO_ROOT"
+  rm -rf "$SANDBOX"
+}
+
+test_contract_aborts_when_fetch_fails() {
+  make_sandbox
+  cd "$LOCAL"
+  git remote set-url origin "$SANDBOX/nonexistent.git"
+  if cut_worktree_from_origin_main "feat/wt4" "$SANDBOX/wt4" >/dev/null 2>&1; then
+    fail "contract_aborts_when_fetch_fails: cut function should have returned non-zero"
+  else
+    if [[ ! -d "$SANDBOX/wt4" ]] && [[ -z "$(git branch --list 'feat/wt4')" ]]; then
+      pass "contract_aborts_when_fetch_fails (no branch or worktree created)"
+    else
+      fail "contract_aborts_when_fetch_fails: branch or worktree was created despite fetch failure"
+    fi
+  fi
+  cd "$REPO_ROOT"
+  rm -rf "$SANDBOX"
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+echo "Running issue #191 worktree.baseRef pin + contract-analog tests..."
+test_settings_file_present
+test_settings_parses_as_json
+test_worktree_base_ref_pinned_to_fresh
+test_worktree_base_ref_literal_string_present
+test_contract_current_local_main
+test_contract_stale_local_main
+test_contract_ignores_local_only_commits
+test_contract_aborts_when_fetch_fails
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
## Summary

- Pin `worktree.baseRef: "fresh"` in `.claude/settings.json` so `EnterWorktree` (provided by the Claude Code harness, not this repo) cuts new worktrees from `origin/<default-branch>` regardless of any future change to the harness default. Closes the implicit-default gap left after #176 / #188.
- Add `scripts/tests/test_worktree_base_setting.sh` with 8 tests in two layers: settings-pin assertions (`jq` + literal-string grep) and a contract-analog sandbox (mirroring the four `test_implement_branch_cut.sh` scenarios via `git fetch origin main && git worktree add -b <name> <dir> origin/main`).
- Wire the new test into `make check`, and add a `Branch-cut invariants` subsection to `docs/developer/SAFETY.md` pointing to both the bash invariant and the contract pin.

The post-`EnterWorktree` "Branch base" block in `implement.md` / `review.md` is intentionally **not** removed — defense-in-depth retained per the engineering-committee synthesis on issue #191.

## Test plan

- [x] `bash scripts/tests/test_worktree_base_setting.sh` — 8/8 PASS
- [x] `bash scripts/tests/test_implement_branch_cut.sh` — 6/6 PASS (no regression)
- [x] Negative-mutation smoke test: removed `worktree` block from `.claude/settings.json` → 2 FAILs with remediation message, exit 1; restored → 8/8 PASS, exit 0
- [x] `cd api && uv run ruff check .` — All checks passed
- [x] `cd web && pnpm lint` — No ESLint warnings or errors; Prettier clean
- [x] `cd web && pnpm typecheck` — `tsc --noEmit` clean
- [x] `jq empty .claude/settings.json` — valid JSON; `.worktree.baseRef == "fresh"`
- [ ] CI runs the full `make check` (api test, web test, web build) on this branch

Closes #191. Follow-up to #176 / #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
