### PR TITLE
test(#191): apply two follow-up NIT fixes from PR #230 review

### DIFF
--- a/scripts/tests/test_implement_branch_cut.sh
+++ b/scripts/tests/test_implement_branch_cut.sh
@@ -23,6 +23,17 @@ FAIL=0
 pass() { echo "  PASS — $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL — $1"; FAIL=$((FAIL + 1)); }
 
+# Defensive cleanup: per-test bodies do `rm -rf "$SANDBOX"` on the success
+# path, but if a test is interrupted (Ctrl-C, SIGTERM) the in-flight sandbox
+# would otherwise survive until the OS reaper. This trap backstops that by
+# removing whatever $SANDBOX currently points at on any script exit.
+cleanup_sandbox() {
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX" 2>/dev/null || true
+  fi
+}
+trap cleanup_sandbox EXIT INT TERM
+
 # ---------------------------------------------------------------------------
 # The function under test mirrors the bash block embedded in implement.md /
 # review.md. The sync tests below assert the markdown files contain the same

--- a/scripts/tests/test_worktree_base_setting.sh
+++ b/scripts/tests/test_worktree_base_setting.sh
@@ -19,6 +19,18 @@
 # depth guard); this one tests the harness contract surface we depend on.
 #
 # Run from repo root: bash scripts/tests/test_worktree_base_setting.sh
+#
+# Negative-mutation smoke test (run before any PR that touches this file or
+# .claude/settings.json):
+#
+#   cp .claude/settings.json /tmp/settings.bak
+#   jq 'del(.worktree, ._comment_worktree)' .claude/settings.json > /tmp/m.json
+#   cp /tmp/m.json .claude/settings.json
+#   bash scripts/tests/test_worktree_base_setting.sh; echo "EXIT=$?"
+#   # → expect EXIT=1 with two FAILs
+#   cp /tmp/settings.bak .claude/settings.json
+#   bash scripts/tests/test_worktree_base_setting.sh; echo "EXIT=$?"
+#   # → expect EXIT=0 with all 8 PASS
 
 set -u
 
@@ -31,6 +43,17 @@ FAIL=0
 
 pass() { echo "  PASS — $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL — $1"; FAIL=$((FAIL + 1)); }
+
+# Defensive cleanup: per-test bodies do `rm -rf "$SANDBOX"` on the success
+# path, but if a test is interrupted (Ctrl-C, SIGTERM) the in-flight sandbox
+# would otherwise survive until the OS reaper. This trap backstops that by
+# removing whatever $SANDBOX currently points at on any script exit.
+cleanup_sandbox() {
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX" 2>/dev/null || true
+  fi
+}
+trap cleanup_sandbox EXIT INT TERM
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "SKIP — jq not installed; tests require jq for JSON assertions"


### PR DESCRIPTION
## Summary

Two minor hygiene improvements addressing NITs from the PR #230 engineering-committee review (originally non-blocking; raised as a follow-up request after merge).

- **SRE NIT — trap-based cleanup.** Added `trap cleanup_sandbox EXIT INT TERM` to both `test_implement_branch_cut.sh` and `test_worktree_base_setting.sh`. The per-test bodies still `rm -rf "$SANDBOX"` on the success path; the trap backstops Ctrl-C / SIGTERM during local development so an in-flight mktemp dir doesn't survive until the OS reaper. Applied to both files for symmetry — both use the same `make_sandbox` pattern.
- **QA NIT 1 — codify smoke-test workflow.** Added a comment block to `test_worktree_base_setting.sh`'s header showing the exact `cp` / `jq del` / re-run sequence that verifies the test fires when the pin is removed. Future maintainers can reproduce the pre-merge verification ritual without reading PR history.

The other six NITs from the PR #230 review are intentionally not addressed here: each was either explicitly self-resolved by the reviewer ("tolerable redundancy — adds context, not noise"; "consistency-within-file beats consistency-across-files"; "the existing project convention is relative paths, so consistency wins"; "Not now"), already resolved in PR conversation (the unchecked CI-passes box was a transient PR-open artifact), or contradicted between reviewers (root-anchored vs. relative `SAFETY.md` links — the Writer's analysis preferred relative).

## Test plan

- [x] `bash scripts/tests/test_implement_branch_cut.sh` — 6/6 PASS
- [x] `bash scripts/tests/test_worktree_base_setting.sh` — 8/8 PASS
- [x] Standalone subshell SIGTERM test: trap fires, sandbox dir removed
- [ ] CI runs the full `make check` on this branch

Follow-up to #191 / PR #230. Closes nothing; the parent issue is already closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
