### PR TITLE
docs(#236): drop Super-Admin from validator persona list (1/N)

### DIFF
--- a/.claude/pm-context.md
+++ b/.claude/pm-context.md
@@ -31,6 +31,8 @@ Multi-tenant SaaS for home health agencies. COREcare connects caregivers, family
 | Caregiver | Nurse, CNA, HHA | Efficient documentation, clear assignments, minimal paperwork |
 | Family Member | Spouse, adult child | Visibility, peace of mind, communication |
 
+*(Super-Admin is v2 forward-looking; v1 has no Super-Admin role — `is_superuser`-gated views fold into Agency Admin per [#236](https://github.com/suniljames/COREcare-v2/issues/236).)*
+
 ## Key Workflows
 
 | Workflow | Description |

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -61,9 +61,8 @@ These conventions apply to every document in this set. **Authors must read this 
 
 ### Personas
 
-Six personas, exact strings from `.claude/pm-context.md`:
+Five personas, exact strings from `.claude/pm-context.md`:
 
-- `Super-Admin`
 - `Agency Admin`
 - `Care Manager`
 - `Caregiver`
@@ -71,6 +70,8 @@ Six personas, exact strings from `.claude/pm-context.md`:
 - `Family Member`
 
 No drift to lowercase, no hyphenation changes, no synonyms ("admin," "agency administrator," "care worker," "field worker").
+
+`pm-context.md` also lists `Super-Admin` as a stakeholder, but that's v2-forward-looking — v1 has no Super-Admin role (verified per `core/models.py:1471-1476`'s `RoleCapabilityGrant.ROLE_CHOICES`). The few `is_superuser`-gated v1 routes (notably the View-As emergency kill switch) are folded into `## Agency Admin` with `rls_bypass_by_design=true` per #236.
 
 ### v2 status enum
 

--- a/scripts/check-v1-doc-structure.sh
+++ b/scripts/check-v1-doc-structure.sh
@@ -128,7 +128,6 @@ GLOSSARY="$DIR/v1-glossary.md"
 README="$DIR/README.md"
 
 REQUIRED_PERSONAS=(
-  "Super-Admin"
   "Agency Admin"
   "Care Manager"
   "Caregiver"
@@ -458,9 +457,11 @@ fi
 # JL-1: status header is "AUTHORED. Last reconciled: YYYY-MM-DD against
 #       v1 commit `<sha>`." once authoring is complete.
 # JL-2: six persona H2 sections present (always).
-# JL-3: per-persona journey count meets locked minimums (Super-Admin ≥2,
-#       Agency Admin ≥5, Care Manager ≥2, Caregiver ≥4, Client ≥2,
-#       Family Member ≥3) — gated on AUTHORED.
+# JL-3: per-persona journey count meets locked minimums (Agency Admin ≥5,
+#       Care Manager ≥2, Caregiver ≥4, Client ≥2, Family Member ≥3) —
+#       gated on AUTHORED. v1 has no Super-Admin role per #236, so no
+#       Super-Admin journey minimum is enforced; the few `is_superuser`-
+#       gated routes fold into Agency Admin.
 # JL-4: no "_pending content authoring_" placeholder remains — gated on
 #       AUTHORED.
 # JL-5: no "**Failure-mode UX:** None" filler — gated on AUTHORED.
@@ -494,7 +495,6 @@ if [[ -f "$JOURNEYS" ]]; then
     # JL-3: per-persona journey count minimums.
     # Pipe-separated "persona|min" pairs (no associative arrays — bash 3.2).
     JL3_PAIRS=(
-      "Super-Admin|2"
       "Agency Admin|5"
       "Care Manager|2"
       "Caregiver|4"
@@ -528,12 +528,11 @@ if [[ -f "$JOURNEYS" ]]; then
     # JL-6: each H3 inside a persona H2 carries Route trace + Side effects.
     jl6_violations=$(awk '
       BEGIN {
-        personas[1] = "Super-Admin"
-        personas[2] = "Agency Admin"
-        personas[3] = "Care Manager"
-        personas[4] = "Caregiver"
-        personas[5] = "Client"
-        personas[6] = "Family Member"
+        personas[1] = "Agency Admin"
+        personas[2] = "Care Manager"
+        personas[3] = "Caregiver"
+        personas[4] = "Client"
+        personas[5] = "Family Member"
       }
       function flush_block() {
         if (in_h3) {
@@ -549,7 +548,7 @@ if [[ -f "$JOURNEYS" ]]; then
         flush_block()
         in_h3 = 0
         in_persona = 0
-        for (i = 1; i <= 6; i++) {
+        for (i = 1; i <= 5; i++) {
           pat = "^## " personas[i] "([[:space:]]|$)"
           if ($0 ~ pat) { in_persona = 1; break }
         }

--- a/scripts/tests/test_check_v1_doc_structure.sh
+++ b/scripts/tests/test_check_v1_doc_structure.sh
@@ -56,9 +56,6 @@ write_good_inventory() {
   cat > "$path" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
-| route | v2_status |
-
 ## Agency Admin
 | route | v2_status |
 
@@ -106,7 +103,6 @@ mkdir -p "$TEST_DIR/missing-persona"
 cat > "$TEST_DIR/missing-persona/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -195,7 +191,6 @@ mkdir -p "$TEST_DIR/shared-pending"
 cat > "$TEST_DIR/shared-pending/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -214,7 +209,6 @@ mkdir -p "$TEST_DIR/shared-empty"
 cat > "$TEST_DIR/shared-empty/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -233,7 +227,6 @@ mkdir -p "$TEST_DIR/shared-populated"
 cat > "$TEST_DIR/shared-populated/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -255,7 +248,6 @@ mkdir -p "$TEST_DIR/family-placeholder"
 cat > "$TEST_DIR/family-placeholder/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -275,7 +267,6 @@ mkdir -p "$TEST_DIR/family-missing-scope"
 cat > "$TEST_DIR/family-missing-scope/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -295,7 +286,6 @@ mkdir -p "$TEST_DIR/family-missing-audit"
 cat > "$TEST_DIR/family-missing-audit/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -315,7 +305,6 @@ mkdir -p "$TEST_DIR/family-missing-phi"
 cat > "$TEST_DIR/family-missing-phi/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -335,7 +324,6 @@ mkdir -p "$TEST_DIR/family-both-audit"
 cat > "$TEST_DIR/family-both-audit/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -355,7 +343,6 @@ mkdir -p "$TEST_DIR/family-good-logged"
 cat > "$TEST_DIR/family-good-logged/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -375,7 +362,6 @@ mkdir -p "$TEST_DIR/family-good-noaudit"
 cat > "$TEST_DIR/family-good-noaudit/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -396,7 +382,6 @@ mkdir -p "$TEST_DIR/family-shared-boundary"
 cat > "$TEST_DIR/family-shared-boundary/v1-pages-inventory.md" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -429,7 +414,6 @@ write_integrations_inventory() {
   cat > "$path" <<'EOF'
 # v1 Pages Inventory
 
-## Super-Admin
 ## Agency Admin
 
 ### dashboard
@@ -1093,26 +1077,6 @@ write_good_journeys() {
 
 **Status:** AUTHORED. Last reconciled: 2026-05-07 against v1 commit `9738412`.
 
-## Super-Admin
-
-### Journey 1
-A Super-Admin manages.
-
-**Route trace:**
-1. [a](v1-pages-inventory.md#super-admin-top-level) — does thing.
-
-**Side effects:**
-- DB: writes a row.
-
-### Journey 2
-A Super-Admin investigates.
-
-**Route trace:**
-1. [a](v1-pages-inventory.md#super-admin-top-level) — does thing.
-
-**Side effects:**
-- DB: writes a row.
-
 ## Agency Admin
 
 ### J1
@@ -1281,7 +1245,6 @@ cat > "$TEST_DIR/journeys-scaffolded/v1-user-journeys.md" <<'EOF'
 
 **Status:** SCAFFOLDED.
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -1304,7 +1267,6 @@ write_good_delta "$TEST_DIR/jl1-missing/v1-functionality-delta.md"
 cat > "$TEST_DIR/jl1-missing/v1-user-journeys.md" <<'EOF'
 # V1 User Journeys
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -1322,7 +1284,6 @@ cat > "$TEST_DIR/jl1-bad/v1-user-journeys.md" <<'EOF'
 
 **Status:** AUTHORED maybe.
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -1340,7 +1301,6 @@ cat > "$TEST_DIR/jl2-missing/v1-user-journeys.md" <<'EOF'
 
 **Status:** SCAFFOLDED.
 
-## Super-Admin
 ## Agency Admin
 ## Care Manager
 ## Caregiver
@@ -1401,7 +1361,7 @@ import sys, pathlib
 p = pathlib.Path(sys.argv[1])
 # Strip the **Route trace:** line from the first journey only.
 text = p.read_text()
-text = text.replace("**Route trace:**\n1. [a](v1-pages-inventory.md#super-admin-top-level) — does thing.\n\n", "", 1)
+text = text.replace("**Route trace:**\n1. [a](v1-pages-inventory.md#dashboard) — x.\n\n", "", 1)
 p.write_text(text)
 PY
 assert_exit "JL-6: missing **Route trace:** sub-block fails" 1 "$STRUCTURE" --dir "$TEST_DIR/jl6-route"
@@ -1415,7 +1375,7 @@ python3 - "$TEST_DIR/jl6-side/v1-user-journeys.md" <<'PY'
 import sys, pathlib
 p = pathlib.Path(sys.argv[1])
 text = p.read_text()
-text = text.replace("**Side effects:**\n- DB: writes a row.\n", "", 1)
+text = text.replace("**Side effects:**\n- DB: y.\n", "", 1)
 p.write_text(text)
 PY
 assert_exit "JL-6: missing **Side effects:** sub-block fails" 1 "$STRUCTURE" --dir "$TEST_DIR/jl6-side"
@@ -1429,7 +1389,7 @@ python3 - "$TEST_DIR/jl7/v1-user-journeys.md" <<'PY'
 import sys, pathlib
 p = pathlib.Path(sys.argv[1])
 text = p.read_text()
-text = text.replace("v1-pages-inventory.md#super-admin-top-level", "v1-pages-inventory.md#nonexistent-anchor", 1)
+text = text.replace("v1-pages-inventory.md#dashboard", "v1-pages-inventory.md#nonexistent-anchor", 1)
 p.write_text(text)
 PY
 assert_exit "JL-7: orphan inventory anchor fails" 1 "$STRUCTURE" --dir "$TEST_DIR/jl7"
@@ -1444,7 +1404,7 @@ import sys, pathlib
 p = pathlib.Path(sys.argv[1])
 text = p.read_text()
 text = text.replace(
-    "(v1-pages-inventory.md#super-admin-top-level)",
+    "(v1-pages-inventory.md#dashboard)",
     "(https://github.com/suniljames/COREcare-v2/blob/main/docs/migration/v1-pages-inventory.md#nonexistent-anchor)",
     1,
 )
@@ -1462,8 +1422,8 @@ import sys, pathlib
 p = pathlib.Path(sys.argv[1])
 text = p.read_text()
 text = text.replace(
-    "(v1-pages-inventory.md#super-admin-top-level)",
-    "(https://github.com/suniljames/COREcare-v2/blob/main/docs/migration/v1-pages-inventory.md#super-admin-top-level)",
+    "(v1-pages-inventory.md#dashboard)",
+    "(https://github.com/suniljames/COREcare-v2/blob/main/docs/migration/v1-pages-inventory.md#dashboard)",
     1,
 )
 p.write_text(text)
@@ -1480,7 +1440,7 @@ import sys, pathlib
 p = pathlib.Path(sys.argv[1])
 text = p.read_text()
 text = text.replace(
-    "(v1-pages-inventory.md#super-admin-top-level)",
+    "(v1-pages-inventory.md#dashboard)",
     "(../blob/main/docs/migration/v1-pages-inventory.md#nonexistent-anchor)",
     1,
 )
@@ -1498,8 +1458,8 @@ import sys, pathlib
 p = pathlib.Path(sys.argv[1])
 text = p.read_text()
 text = text.replace(
-    "(v1-pages-inventory.md#super-admin-top-level)",
-    "(../blob/main/docs/migration/v1-pages-inventory.md#super-admin-top-level)",
+    "(v1-pages-inventory.md#dashboard)",
+    "(../blob/main/docs/migration/v1-pages-inventory.md#dashboard)",
     1,
 )
 p.write_text(text)


### PR DESCRIPTION
## Summary

First of N PRs against #236 (rescope Super-Admin section because v1 has no Super-Admin role per `core/models.py:1471–1476`). Lands the validator + persona-vocabulary alignment so future commits can delete the inventory section, migrate the kill-all row to Agency Admin, and update the cold-reader contract without churning the validator's tests.

**This PR does NOT close #236.** #236 closes when the inventory section deletion (B+C bundle), cross-ref audit (D), and cold-reader contract update (E) all land.

## What this PR changes

### Validator (`scripts/check-v1-doc-structure.sh`)
- `REQUIRED_PERSONAS` array drops `Super-Admin`; now five personas.
- JL-3 journey-count minimums (`JL3_PAIRS`) drop the `Super-Admin|2` entry.
- JL-6 awk personas array shrinks from 6 to 5; loop bound updated.
- JL-3 comment header reflects the new minimum set + cross-references #236 for the rationale.

### Validator self-tests (`scripts/tests/test_check_v1_doc_structure.sh`)
- Bulk fixture writers (`write_good_inventory`, `write_good_journeys`, `write_journeys_inventory`, `write_integrations_inventory`) no longer emit `## Super-Admin` H2 + body.
- JL-6 / JL-7 corruption tests retargeted from Super-Admin's `#super-admin-top-level` anchor to Agency Admin's `#dashboard` anchor — the test intent (catch missing `**Route trace:**` / `**Side effects:**` / orphan anchors) is preserved against a still-required persona.

### Persona vocabulary lock
- `docs/migration/README.md` — Locked Conventions §Personas list 6 → 5 with a paragraph noting that `pm-context.md`'s Super-Admin entry is v2-forward-looking and the few `is_superuser`-gated v1 routes will fold into Agency Admin per #236.
- `.claude/pm-context.md` — Stakeholders table keeps Super-Admin row with the Writer-locked annotation: `*(Super-Admin is v2 forward-looking; v1 has no Super-Admin role — `is_superuser`-gated views fold into Agency Admin per #236.)*`.

## Why this PR is scoped to (1/N)

The full rescope (delete `## Super-Admin` from inventory; migrate kill-all row + catalog file; cross-reference audit; cold-reader contract update) is ~100–145 minutes of additional focused work. Splitting per the conventions locked at /design lets the four remaining work items parallelize:

- **B+C bundle** (~45–60 min) — inventory section delete + row migration + catalog `git mv`. **First — gates the user-visible fix.**
- **D** (~30–45 min) — cross-reference audit across `v1-user-journeys.md`, `v1-glossary.md`, `v1-functionality-delta.md`, catalog `README.md` + `RUN-MANIFEST.md` + `reproducibility-report/`, 4 caption .md files in `agency-admin/`, and any remaining script references. Parallel with E after B+C lands.
- **E** (~30–45 min) — cold-reader contract: delete `super-admin.yaml` fixture, remove from `inventory.py` + tests, update `coldreader/README.md`. Parallel with D.

## Why this PR's changes are safe in isolation

The validator now no longer requires `## Super-Admin` to be present, but it remains permissive of it — the inventory still has the section, and `make scan-v1-docs` passes. The validator is forward-compatible with the planned end state without forcing the inventory to change in lock-step.

## Verification

- [x] `make test-v1-docs` → 256 self-tests pass across 8 suites.
- [x] `make scan-v1-docs` → exits 0 against the unchanged inventory (Super-Admin section still present).
- [x] No PHI, no absolute paths, no plausible real-name pairs introduced.

## Test plan

- [ ] CI workflow `V1 Doc Hygiene` passes on this PR.
- [ ] Reviewer reads the validator changes against the issue body's Commit A spec (→ matches).
- [ ] Reviewer spot-checks the test-fixture retargeting — JL-6/JL-7 fixtures still test the same intent (corruption catches).
- [ ] **No PHI sign-off needed for this PR specifically** — no doc content moved or quoted; validator/tests/persona-vocabulary only.

## Out of scope (deliberately deferred)

- Inventory section deletion + kill-all row migration (B+C — separate follow-up).
- Catalog `git mv super-admin/ → agency-admin/100-*` (B+C — bundled with B).
- Cross-reference audit across docs and caption files (D — separate follow-up).
- LLM cold-reader contract update (E — separate follow-up).

## Related

- **Toward:** #236 (does NOT close it).
- **Pattern reference:** prior persona-section work landed in #80 / #82 / #117 / #82 / #84..#89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)