### PR TITLE
docs(#237): crawler-side prep — SEED_IDS extension + classifyScreenshotRef helper

### DIFF
--- a/tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md
+++ b/tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md
@@ -257,3 +257,99 @@ Do not proceed to Phase 2D until **every** category is yes/N/A.
 
 - If LFS push hits bandwidth limits mid-push: don't `git lfs prune`; check GitHub Settings → Billing → Git LFS for the v2 repo. May need to wait for the next billing cycle or upgrade.
 - If the PHI-audit-artifacts CI gate fails: confirm both `PHI-AUDIT-PRECRAWL-*.md` and `PHI-AUDIT-POSTCRAWL-*.md` were committed in the same PR.
+
+## Phase 2H — Care Manager fixture extension + targeted re-crawl (#237, ~2 hours)
+
+Closes the Care Manager catalog gap: 3 inventory rows whose `screenshot_ref` was `not_screenshotted: no_seed_data` because the test Care Manager account had no assigned `Client` and no submitted `Expense`. Phase 2D's fixture optimised cross-persona coverage of read-heavy surfaces and under-seeded CM-specific relational state.
+
+### Pre-flight (v1 side)
+
+1. `cd ~/Code/COREcare-access && git status` — clean tree, on commit `9738412a6e41064203fc253d9dd2a5c6a9c2e231`.
+2. Read `care_manager/services.py` for `CareManagerService.get_assigned_client_ids` and `care_manager/models.py` (or wherever `CareManagerProfile` is defined) to confirm the `CareManagerProfile`↔`Client` linkage model. Common shapes: an M2M field on `CareManagerProfile`, an explicit through-table (`CareManagerAssignment`), or a FK on `Client`. The fixture row format follows the linkage model exactly — wrong model = `Http404` persists.
+3. Inspect `expenses/models.py` `Expense` and `ExpenseReceipt` for `full_clean()` validation rules, max_length on text fields, custom `save()` hooks, and `post_save` signals. Loaddata fires signals unless they short-circuit on `kwargs.get("raw")` — confirm no signal will hit network during loaddata.
+4. Confirm env-var hygiene per Phase 2E (line 144): `unset DATABASE_URL SENDGRID_API_KEY EMAIL_HOST_PASSWORD QUICKBOOKS_CLIENT_ID QUICKBOOKS_CLIENT_SECRET SENTRY_DSN`. Critical: `EMAIL_HOST_PASSWORD` must be unset so `loaddata`'s shift-assignment signal hits `console.EmailBackend`, not real SMTP.
+
+### Steps
+
+5. Edit `~/Code/COREcare-access/fixtures/v2_catalog_snapshot.json`:
+   - **Link** the existing `CareManagerProfile` (test CM) to the existing `Client` (PK 1) via the confirmed mechanism. **Do not** add the Client to any caregiver/shift/chart relationships — minimise cross-persona blast radius.
+   - **Enrich** the `Client` row to render rich Client Focus UI: DNR flag, ≥1 alert flag, `diagnosis = "[DIAGNOSIS]"`, `address = "[ADDRESS]"`, `phone = "[PHONE]"`. Reuse the existing `ClientFamilyMember` link.
+   - **Add** 1 `Expense` row: `pk = 1`, `submitter = <test_cm_user_pk>`, `client = 1`, `status = "REJECTED"`, `description = "[NOTE_TEXT]"`, `amount = 9.99` (deliberately non-realistic — document the convention in `INVESTIGATIONS.md`).
+   - **Add** 1 `ExpenseReceipt` row: `pk = 1`, `expense = 1`, `original_filename = "[REDACTED].png"`, `image = "<MEDIA-relative-path-to-placeholder.png>"`.
+6. Place a synthetic placeholder PNG at `<MEDIA_ROOT>/<image-path>`: ≤2 KB, flat-grey or "RECEIPT [REDACTED]" synthetic, no identifying marks.
+7. Re-validate fixture loads cleanly:
+   ```bash
+   cd ~/Code/COREcare-access
+   rm -f db.sqlite3
+   DJANGO_SETTINGS_MODULE=elitecare.settings.development ./venv/bin/python manage.py migrate
+   DJANGO_SETTINGS_MODULE=elitecare.settings.development ./venv/bin/python manage.py loaddata fixtures/v2_catalog_snapshot.json
+   ```
+   Exit code 0; reported object count matches the new total in `INVESTIGATIONS.md` Records line.
+8. Re-hash fixture: `shasum -a 256 fixtures/v2_catalog_snapshot.json`.
+9. Update `tools/v1-screenshot-catalog/INVESTIGATIONS.md` "Fixture snapshot" table:
+   - `sha256` row → new hash.
+   - `Records` line → updated total (was 20; new total = 20 + linkage + Expense + ExpenseReceipt = 23 if linkage is a single row).
+   - Add a `placeholder_blobs` row listing the placeholder PNG path + sha256.
+   - Add a paragraph in the table caption describing the linkage model and the `9.99` amount-value convention.
+10. Update `tools/v1-screenshot-catalog/.env` (gitignored, operator-side): `V1_FIXTURE_SHA256=<new-hash>`.
+11. Smoke-test the 3 routes manually via `runserver`:
+    ```bash
+    DJANGO_SETTINGS_MODULE=elitecare.settings.development ./venv/bin/python manage.py runserver 0.0.0.0:8000
+    # In another shell, log in as test CM in a browser, then:
+    curl -I -b cookies.txt http://localhost:8000/care-manager/expenses/1/receipt/1/
+    ```
+    Expect: `/care-manager/` populated; `/care-manager/client/1/` HTTP 200 (no 404); `/care-manager/expenses/1/edit/` HTTP 200 with REJECTED status visible; receipt route HTTP 200 with `Content-Disposition: attachment`.
+
+### Re-crawl
+
+12. Full re-crawl all 5 personas (single canonical fixture; replace existing CM captures + capture 2 new ones). The receipt route is now skipped via inventory `non_html_response`.
+    ```bash
+    cd tools/v1-screenshot-catalog
+    pnpm crawl --output-dir ../../docs/legacy/v1-ui-catalog/
+    ```
+13. Verify CM directory contents: `001-care-manager.{desktop,mobile}.webp` (re-captured, populated), `002-client.{desktop,mobile}.webp` (new), `003-expenses.{desktop,mobile}.webp` (re-captured, populated), `004-submit.{desktop,mobile}.webp` (re-captured), `005-edit.{desktop,mobile}.webp` (new). Receipt route produces no files.
+
+### Reproducibility + PHI gates
+
+14. Second crawl to a temp dir, then reproducibility check:
+    ```bash
+    pnpm crawl --output-dir /tmp/catalog-rerun/
+    bash ../../scripts/check-catalog-reproducibility.sh \
+      ../../docs/legacy/v1-ui-catalog/ /tmp/catalog-rerun/ \
+      --output-dir ../../docs/legacy/v1-ui-catalog/reproducibility-report
+    ```
+    Pixel diff ≤ 0.5%.
+15. Pixel-diff existing AA / CG / FM `.webp` files pre/post (operator: `git diff --stat docs/legacy/v1-ui-catalog/`). Any non-empty image diff → re-PHI-audit those captures.
+16. PHI audit on changed CM `.webp` files + new captions per `PHI-CHECKLIST.md`. Author at `tools/v1-screenshot-catalog/PHI-AUDIT-POSTCRAWL-<date>-cm-recrawl.md`. Zero `no` verdicts.
+
+### Captions, inventory, READMEs
+
+17. Rewrite `docs/legacy/v1-ui-catalog/care-manager/001-care-manager.md` body (now populated state — drop the "with assigned clients (not visible at this seed_state)" hedging block).
+18. Author `docs/legacy/v1-ui-catalog/care-manager/002-client.md` per `CAPTION-STYLE.md` (cite `cm_client_focus`).
+19. Rewrite `docs/legacy/v1-ui-catalog/care-manager/003-expenses.md` body (now lists the new REJECTED expense).
+20. Spot-check `004-submit.md`; rewrite only if rendered content actually changed.
+21. Author `docs/legacy/v1-ui-catalog/care-manager/005-edit.md` per `CAPTION-STYLE.md` (cite `ExpenseService.resubmit_expense` for REJECTED + `ExpenseService.edit_expense` otherwise).
+22. **Do not** author a `006-receipt.md` — receipt route's inventory row is the canonical documentation; no caption file for skipped routes.
+23. Update `docs/migration/v1-pages-inventory.md`:
+    - Row 380 (`/care-manager/client/<int:pk>/`): `screenshot_ref` → `care-manager/002-client`.
+    - Row 383 (`/care-manager/expenses/<int:expense_id>/edit/`): `screenshot_ref` → `care-manager/005-edit`.
+    - Row 384 (`/care-manager/expenses/<int:expense_id>/receipt/<int:receipt_id>/`): `screenshot_ref` → `not_screenshotted: non_html_response`.
+24. Update `docs/legacy/v1-ui-catalog/README.md`:
+    - Persona table Care Manager count `3` → `5`.
+    - Per-route index Care Manager subsection: add `care-manager/002-client` and `care-manager/005-edit` bullets in canonical_id-ascending order.
+25. Update `docs/legacy/v1-ui-catalog/RUN-MANIFEST.md`: new fixture sha256, generated date, route counts (`captured`, `skipped`, `errored`).
+
+### Verification (release gates)
+
+26. `make scan-v1-docs` passes (hygiene + structure + coverage).
+27. `cd tools/v1-screenshot-catalog && pnpm test` — 91 tests pass (existing 79 + 12 added by #237 prep).
+28. Reproducibility check ≤ 0.5% pixel diff (step 14).
+29. PHI audit zero `no` verdicts (step 16).
+30. Sunil PHI sign-off on the new captures.
+
+### Remediation
+
+- If `cm_client_focus` still raises `Http404` after fixture extension: the `CareManagerProfile`↔`Client` linkage model was wrong (step 2). Re-read v1 source; rebuild fixture row.
+- If `cm_edit_expense` renders the *edit* form (not *resubmit*): `Expense.status` enum value is wrong. v1's enum is case-sensitive; confirm the literal value (likely `"REJECTED"` but verify).
+- If receipt route returns a non-attachment response (e.g., HTTP 200 with `Content-Type: image/png` and inline disposition): the `non_html_response` reclassification may not apply. Inspect v1's `cm_serve_receipt` view for the actual response shape and re-evaluate; possibly the route IS screenshottable as an inline image.
+- If pixel-diff against AA / CG / FM captures is non-empty: the new fixture row leaked into other personas' views. Narrow the linkage scope (no caregiver assignment, no shifts on the new client) and re-crawl.

--- a/tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md
+++ b/tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md
@@ -273,7 +273,7 @@ Closes the Care Manager catalog gap: 3 inventory rows whose `screenshot_ref` was
 
 5. Edit `~/Code/COREcare-access/fixtures/v2_catalog_snapshot.json`:
    - **Link** the existing `CareManagerProfile` (test CM) to the existing `Client` (PK 1) via the confirmed mechanism. **Do not** add the Client to any caregiver/shift/chart relationships — minimise cross-persona blast radius.
-   - **Enrich** the `Client` row to render rich Client Focus UI: DNR flag, ≥1 alert flag, `diagnosis = "[DIAGNOSIS]"`, `address = "[ADDRESS]"`, `phone = "[PHONE]"`. Reuse the existing `ClientFamilyMember` link.
+   - **Enrich** the `Client` row to render rich `cm_client_focus` UI: DNR flag, ≥1 alert flag, `diagnosis = "[DIAGNOSIS]"`, `address = "[ADDRESS]"`, `phone = "[PHONE]"`. Reuse the existing `ClientFamilyMember` link.
    - **Add** 1 `Expense` row: `pk = 1`, `submitter = <test_cm_user_pk>`, `client = 1`, `status = "REJECTED"`, `description = "[NOTE_TEXT]"`, `amount = 9.99` (deliberately non-realistic — document the convention in `INVESTIGATIONS.md`).
    - **Add** 1 `ExpenseReceipt` row: `pk = 1`, `expense = 1`, `original_filename = "[REDACTED].png"`, `image = "<MEDIA-relative-path-to-placeholder.png>"`.
 6. Place a synthetic placeholder PNG at `<MEDIA_ROOT>/<image-path>`: ≤2 KB, flat-grey or "RECEIPT [REDACTED]" synthetic, no identifying marks.

--- a/tools/v1-screenshot-catalog/__tests__/placeholders.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/placeholders.test.ts
@@ -28,11 +28,11 @@ describe("substitutePlaceholders", () => {
   });
 
   it("reports missing placeholders without substituting partials", () => {
-    const r = substitutePlaceholders("/admin/expenses/<int:expense_id>/approve/");
+    const r = substitutePlaceholders("/admin/visits/<int:visit_id>/approve/");
     expect(r.substituted).toBe(false);
-    expect(r.missing).toEqual(["int:expense_id"]);
+    expect(r.missing).toEqual(["int:visit_id"]);
     // URL is left in pattern form so the operator can debug
-    expect(r.url).toBe("/admin/expenses/<int:expense_id>/approve/");
+    expect(r.url).toBe("/admin/visits/<int:visit_id>/approve/");
   });
 
   it("handles routes with mixed known + unknown placeholders", () => {

--- a/tools/v1-screenshot-catalog/__tests__/seed-ids.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/seed-ids.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { SEED_IDS, substitutePlaceholders } from "../crawl.ts";
+
+// Issue #237 extends the v2_catalog_snapshot.json fixture with a
+// CareManagerProfile↔Client linkage, one Expense (REJECTED), and one
+// ExpenseReceipt. Three new placeholders appear in the Care Manager routes:
+//
+//   /care-manager/client/<int:pk>/                        → cm_client_focus
+//   /care-manager/expenses/<int:expense_id>/edit/         → cm_edit_expense
+//   /care-manager/expenses/<int:expense_id>/receipt/<int:receipt_id>/
+//                                                         → cm_serve_receipt (skipped non_html_response)
+//
+// SEED_IDS must resolve all three so substitutePlaceholders does not return
+// `missing` entries that route the crawler back into no_seed_data.
+
+describe("SEED_IDS — Care Manager fixture extension (#237)", () => {
+  it("maps int:pk to the seeded Client pk (used by cm_client_focus)", () => {
+    expect(SEED_IDS["int:pk"]).toBe(1);
+  });
+
+  it("maps int:expense_id to the seeded Expense pk (used by cm_edit_expense)", () => {
+    expect(SEED_IDS["int:expense_id"]).toBe(1);
+  });
+
+  it("maps int:receipt_id to the seeded ExpenseReceipt pk (used by cm_serve_receipt)", () => {
+    expect(SEED_IDS["int:receipt_id"]).toBe(1);
+  });
+
+  it("substitutes /care-manager/client/<int:pk>/ to a concrete URL", () => {
+    const r = substitutePlaceholders("/care-manager/client/<int:pk>/");
+    expect(r.substituted).toBe(true);
+    expect(r.missing).toEqual([]);
+    expect(r.url).toBe("/care-manager/client/1/");
+  });
+
+  it("substitutes /care-manager/expenses/<int:expense_id>/edit/ to a concrete URL", () => {
+    const r = substitutePlaceholders("/care-manager/expenses/<int:expense_id>/edit/");
+    expect(r.substituted).toBe(true);
+    expect(r.missing).toEqual([]);
+    expect(r.url).toBe("/care-manager/expenses/1/edit/");
+  });
+
+  it("substitutes the receipt route's two placeholders to a concrete URL", () => {
+    // The receipt route itself is skipped at capture time (see
+    // skip-reasons.test.ts) but substitution must still resolve so the
+    // crawler doesn't double-classify the skip-reason.
+    const r = substitutePlaceholders(
+      "/care-manager/expenses/<int:expense_id>/receipt/<int:receipt_id>/",
+    );
+    expect(r.substituted).toBe(true);
+    expect(r.missing).toEqual([]);
+    expect(r.url).toBe("/care-manager/expenses/1/receipt/1/");
+  });
+});

--- a/tools/v1-screenshot-catalog/__tests__/skip-reasons.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/skip-reasons.test.ts
@@ -10,37 +10,39 @@ import { classifyScreenshotRef } from "../crawl.ts";
 
 describe("classifyScreenshotRef", () => {
   it("classifies a captured ref as 'capture'", () => {
-    const r = classifyScreenshotRef("care-manager/002-client");
-    expect(r.kind).toBe("capture");
+    expect(classifyScreenshotRef("care-manager/002-client")).toEqual({ kind: "capture" });
   });
 
   it("classifies not_screenshotted: non_html_response as skipped with that reason", () => {
-    const r = classifyScreenshotRef("not_screenshotted: non_html_response");
-    expect(r.kind).toBe("skip");
-    expect(r.reason).toBe("non_html_response");
+    expect(classifyScreenshotRef("not_screenshotted: non_html_response")).toEqual({
+      kind: "skip",
+      reason: "non_html_response",
+    });
   });
 
   it("classifies not_screenshotted: no_seed_data as skipped with that reason", () => {
-    const r = classifyScreenshotRef("not_screenshotted: no_seed_data");
-    expect(r.kind).toBe("skip");
-    expect(r.reason).toBe("no_seed_data");
+    expect(classifyScreenshotRef("not_screenshotted: no_seed_data")).toEqual({
+      kind: "skip",
+      reason: "no_seed_data",
+    });
   });
 
   it("strips whitespace after the colon (operator-format leniency)", () => {
-    const r = classifyScreenshotRef("not_screenshotted:   pending #79");
-    expect(r.kind).toBe("skip");
-    expect(r.reason).toBe("pending #79");
+    expect(classifyScreenshotRef("not_screenshotted:   pending #79")).toEqual({
+      kind: "skip",
+      reason: "pending #79",
+    });
   });
 
   it("handles missing space after the colon", () => {
-    const r = classifyScreenshotRef("not_screenshotted:non_html_response");
-    expect(r.kind).toBe("skip");
-    expect(r.reason).toBe("non_html_response");
+    expect(classifyScreenshotRef("not_screenshotted:non_html_response")).toEqual({
+      kind: "skip",
+      reason: "non_html_response",
+    });
   });
 
   it("does not classify other prefixes as skip", () => {
     // Defensive: only the literal "not_screenshotted:" prefix triggers skip.
-    const r = classifyScreenshotRef("foo: bar");
-    expect(r.kind).toBe("capture");
+    expect(classifyScreenshotRef("foo: bar")).toEqual({ kind: "capture" });
   });
 });

--- a/tools/v1-screenshot-catalog/__tests__/skip-reasons.test.ts
+++ b/tools/v1-screenshot-catalog/__tests__/skip-reasons.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { classifyScreenshotRef } from "../crawl.ts";
+
+// Issue #237 reclassifies cm_serve_receipt as non_html_response (the existing
+// taxonomy entry — see docs/legacy/README.md "Skip-reason taxonomy"). The
+// inventory's screenshot_ref column is the source of truth: when its value
+// starts with "not_screenshotted:", the crawler must skip the route and
+// propagate the reason verbatim into the run-manifest. Capture-classification
+// is pure; this lets it be tested without spinning up Playwright.
+
+describe("classifyScreenshotRef", () => {
+  it("classifies a captured ref as 'capture'", () => {
+    const r = classifyScreenshotRef("care-manager/002-client");
+    expect(r.kind).toBe("capture");
+  });
+
+  it("classifies not_screenshotted: non_html_response as skipped with that reason", () => {
+    const r = classifyScreenshotRef("not_screenshotted: non_html_response");
+    expect(r.kind).toBe("skip");
+    expect(r.reason).toBe("non_html_response");
+  });
+
+  it("classifies not_screenshotted: no_seed_data as skipped with that reason", () => {
+    const r = classifyScreenshotRef("not_screenshotted: no_seed_data");
+    expect(r.kind).toBe("skip");
+    expect(r.reason).toBe("no_seed_data");
+  });
+
+  it("strips whitespace after the colon (operator-format leniency)", () => {
+    const r = classifyScreenshotRef("not_screenshotted:   pending #79");
+    expect(r.kind).toBe("skip");
+    expect(r.reason).toBe("pending #79");
+  });
+
+  it("handles missing space after the colon", () => {
+    const r = classifyScreenshotRef("not_screenshotted:non_html_response");
+    expect(r.kind).toBe("skip");
+    expect(r.reason).toBe("non_html_response");
+  });
+
+  it("does not classify other prefixes as skip", () => {
+    // Defensive: only the literal "not_screenshotted:" prefix triggers skip.
+    const r = classifyScreenshotRef("foo: bar");
+    expect(r.kind).toBe("capture");
+  });
+});

--- a/tools/v1-screenshot-catalog/crawl.ts
+++ b/tools/v1-screenshot-catalog/crawl.ts
@@ -193,6 +193,9 @@ export const SEED_IDS: Record<string, number> = {
   "int:client_id": 1,        // clients.client.pk = 1
   "int:user_id": 4,          // auth.user.pk = 4 (caregiver)
   "int:caregiver_id": 4,     // same caregiver user
+  "int:pk": 1,               // generic int — Care Manager cm_client_focus uses this for client pk (#237)
+  "int:expense_id": 1,       // expenses.expense.pk = 1 (#237 fixture extension)
+  "int:receipt_id": 1,       // expenses.expensereceipt.pk = 1 (#237 fixture extension)
   "id": 1,                   // generic int (default to client)
 };
 
@@ -200,6 +203,22 @@ export interface SubstitutionResult {
   url: string;
   substituted: boolean;       // true if all placeholders resolved
   missing: string[];          // unresolved placeholder names
+}
+
+// Inventory `screenshot_ref` cells are the source of truth for whether a
+// row should be captured or skipped. The taxonomy of skip-reasons lives in
+// docs/legacy/README.md "Skip-reason taxonomy" — see issue #237 for the
+// non_html_response application to cm_serve_receipt.
+export type ScreenshotRefClassification =
+  | { kind: "capture" }
+  | { kind: "skip"; reason: string };
+
+export function classifyScreenshotRef(ref: string): ScreenshotRefClassification {
+  if (ref.startsWith("not_screenshotted:")) {
+    const reason = ref.replace(/^not_screenshotted:\s*/, "").trim();
+    return { kind: "skip", reason };
+  }
+  return { kind: "capture" };
 }
 
 export function substitutePlaceholders(
@@ -607,9 +626,9 @@ interface CaptureResult {
 async function captureRoute(args: CaptureArgs): Promise<CaptureResult> {
   const start = Date.now();
 
-  if (args.row.screenshot_ref.startsWith("not_screenshotted:")) {
-    const reason = args.row.screenshot_ref.replace(/^not_screenshotted:\s*/, "");
-    return { status: "skipped", reason, durationMs: Date.now() - start };
+  const classified = classifyScreenshotRef(args.row.screenshot_ref);
+  if (classified.kind === "skip") {
+    return { status: "skipped", reason: classified.reason, durationMs: Date.now() - start };
   }
 
   // Substitute Django URL-pattern placeholders. Routes whose placeholders


### PR DESCRIPTION
## Summary

Crawler-side prep for closing the Care Manager catalog gap (#237). Lands the v2-only changes — `SEED_IDS` extension for the new fixture rows + a pure `classifyScreenshotRef` helper — so the operator can do the v1-side fixture extension + re-crawl in a follow-up without needing crawler changes mid-flight.

This PR does **not** close the issue. The remaining work (operator-owned, v1-side + re-crawl + new captures + caption/inventory/README updates) is documented as Phase 2H in `tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md`.

## What's in this PR

- `tools/v1-screenshot-catalog/crawl.ts`:
  - `SEED_IDS` gains `int:pk`, `int:expense_id`, `int:receipt_id` (all → fixture pk 1).
  - `classifyScreenshotRef()` extracted as a pure function from `captureRoute()` so the `not_screenshotted: <reason>` skip path is unit-testable.
- `tools/v1-screenshot-catalog/__tests__/seed-ids.test.ts` — 6 new tests.
- `tools/v1-screenshot-catalog/__tests__/skip-reasons.test.ts` — 6 new tests.
- `tools/v1-screenshot-catalog/__tests__/placeholders.test.ts` — one test updated (missing-placeholder example moved from `int:expense_id` → `int:visit_id` since the former is now resolved).
- `tools/v1-screenshot-catalog/PHASE-2-RUNBOOK.md` — new Phase 2H section (operator workflow).

91 crawler tests pass (was 79 + 12 added).

## Decision delta vs design plan

The design committee (#237 comment thread) proposed a new `not_a_page` skip-reason. While starting `/implement`, I checked `docs/legacy/README.md` "Skip-reason taxonomy" and found `non_html_response` already covers the same case ("Endpoint returns a binary file via `Content-Disposition: attachment`; nothing to render"). **Using the existing entry instead** — no taxonomy doc change in this PR.

This was posted as a correction comment on #237. The issue body's references to `not_a_page` will be retroactively reconciled to `non_html_response` when the operator does the inventory update in the follow-up PR.

## Out of scope (operator-owned, follow-up PR)

Per Phase 2H of the runbook:

- Edit `~/Code/COREcare-access/fixtures/v2_catalog_snapshot.json` (CM↔Client linkage, Expense REJECTED, ExpenseReceipt with placeholder PNG).
- Update `INVESTIGATIONS.md` fixture sha256 + records count + conventions.
- Update `tools/v1-screenshot-catalog/.env V1_FIXTURE_SHA256` (gitignored).
- Full re-crawl all 5 personas.
- Reproducibility check (≤ 0.5% pixel diff).
- PHI audit (`PHI-AUDIT-POSTCRAWL-<date>-cm-recrawl.md`).
- Caption authoring/rewrites (`001`, `002` new, `003`, `005` new; spot-check `004`; no `006`).
- Inventory rows 380, 383, 384 update.
- Catalog `README.md` (Care Manager count 3 → 5).
- `RUN-MANIFEST.md` update.

The follow-up PR is mostly artifact updates + LFS commits. The crawler code itself is done here.

## Test plan

- [x] `cd tools/v1-screenshot-catalog && pnpm test` — 91/91 pass.
- [x] `make scan-v1-docs` — coverage gate green.
- [x] `make check` — full quality gate green (api lint/test, web lint/typecheck/test/build, scripts/tests/*).
- [ ] Operator: full re-crawl + reproducibility + PHI audit (Phase 2H follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
