### PR TITLE
ops(#185): LFS bandwidth watch — posture guard, snapshot helper, runbook + day-30 cron

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,19 @@
+# Workflow conventions
+
+## Git LFS posture
+
+The v1 UI catalog under `docs/legacy/v1-ui-catalog/` is stored via Git LFS (see [ADR-010](../../docs/adr/010-v1-ui-catalog-storage.md)). To keep monthly LFS bandwidth well under the free-tier 1 GB quota, workflows that do not need to read the catalog binaries must skip LFS smudging.
+
+`actions/checkout@v4` defaults to `lfs: false`, so omitting the key is sufficient. Workflows that touch the catalog and explicitly set `lfs: false` are belt-and-suspenders.
+
+A workflow that legitimately needs the catalog binaries — e.g. a hypothetical visual-regression check — must declare why on the same line:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    lfs: true  # rationale: visual diff requires the actual WebP bytes
+```
+
+`scripts/check-workflow-lfs-posture.sh` enforces this convention and runs in `make check`. Reviewers must reject any PR that flips `lfs: true` without a same-line `# rationale: <text>` comment.
+
+See [`docs/operations/lfs-bandwidth-watch.md`](../../docs/operations/lfs-bandwidth-watch.md) for the operational runbook covering the 30-day watch period that follows the catalog merge.

--- a/.github/workflows/lfs-bandwidth-day30-reminder.yml
+++ b/.github/workflows/lfs-bandwidth-day30-reminder.yml
@@ -1,0 +1,62 @@
+name: LFS bandwidth day-30 reminder
+
+# One-shot reminder for issue #185. Fires on 2026-06-07 17:00 UTC and posts
+# a comment prompting the operator to run `scripts/lfs-bandwidth-snapshot.sh`
+# and post the day-30 report. Delete this workflow file in the closure PR
+# once the report has been posted. See docs/operations/lfs-bandwidth-watch.md
+# for the runbook.
+#
+# The cron field below uses standard 5-field syntax which fires every June 7
+# at 17:00 UTC, not just in 2026. The "Verify date" step short-circuits any
+# subsequent annual firings — belt-and-suspenders against forgetting to delete
+# this workflow on closure day.
+
+on:
+  schedule:
+    - cron: '0 17 7 6 *'
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify date is 2026-06-07
+        id: date-guard
+        run: |
+          today=$(date -u +%F)
+          echo "today=$today" >> "$GITHUB_OUTPUT"
+          if [[ "$today" != "2026-06-07" ]]; then
+            echo "Today is $today, not the one-shot target 2026-06-07. Skipping."
+            echo "fire=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "fire=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Post reminder comment on issue #185
+        if: steps.date-guard.outputs.fire == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment 185 --repo "${{ github.repository }}" --body "$(cat <<'BODY'
+          **Reminder — 30-day Git LFS bandwidth watch window has closed**
+
+          Per [`docs/operations/lfs-bandwidth-watch.md`](https://github.com/suniljames/COREcare-v2/blob/main/docs/operations/lfs-bandwidth-watch.md), the 30-day post-#107 watch closes today (2026-06-07).
+
+          Next steps for the operator:
+
+          1. Run `scripts/lfs-bandwidth-snapshot.sh` to print the day-30 closure template pre-filled with today's date.
+          2. Read the GitHub LFS bandwidth meter at https://github.com/settings/billing → Git LFS Data.
+          3. Take a screenshot of the panel.
+          4. Fill the TBDs in the template and post as a comment on this issue, attaching the screenshot.
+          5. Either close as resolved (no threshold approached) or link the ADR-010 escalation follow-up.
+          6. In the closure PR, delete `.github/workflows/lfs-bandwidth-day30-reminder.yml` — the one-shot reminder is no longer needed.
+
+          _This comment was posted automatically by `.github/workflows/lfs-bandwidth-day30-reminder.yml`._
+          BODY
+          )"

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ check: ## Run all quality gates (pre-PR)
 	$(MAKE) -C web build
 	bash scripts/tests/test_implement_branch_cut.sh
 	bash scripts/tests/test_pipeline_state_gate.sh
+	bash scripts/tests/test_check_workflow_lfs_posture.sh
+	bash scripts/tests/test_lfs_bandwidth_snapshot.sh
+	bash scripts/check-workflow-lfs-posture.sh
 
 # --- Individual targets ---
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,0 +1,15 @@
+# Operations runbooks
+
+Operator-facing procedures for time-bounded watches, escalations, and routine ops tasks. Each runbook in this directory is self-contained: open it, follow the steps, post the templated comment.
+
+## Active runbooks
+
+| Runbook | Window | Issue |
+|---|---|---|
+| [Git LFS bandwidth watch](lfs-bandwidth-watch.md) | 2026-05-07 → 2026-06-07 | [#185](https://github.com/suniljames/COREcare-v2/issues/185) |
+
+## Conventions
+
+- Runbooks use second-person imperative voice. Operators reading at 11pm need clear action verbs, not narrative.
+- Every runbook names its closure date and its archive policy. Watches that have closed are moved to `archive/` rather than deleted, so the audit trail stays in git.
+- Templates inside runbooks are copy-paste-ready. Where today's date or other dynamic fields apply, prefer a shell helper that prints the pre-filled template (see `scripts/lfs-bandwidth-snapshot.sh`).

--- a/docs/operations/lfs-bandwidth-watch.md
+++ b/docs/operations/lfs-bandwidth-watch.md
@@ -1,0 +1,126 @@
+# Runbook — Git LFS bandwidth watch (post-#107)
+
+## Why this exists
+
+The v1 UI screenshot catalog committed in [#107](https://github.com/suniljames/COREcare-v2/issues/107) ships 168 WebP files via Git LFS. [ADR-010](../adr/010-v1-ui-catalog-storage.md) names GitHub LFS bandwidth quota as a foreseeable constraint and reserves Alternative B (separate static site / `gh-pages` branch / new repo) as the escalation path. [Issue #185](https://github.com/suniljames/COREcare-v2/issues/185) is the 30-day operational watch period that confirms or refutes the constraint and decides whether to escalate.
+
+This runbook is the operator-facing companion to that issue. Follow it weekly through 2026-06-07.
+
+## How to read the meter
+
+GitHub does not expose per-repo Git LFS bandwidth via API for personal accounts. The Settings → Billing → "Git LFS Data" web panel is the only authoritative source. Read it manually.
+
+1. Open [`https://github.com/settings/billing`](https://github.com/settings/billing).
+2. Scroll to the **Git LFS Data** section.
+3. Record three numbers and one date:
+   - **Bandwidth used this period** (MB)
+   - **Bandwidth quota** (MB; expect 1024 MB / 1 GB on free tier)
+   - **Reset date** for the current billing period
+4. Take a screenshot of the Git LFS Data panel. Save it locally — it is the audit trail attached to every yellow-flag, red-flag, or closure comment.
+
+The helper `scripts/lfs-bandwidth-snapshot.sh` prints these instructions plus a copy-paste day-30 closure template. It does not call the network.
+
+## Decision tree
+
+After every weekly read, evaluate the numbers in this order. Stop at the first match.
+
+### Trigger A — single CI run > 100 MB LFS bandwidth
+
+If a single workflow run consumed more than 100 MB of LFS bandwidth, find the workflow:
+
+1. Open [`https://github.com/suniljames/COREcare-v2/actions`](https://github.com/suniljames/COREcare-v2/actions) and inspect the recent run with the spike.
+2. Confirm the offending step is `actions/checkout` with `lfs: true` (explicit or implicit).
+3. PR a fix that either sets `lfs: false` or adds `# rationale: <text>` per the convention enforced by `scripts/check-workflow-lfs-posture.sh`.
+4. Stay in #185 — the fix lives in this issue's PR series, not a follow-up.
+
+### Trigger B — cumulative monthly > 500 MB (yellow flag)
+
+Post a yellow-flag comment on issue #185 using the template below. This is an early warning, not an escalation. Continue weekly reads.
+
+### Trigger C — cumulative monthly > 800 MB OR trending to exceed 1 GB
+
+Escalate per [ADR-010](../adr/010-v1-ui-catalog-storage.md) Alternative B. Post the red-flag comment on issue #185 using the template below, then file a follow-up implementation issue that evaluates three options:
+
+- **(a)** Move the catalog to a `gh-pages` branch in this repo with LFS removed from the new branch
+- **(b)** Move the catalog to a new repo `coreacare-v1-catalog/` with its own LFS quota
+- **(c)** Build the catalog as a static-site artifact (Vercel / Netlify) and remove from this repo
+
+The follow-up issue picks one. This runbook does not.
+
+### None of the above
+
+Log the reading locally (date + bandwidth + quota + reset day). No action required. Move on.
+
+## Templates
+
+### Yellow-flag comment
+
+```markdown
+**Yellow flag — Git LFS bandwidth crossed 50% of free-tier quota**
+
+**Reading taken on:** YYYY-MM-DD
+**Bandwidth used (account-wide):** XXX MB / 1024 MB (XX%)
+**Reset day:** YYYY-MM-DD
+**Largest single CI run since last reading:** XX MB (workflow: NAME)
+
+No escalation yet — continuing weekly reads. Will reassess at next reading or if Trigger C threshold is crossed.
+
+_Screenshot of Settings → Billing → Git LFS Data attached below._
+```
+
+### Red-flag comment
+
+```markdown
+**Red flag — Git LFS bandwidth on track to exceed free-tier quota**
+
+**Reading taken on:** YYYY-MM-DD
+**Bandwidth used (account-wide):** XXX MB / 1024 MB (XX%)
+**Reset day:** YYYY-MM-DD
+**Trend:** projected to exceed 1 GB before reset
+
+Escalating per ADR-010 Alternative B. Filing follow-up issue to evaluate (a) `gh-pages` branch / (b) new repo / (c) static-site artifact.
+
+Follow-up issue: _link_
+
+_Screenshot of Settings → Billing → Git LFS Data attached below._
+```
+
+### Day-30 closure comment
+
+Run `scripts/lfs-bandwidth-snapshot.sh` to print this template pre-filled with today's date and the issue's static fields. Edit the TBDs and post.
+
+```markdown
+**30-day Git LFS bandwidth report** for [`docs/legacy/v1-ui-catalog/`](https://github.com/suniljames/COREcare-v2/tree/main/docs/legacy/v1-ui-catalog) (post-#107 merge).
+
+**Period:** 2026-05-07 → 2026-06-07
+**Reading taken on:** YYYY-MM-DD
+**Bandwidth used (account-wide):** _TBD_ MB / 1024 MB free-tier quota
+**Largest single CI run observed:** _TBD_ MB (workflow: _TBD_)
+**Reset day(s) within window:** _TBD_
+
+_Screenshot of Settings → Billing → Git LFS Data attached below._
+
+**Outcome:** [Threshold not approached → closing as resolved.] *or* [Yellow flag triggered on _date_; mitigation _link_.] *or* [Red flag → ADR-010 follow-up filed at _link_.]
+```
+
+## Reset-day caveat
+
+GitHub's LFS bandwidth meter resets on the account's billing-period reset day (typically the account creation anniversary). If the reset day falls **inside** the 30-day watch window for #185, report bandwidth from both sides of the reset:
+
+```
+**Bandwidth used:** XXX MB this period (since YYYY-MM-DD reset) + YYY MB previous period (YYYY-MM-DD to YYYY-MM-DD)
+```
+
+Do not sum the two periods into a single "30-day total" — the quota is per-period, and the trend that matters for escalation is the within-period rate, not the cross-reset cumulative.
+
+## Cleanup after closure
+
+When #185 closes, delete `.github/workflows/lfs-bandwidth-day30-reminder.yml` in the closure PR. The cron is one-shot and serves no purpose after the day-30 report is posted.
+
+## Related
+
+- [ADR-010 — v1 UI Screenshot Catalog Storage](../adr/010-v1-ui-catalog-storage.md)
+- [Issue #107 — Phase 2 catalog merge](https://github.com/suniljames/COREcare-v2/issues/107)
+- [Issue #185 — this watch period](https://github.com/suniljames/COREcare-v2/issues/185)
+- [`scripts/check-workflow-lfs-posture.sh`](../../scripts/check-workflow-lfs-posture.sh)
+- [`scripts/lfs-bandwidth-snapshot.sh`](../../scripts/lfs-bandwidth-snapshot.sh)

--- a/scripts/check-workflow-lfs-posture.sh
+++ b/scripts/check-workflow-lfs-posture.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Scans GitHub Actions workflow YAML for `lfs: true` set on `actions/checkout`
+# steps that lack a same-line `# rationale: <text>` comment.
+#
+# Per ADR-010 and issue #185, the v1 UI catalog is stored via Git LFS and
+# workflows that do not need to read the binaries skip LFS smudging. Any
+# workflow that legitimately opts into LFS smudging must declare why on the
+# same line as `lfs: true`. This guard enforces the declaration so reviewers
+# can reject silent flips of the convention.
+#
+# Usage:
+#   scripts/check-workflow-lfs-posture.sh                  # scan .github/workflows/*.yml
+#   scripts/check-workflow-lfs-posture.sh <file> [<file>…] # scan named files
+#
+# Exit codes:
+#   0  no violations
+#   1  one or more files violate the rationale-comment requirement
+#   2  usage error (e.g. file not found)
+
+set -u
+
+if [[ $# -eq 0 ]]; then
+  shopt -s nullglob
+  files=(.github/workflows/*.yml .github/workflows/*.yaml)
+  if [[ ${#files[@]} -eq 0 ]]; then
+    # No workflows is not a failure; nothing to enforce.
+    exit 0
+  fi
+else
+  files=("$@")
+  for f in "${files[@]}"; do
+    if [[ ! -f "$f" ]]; then
+      echo "ERROR: file not found: $f" >&2
+      exit 2
+    fi
+  done
+fi
+
+violations=$(awk '
+  function trim(s) {
+    sub(/^[[:space:]]+/, "", s)
+    sub(/[[:space:]]+$/, "", s)
+    return s
+  }
+  FNR == 1 { last_uses = "" }
+  /^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*/ {
+    line = $0
+    sub(/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*/, "", line)
+    sub(/[[:space:]]*#.*$/, "", line)
+    last_uses = trim(line)
+    next
+  }
+  /^[[:space:]]*lfs:[[:space:]]*(true|false)([[:space:]]|$|#)/ {
+    if (last_uses ~ /^actions\/checkout(@|$)/) {
+      val = $0
+      sub(/^[[:space:]]*lfs:[[:space:]]*/, "", val)
+      if (match(val, /^(true|false)/)) {
+        v = substr(val, RSTART, RLENGTH)
+        rest = substr(val, RSTART + RLENGTH)
+        if (v == "true") {
+          if (rest !~ /#[[:space:]]*rationale:[[:space:]]*[^[:space:]]/) {
+            print FILENAME ":" FNR ": lfs: true on actions/checkout requires same-line `# rationale: <text>` comment"
+          }
+        }
+      }
+    }
+    next
+  }
+' "${files[@]}")
+
+if [[ -n "$violations" ]]; then
+  echo "$violations" >&2
+  exit 1
+fi
+exit 0

--- a/scripts/lfs-bandwidth-snapshot.sh
+++ b/scripts/lfs-bandwidth-snapshot.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Prints the operator procedure for reading Git LFS bandwidth from
+# GitHub Settings -> Billing, plus a copy-paste comment template for
+# the 30-day post-#107 bandwidth report on issue #185.
+#
+# This script does NOT make any network calls. The bandwidth meter for
+# personal-account repos is web-only; the operator transcribes the
+# reading into the comment template manually. See ADR-010, issue #185
+# System Architect review, and docs/operations/lfs-bandwidth-watch.md
+# for the full rationale.
+#
+# Usage:
+#   scripts/lfs-bandwidth-snapshot.sh
+#   scripts/lfs-bandwidth-snapshot.sh | gh issue comment 185 --repo suniljames/COREcare-v2 --body-file -
+
+set -u
+
+today=$(date +%F)
+
+cat <<EOF
+============================================================
+ Git LFS bandwidth snapshot — operator procedure
+ Today: $today
+============================================================
+
+STEP 1 — Open the GitHub billing panel for your account:
+  https://github.com/settings/billing
+
+STEP 2 — Locate the "Git LFS Data" section. Record:
+  - bandwidth used this period (MB)
+  - bandwidth quota (MB; expect 1024 MB / 1 GB on free tier)
+  - reset date for the current billing period
+
+STEP 3 — Take a screenshot of the panel. Attach to the report comment.
+
+STEP 4 — Copy the template below, fill the TBDs, post via:
+  gh issue comment 185 --repo suniljames/COREcare-v2 --body-file <path>
+
+See docs/operations/lfs-bandwidth-watch.md for the full runbook,
+including yellow-flag and red-flag templates and the reset-day caveat.
+
+============================================================
+ Day-30 report comment template
+============================================================
+**30-day Git LFS bandwidth report** for [\`docs/legacy/v1-ui-catalog/\`](https://github.com/suniljames/COREcare-v2/tree/main/docs/legacy/v1-ui-catalog) (post-#107 merge).
+
+**Period:** 2026-05-07 → 2026-06-07
+**Reading taken on:** $today
+**Bandwidth used (account-wide):** _TBD_ MB / 1024 MB free-tier quota
+**Largest single CI run observed:** _TBD_ MB (workflow: _TBD_)
+**Reset day(s) within window:** _TBD_
+
+_Screenshot of Settings → Billing → Git LFS Data attached below._
+
+**Outcome:** [Threshold not approached → closing as resolved.] *or* [Yellow flag triggered on _date_; mitigation _link_.] *or* [Red flag → ADR-010 follow-up filed at _link_.]
+EOF

--- a/scripts/tests/fixtures/lfs-posture/01-rationale-pass.yml
+++ b/scripts/tests/fixtures/lfs-posture/01-rationale-pass.yml
@@ -1,0 +1,10 @@
+name: Test fixture — lfs:true with rationale
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true  # rationale: catalog viewer must read WebPs
+      - run: echo ok

--- a/scripts/tests/fixtures/lfs-posture/02-no-rationale-fail.yml
+++ b/scripts/tests/fixtures/lfs-posture/02-no-rationale-fail.yml
@@ -1,0 +1,10 @@
+name: Test fixture — lfs:true without rationale
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - run: echo ok

--- a/scripts/tests/fixtures/lfs-posture/03-explicit-false-pass.yml
+++ b/scripts/tests/fixtures/lfs-posture/03-explicit-false-pass.yml
@@ -1,0 +1,10 @@
+name: Test fixture — lfs:false explicit
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+      - run: echo ok

--- a/scripts/tests/fixtures/lfs-posture/04-no-key-pass.yml
+++ b/scripts/tests/fixtures/lfs-posture/04-no-key-pass.yml
@@ -1,0 +1,8 @@
+name: Test fixture — no lfs key
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo ok

--- a/scripts/tests/fixtures/lfs-posture/05-non-checkout-ignored-pass.yml
+++ b/scripts/tests/fixtures/lfs-posture/05-non-checkout-ignored-pass.yml
@@ -1,0 +1,14 @@
+name: Test fixture — lfs key under non-checkout action
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: false
+      - uses: example-org/some-other-action@v1
+        with:
+          lfs: true
+          other-input: yes
+      - run: echo ok

--- a/scripts/tests/fixtures/lfs-snapshot-expected.txt
+++ b/scripts/tests/fixtures/lfs-snapshot-expected.txt
@@ -1,0 +1,35 @@
+============================================================
+ Git LFS bandwidth snapshot — operator procedure
+ Today: 2026-05-08
+============================================================
+
+STEP 1 — Open the GitHub billing panel for your account:
+  https://github.com/settings/billing
+
+STEP 2 — Locate the "Git LFS Data" section. Record:
+  - bandwidth used this period (MB)
+  - bandwidth quota (MB; expect 1024 MB / 1 GB on free tier)
+  - reset date for the current billing period
+
+STEP 3 — Take a screenshot of the panel. Attach to the report comment.
+
+STEP 4 — Copy the template below, fill the TBDs, post via:
+  gh issue comment 185 --repo suniljames/COREcare-v2 --body-file <path>
+
+See docs/operations/lfs-bandwidth-watch.md for the full runbook,
+including yellow-flag and red-flag templates and the reset-day caveat.
+
+============================================================
+ Day-30 report comment template
+============================================================
+**30-day Git LFS bandwidth report** for [`docs/legacy/v1-ui-catalog/`](https://github.com/suniljames/COREcare-v2/tree/main/docs/legacy/v1-ui-catalog) (post-#107 merge).
+
+**Period:** 2026-05-07 → 2026-06-07
+**Reading taken on:** 2026-05-08
+**Bandwidth used (account-wide):** _TBD_ MB / 1024 MB free-tier quota
+**Largest single CI run observed:** _TBD_ MB (workflow: _TBD_)
+**Reset day(s) within window:** _TBD_
+
+_Screenshot of Settings → Billing → Git LFS Data attached below._
+
+**Outcome:** [Threshold not approached → closing as resolved.] *or* [Yellow flag triggered on _date_; mitigation _link_.] *or* [Red flag → ADR-010 follow-up filed at _link_.]

--- a/scripts/tests/test_check_workflow_lfs_posture.sh
+++ b/scripts/tests/test_check_workflow_lfs_posture.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Tests for scripts/check-workflow-lfs-posture.sh.
+#
+# Run from repo root: bash scripts/tests/test_check_workflow_lfs_posture.sh
+#
+# Five fixture cases enumerated in the issue #185 Test Specification:
+#   01 — lfs: true with same-line `# rationale: …` comment   → PASS
+#   02 — lfs: true without rationale comment                 → FAIL
+#   03 — lfs: false                                          → PASS
+#   04 — no lfs key set                                      → PASS
+#   05 — lfs: key under a non-actions/checkout step          → PASS
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+GUARD="$REPO_ROOT/scripts/check-workflow-lfs-posture.sh"
+FIXTURES="$SCRIPT_DIR/fixtures/lfs-posture"
+
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local description="$1"
+  local expected_code="$2"
+  shift 2
+  local actual_output
+  actual_output=$("$@" 2>&1 || true)
+  local actual_code
+  "$@" >/dev/null 2>&1
+  actual_code=$?
+  if [[ "$actual_code" == "$expected_code" ]]; then
+    echo "  PASS — $description (exit $actual_code)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description (expected exit $expected_code, got $actual_code)"
+    echo "    output: $actual_output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_output_contains() {
+  local description="$1"
+  local needle="$2"
+  shift 2
+  local actual_output
+  actual_output=$("$@" 2>&1 || true)
+  if echo "$actual_output" | grep -qF "$needle"; then
+    echo "  PASS — $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $description (output did not contain: $needle)"
+    echo "    actual: $actual_output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "== check-workflow-lfs-posture.sh tests =="
+
+[[ -x "$GUARD" ]] || { echo "FAIL — guard script not executable at $GUARD"; exit 1; }
+[[ -d "$FIXTURES" ]] || { echo "FAIL — fixtures dir missing at $FIXTURES"; exit 1; }
+
+# Single-fixture cases.
+assert_exit "01 lfs:true + rationale → exit 0" 0 \
+  "$GUARD" "$FIXTURES/01-rationale-pass.yml"
+
+assert_exit "02 lfs:true + no rationale → exit 1" 1 \
+  "$GUARD" "$FIXTURES/02-no-rationale-fail.yml"
+
+assert_output_contains "02 failure message identifies file:line" \
+  "02-no-rationale-fail.yml" \
+  "$GUARD" "$FIXTURES/02-no-rationale-fail.yml"
+
+assert_output_contains "02 failure message names the rationale requirement" \
+  "rationale" \
+  "$GUARD" "$FIXTURES/02-no-rationale-fail.yml"
+
+assert_exit "03 lfs:false explicit → exit 0" 0 \
+  "$GUARD" "$FIXTURES/03-explicit-false-pass.yml"
+
+assert_exit "04 no lfs key → exit 0" 0 \
+  "$GUARD" "$FIXTURES/04-no-key-pass.yml"
+
+assert_exit "05 lfs:true under non-checkout action → exit 0 (ignored)" 0 \
+  "$GUARD" "$FIXTURES/05-non-checkout-ignored-pass.yml"
+
+# Multi-file cases.
+assert_exit "multi-file all-pass → exit 0" 0 \
+  "$GUARD" \
+  "$FIXTURES/01-rationale-pass.yml" \
+  "$FIXTURES/03-explicit-false-pass.yml" \
+  "$FIXTURES/04-no-key-pass.yml" \
+  "$FIXTURES/05-non-checkout-ignored-pass.yml"
+
+assert_exit "multi-file with one bad → exit 1" 1 \
+  "$GUARD" \
+  "$FIXTURES/01-rationale-pass.yml" \
+  "$FIXTURES/02-no-rationale-fail.yml"
+
+# Default scan (no args) runs against the repo's own .github/workflows/.
+# All current workflows must already be compliant.
+assert_exit "default scan of repo workflows → exit 0" 0 \
+  bash -c "cd '$REPO_ROOT' && '$GUARD'"
+
+# Usage error path.
+assert_exit "missing-file argument → exit 2" 2 \
+  "$GUARD" "$FIXTURES/this-file-does-not-exist.yml"
+
+echo ""
+echo "== Summary: $PASS passed, $FAIL failed =="
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/tests/test_lfs_bandwidth_snapshot.sh
+++ b/scripts/tests/test_lfs_bandwidth_snapshot.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Tests for scripts/lfs-bandwidth-snapshot.sh.
+#
+# Run from repo root: bash scripts/tests/test_lfs_bandwidth_snapshot.sh
+#
+# Two assertions per the #185 Test Specification:
+#   1. Output golden test — stdout matches fixtures/lfs-snapshot-expected.txt
+#      after both sides are normalized via:
+#        sed -E 's/[0-9]{4}-[0-9]{2}-[0-9]{2}/YYYY-MM-DD/g'
+#      No other normalization is permitted.
+#   2. No-network assertion — `bash -x …` trace plus stdout must not contain
+#      any of: curl, wget, gh api, nc<space>, ssh<space>.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SNAPSHOT="$REPO_ROOT/scripts/lfs-bandwidth-snapshot.sh"
+EXPECTED="$SCRIPT_DIR/fixtures/lfs-snapshot-expected.txt"
+
+PASS=0
+FAIL=0
+
+echo "== lfs-bandwidth-snapshot.sh tests =="
+
+[[ -x "$SNAPSHOT" ]] || { echo "FAIL — snapshot script not executable at $SNAPSHOT"; exit 1; }
+[[ -f "$EXPECTED" ]] || { echo "FAIL — golden file missing at $EXPECTED"; exit 1; }
+
+# --- Golden output test ---
+
+normalize() {
+  sed -E 's/[0-9]{4}-[0-9]{2}-[0-9]{2}/YYYY-MM-DD/g'
+}
+
+actual_normalized=$("$SNAPSHOT" | normalize)
+expected_normalized=$(normalize < "$EXPECTED")
+
+if [[ "$actual_normalized" == "$expected_normalized" ]]; then
+  echo "  PASS — stdout matches golden fixture (after ISO-date normalization)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL — stdout differs from golden fixture"
+  echo "  --- diff (expected | actual) ---"
+  diff <(echo "$expected_normalized") <(echo "$actual_normalized") || true
+  echo "  --- end diff ---"
+  FAIL=$((FAIL + 1))
+fi
+
+# --- No-network assertion ---
+# Run with `bash -x` and merge stderr into stdout. The combined stream must
+# not contain any of the network primitives we explicitly forbid.
+
+trace=$(bash -x "$SNAPSHOT" 2>&1 || true)
+forbidden_pattern='(curl|wget|gh api|nc |ssh )'
+
+if echo "$trace" | grep -qE "$forbidden_pattern"; then
+  echo "  FAIL — bash -x trace or stdout contains a forbidden network primitive"
+  echo "  --- offending lines ---"
+  echo "$trace" | grep -nE "$forbidden_pattern" || true
+  echo "  --- end offending lines ---"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS — no curl/wget/gh-api/nc/ssh in trace or stdout"
+  PASS=$((PASS + 1))
+fi
+
+echo ""
+echo "== Summary: $PASS passed, $FAIL failed =="
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #185

## Summary

- Adds `scripts/check-workflow-lfs-posture.sh` — fails any workflow that opts into `lfs: true` on `actions/checkout` without a same-line `# rationale: <text>` comment. Wired into `make check` and runs on every PR. All six existing repo workflows pass the default scan.
- Adds `scripts/lfs-bandwidth-snapshot.sh` — prints the manual operator procedure for reading `https://github.com/settings/billing` → Git LFS Data, plus a copy-paste day-30 closure template pre-filled with today's date. No network calls; the no-curl/wget/gh-api/nc/ssh assertion is enforced by the test.
- Adds `docs/operations/lfs-bandwidth-watch.md` — operator runbook covering the 30-day watch period that follows the #107 catalog merge. Decision tree with three thresholds (Trigger A: single CI run > 100 MB; Trigger B yellow: monthly > 500 MB; Trigger C red: monthly > 800 MB or trending > 1 GB), copy-paste templates, and reset-day caveat.
- Adds `docs/operations/README.md` — index for runbooks-by-closure-date.
- Adds `.github/workflows/lfs-bandwidth-day30-reminder.yml` — one-shot cron firing on 2026-06-07 17:00 UTC that posts a reminder comment on issue #185. Includes a date guard against subsequent annual firings; deleted in the closure PR.
- Adds `.github/workflows/README.md` — documents the LFS-rationale convention so reviewers can point to a written rule.

The committee design synthesis is in [issue #185](https://github.com/suniljames/COREcare-v2/issues/185); the test specification flowed directly from the EM synthesis.

## Test Plan

- [x] `bash scripts/tests/test_check_workflow_lfs_posture.sh` — 11/11 PASS (5 fixture cases + multi-file cases + default scan + usage error)
- [x] `bash scripts/tests/test_lfs_bandwidth_snapshot.sh` — 2/2 PASS (golden output + no-network assertion)
- [x] `bash scripts/check-workflow-lfs-posture.sh` (default scan of repo workflows) — exit 0
- [x] `bash scripts/tests/test_implement_branch_cut.sh` — 6/6 PASS (existing pipeline test)
- [x] `bash scripts/tests/test_pipeline_state_gate.sh` — 30/30 PASS (existing pipeline test)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lfs-bandwidth-day30-reminder.yml'))"` — parses
- [x] All runbook relative links resolve to existing files
- [ ] CI passes
- [ ] Docker health check passes (this PR touches no api/web surface; deploy verification is for completeness only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)