### PR TITLE
fix(#241): env-gate dev auth fallback + startup guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,9 @@ Tailscale for network access from other devices.
 
 ## Local authentication
 
-The API ships with a **dev fallback** in [`api/app/auth.py`](api/app/auth.py): when `CLERK_SECRET_KEY` is empty *and* the request has no `Authorization` header, every endpoint resolves to a mock `super_admin` user. This lets you exercise API endpoints (via `curl`, the Swagger UI at `/docs`, or unit tests) with no Clerk account.
+The API ships with a **dev fallback** in [`api/app/auth.py`](api/app/auth.py): when `ENVIRONMENT=development` *and* `CLERK_SECRET_KEY` is empty *and* the request has no `Authorization` header, every endpoint resolves to a mock `super_admin` user. This lets you exercise API endpoints (via `curl`, the Swagger UI at `/docs`, or unit tests) with no Clerk account.
+
+In any non-development environment, the API will **refuse to start** without `CLERK_SECRET_KEY` set — see [#241](https://github.com/suniljames/COREcare-v2/issues/241). This prevents a misconfigured production deploy from silently granting unauthenticated requests admin access.
 
 The web app boots with a publicly-known dummy Clerk publishable key (the same one CI uses) so `pnpm dev` and `pnpm build` succeed locally. You **cannot sign in through the web UI with the dummy key** — Clerk's hosted sign-in flow needs a real `pk_test_...` and matching `sk_test_...`.
 
@@ -92,6 +94,7 @@ When to set real Clerk keys:
 | Run web in dev with the layout rendering | No (dummy key boots it) |
 | Sign in via the web UI as a seeded user | Yes — both `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` |
 | Run E2E tests against the full stack | Yes |
+| Run any non-development environment (`ENVIRONMENT != development`) | **Yes — the API refuses to boot without it** |
 
 Get keys from [Clerk's dashboard](https://dashboard.clerk.com/) and put them in `web/.env.local` and `api/.env`.
 

--- a/api/app/auth.py
+++ b/api/app/auth.py
@@ -57,8 +57,9 @@ async def _get_clerk_user_id(request: Request) -> str:
 
     token = auth_header[7:]
 
-    # Dev mode: skip verification when no Clerk secret configured
-    if not settings.clerk_secret_key:
+    # Dev mode: skip verification when no Clerk secret configured.
+    # Env-gated to fail closed in any non-development deploy — see #241.
+    if settings.is_dev_mode and not settings.clerk_secret_key:
         try:
             claims = jwt.decode(
                 token,
@@ -110,8 +111,14 @@ async def get_current_user(
     """
     auth_header = request.headers.get("Authorization", "")
 
-    # Dev fallback: no Clerk configured and no auth header → mock user
-    if not settings.clerk_secret_key and not auth_header:
+    # Dev fallback: ENVIRONMENT=development AND no Clerk secret AND no auth header → mock user.
+    # See #241 — env-gated to fail closed in any non-development deploy.
+    if settings.is_dev_mode and not settings.clerk_secret_key and not auth_header:
+        await logger.awarning(
+            "auth.dev_fallback_used",
+            environment=settings.environment,
+            path=request.url.path,
+        )
         await clear_tenant_context(session)
         return User(
             id=uuid.UUID("00000000-0000-0000-0000-000000000099"),

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -29,5 +29,10 @@ class Settings(BaseSettings):
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
+    @property
+    def is_dev_mode(self) -> bool:
+        """Single source of truth for dev-mode behavior gates — see #241."""
+        return self.environment == "development"
+
 
 settings = Settings()

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -104,4 +104,19 @@ def create_app() -> FastAPI:
     return app
 
 
+def _validate_startup_config() -> None:
+    """Refuse to boot in fail-open auth configuration.
+
+    See #241 — without a Clerk secret, the only legitimate environment
+    is development. Any other environment with an empty CLERK_SECRET_KEY
+    would silently grant unauthenticated requests admin access.
+    """
+    if not settings.is_dev_mode and not settings.clerk_secret_key:
+        raise RuntimeError(
+            "CLERK_SECRET_KEY must be set when ENVIRONMENT != 'development'. "
+            "Refusing to start in fail-open auth configuration."
+        )
+
+
+_validate_startup_config()
 app = create_app()

--- a/api/app/tests/test_auth.py
+++ b/api/app/tests/test_auth.py
@@ -5,12 +5,15 @@ from collections.abc import AsyncGenerator
 from unittest.mock import patch
 
 import pytest
+import structlog
 from fastapi import Depends, FastAPI
 from httpx import ASGITransport, AsyncClient
 from jose import jwt
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
+from app.config import settings
+from app.db import get_session
 from app.models import Agency, User  # noqa: F401 — register models
 from app.models.user import UserRole
 
@@ -119,3 +122,233 @@ async def test_get_current_user_callable(session: AsyncSession) -> None:
     await session.commit()
 
     assert callable(get_current_user)
+
+
+# ---------------------------------------------------------------------------
+# Issue #241 — env-gated dev fallback + startup guard
+# ---------------------------------------------------------------------------
+
+
+def _attach_session_override(test_app: FastAPI, session: AsyncSession) -> None:
+    """Wire the test's SQLite session into the app's get_session dependency."""
+
+    async def _override() -> AsyncGenerator[AsyncSession, None]:
+        yield session
+
+    test_app.dependency_overrides[get_session] = _override
+
+
+# Group 1 — runtime gate on get_current_user mock fallback (auth.py:114)
+
+
+@pytest.mark.asyncio
+async def test_dev_env_no_secret_no_header_returns_mock_user(
+    session: AsyncSession,
+) -> None:
+    """environment=development + no secret + no header → 200 with mock super_admin."""
+    test_app = _make_protected_app()
+    _attach_session_override(test_app, session)
+    with (
+        patch.object(settings, "environment", "development"),
+        patch.object(settings, "clerk_secret_key", ""),
+    ):
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected")
+            assert resp.status_code == 200
+            assert resp.json()["email"] == "dev@localhost"
+
+
+@pytest.mark.asyncio
+async def test_prod_env_no_secret_no_header_returns_401(
+    session: AsyncSession,
+) -> None:
+    """environment=production + no secret + no header → 401 (the bug being fixed)."""
+    test_app = _make_protected_app()
+    _attach_session_override(test_app, session)
+    with (
+        patch.object(settings, "environment", "production"),
+        patch.object(settings, "clerk_secret_key", ""),
+    ):
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected")
+            assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_staging_env_no_secret_no_header_returns_401(
+    session: AsyncSession,
+) -> None:
+    """environment=staging + no secret + no header → 401 (any non-development fails closed)."""
+    test_app = _make_protected_app()
+    _attach_session_override(test_app, session)
+    with (
+        patch.object(settings, "environment", "staging"),
+        patch.object(settings, "clerk_secret_key", ""),
+    ):
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected")
+            assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_dev_env_with_secret_no_header_returns_401(
+    session: AsyncSession,
+) -> None:
+    """environment=development + secret set + no header → 401 (real Clerk in dev still demands a token)."""
+    test_app = _make_protected_app()
+    _attach_session_override(test_app, session)
+    with (
+        patch.object(settings, "environment", "development"),
+        patch.object(settings, "clerk_secret_key", "sk_test_real"),
+    ):
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected")
+            assert resp.status_code == 401
+
+
+# Group 2 — runtime gate on _get_clerk_user_id verification-skip (auth.py:61)
+
+
+@pytest.mark.asyncio
+async def test_prod_env_no_secret_forged_token_returns_401(
+    session: AsyncSession,
+) -> None:
+    """environment=production + no secret + forged Bearer for an EXISTING user → 401.
+
+    Seeds a real user matching the forged ``sub`` claim; in unfixed code the
+    dev-decode branch would resolve the forged token to that user and return 200.
+    The env gate must block the dev-decode path so the request falls through to
+    real JWKS verification (which 401s the unsigned-by-Clerk token).
+    """
+    agency_id = uuid.uuid4()
+    target_user = User(
+        email="target@victim.local",
+        first_name="Target",
+        last_name="Victim",
+        role=UserRole.AGENCY_ADMIN,
+        clerk_id="user_241_forged_target",
+        agency_id=agency_id,
+    )
+    session.add(target_user)
+    await session.commit()
+
+    test_app = _make_protected_app()
+    _attach_session_override(test_app, session)
+    forged = jwt.encode({"sub": "user_241_forged_target"}, "fake-secret", algorithm="HS256")
+    with (
+        patch.object(settings, "environment", "production"),
+        patch.object(settings, "clerk_secret_key", ""),
+        patch("app.auth._get_clerk_jwks", return_value={}),
+    ):
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected", headers={"Authorization": f"Bearer {forged}"})
+            assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_dev_env_no_secret_token_resolves_seeded_user(
+    session: AsyncSession,
+) -> None:
+    """environment=development + no secret + dev-decoded token with valid sub → 200, that user."""
+    agency_id = uuid.uuid4()
+    user = User(
+        email="seeded@dev.local",
+        first_name="Seeded",
+        last_name="DevUser",
+        role=UserRole.CAREGIVER,
+        clerk_id="user_241_seeded",
+        agency_id=agency_id,
+    )
+    session.add(user)
+    await session.commit()
+
+    test_app = _make_protected_app()
+    _attach_session_override(test_app, session)
+    token = jwt.encode({"sub": "user_241_seeded"}, "dummy", algorithm="HS256")
+    with (
+        patch.object(settings, "environment", "development"),
+        patch.object(settings, "clerk_secret_key", ""),
+    ):
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+            assert resp.status_code == 200
+            assert resp.json()["email"] == "seeded@dev.local"
+
+
+# Group 3 — startup guard
+
+
+def test_startup_guard_raises_in_production_without_secret() -> None:
+    """environment=production + no secret → _validate_startup_config raises RuntimeError."""
+    from app.main import _validate_startup_config
+
+    with (
+        patch.object(settings, "environment", "production"),
+        patch.object(settings, "clerk_secret_key", ""),
+        pytest.raises(RuntimeError, match="CLERK_SECRET_KEY must be set"),
+    ):
+        _validate_startup_config()
+
+
+def test_startup_guard_raises_in_staging_without_secret() -> None:
+    """environment=staging + no secret → _validate_startup_config raises RuntimeError."""
+    from app.main import _validate_startup_config
+
+    with (
+        patch.object(settings, "environment", "staging"),
+        patch.object(settings, "clerk_secret_key", ""),
+        pytest.raises(RuntimeError, match="CLERK_SECRET_KEY must be set"),
+    ):
+        _validate_startup_config()
+
+
+def test_startup_guard_passes_in_development_without_secret() -> None:
+    """environment=development + no secret → _validate_startup_config returns cleanly."""
+    from app.main import _validate_startup_config
+
+    with (
+        patch.object(settings, "environment", "development"),
+        patch.object(settings, "clerk_secret_key", ""),
+    ):
+        _validate_startup_config()  # should not raise
+
+
+def test_startup_guard_passes_in_production_with_secret() -> None:
+    """environment=production + secret set → _validate_startup_config returns cleanly."""
+    from app.main import _validate_startup_config
+
+    with (
+        patch.object(settings, "environment", "production"),
+        patch.object(settings, "clerk_secret_key", "sk_live_real"),
+    ):
+        _validate_startup_config()  # should not raise
+
+
+# Group 4 — telemetry
+
+
+@pytest.mark.asyncio
+async def test_dev_fallback_emits_telemetry_event(session: AsyncSession) -> None:
+    """When the dev fallback fires, log event auth.dev_fallback_used is emitted exactly once."""
+    test_app = _make_protected_app()
+    _attach_session_override(test_app, session)
+    with (
+        patch.object(settings, "environment", "development"),
+        patch.object(settings, "clerk_secret_key", ""),
+        structlog.testing.capture_logs() as captured,
+    ):
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected")
+            assert resp.status_code == 200
+
+    fallback_events = [e for e in captured if e.get("event") == "auth.dev_fallback_used"]
+    assert len(fallback_events) == 1
+    assert fallback_events[0].get("environment") == "development"
+    assert fallback_events[0].get("path") == "/protected"

--- a/api/app/tests/test_auth.py
+++ b/api/app/tests/test_auth.py
@@ -197,7 +197,11 @@ async def test_staging_env_no_secret_no_header_returns_401(
 async def test_dev_env_with_secret_no_header_returns_401(
     session: AsyncSession,
 ) -> None:
-    """environment=development + secret set + no header → 401 (real Clerk in dev still demands a token)."""
+    """environment=development + secret set + no header → 401.
+
+    Real Clerk in dev still demands a token; the env gate alone does not
+    re-enable the mock-user fallback when CLERK_SECRET_KEY is configured.
+    """
     test_app = _make_protected_app()
     _attach_session_override(test_app, session)
     with (

--- a/docs/developer/SAFETY.md
+++ b/docs/developer/SAFETY.md
@@ -17,6 +17,16 @@ This file covers COREcare project-specific safety only.
 - Test tenant isolation in every data-access service test
 - Log all cross-tenant access attempts
 
+## Auth fail-closed posture
+
+The dev-mode auth fallback (mock `super_admin` user, JWT signature-skip) is gated on `ENVIRONMENT=development` via the `Settings.is_dev_mode` property. The API **refuses to start** in any other environment without `CLERK_SECRET_KEY` set — see [`api/app/main.py`](../../api/app/main.py) `_validate_startup_config()`.
+
+- Do not relax either gate in [`api/app/auth.py`](../../api/app/auth.py).
+- Do not introduce new env-blind dev fallbacks.
+- Any new dev-only behavior must route through `settings.is_dev_mode`.
+
+Issue reference: [#241](https://github.com/suniljames/COREcare-v2/issues/241).
+
 ## Safe Branch-Switching
 
 1. Prefer `git worktree` over stash


### PR DESCRIPTION
Closes #241

## Summary

- Add `Settings.is_dev_mode` property and gate **both** env-blind dev branches in `api/app/auth.py` (the `get_current_user` mock-user fallback at line 114 *and* the `_get_clerk_user_id` JWT signature-skip at line 60-75 — the second hole the design committee uncovered).
- Add `_validate_startup_config()` in `api/app/main.py` at module scope: refuse to boot when `ENVIRONMENT != "development"` and `CLERK_SECRET_KEY` is empty. Process exits non-zero so the platform marks the deploy unhealthy.
- Emit a structlog warning `auth.dev_fallback_used` when the dev branch fires, so any unexpected non-development firing surfaces in alerting (defense-in-depth on top of the startup guard).
- Update `CONTRIBUTING.md` "Local authentication" + add `docs/developer/SAFETY.md` "Auth fail-closed posture" section.

## Test Plan

- [x] `make check` passes locally (API: 349 passed, 3 skipped; Web: 7 passed; build clean; repo invariant scripts: 55 passed)
- [x] 11 new tests in `api/app/tests/test_auth.py` across 4 groups (runtime gate × 4, signature-skip gate × 2, startup guard × 4, telemetry × 1)
- [x] RED→GREEN observed: 8 tests failed in RED for the right reason before the implementation commit landed
- [x] Forged-token test seeds a real user matching the forged `sub` to prove the gate blocks impersonation, not just unknown subjects
- [ ] CI passes
- [ ] Docker `/healthz` smoke check passes

## Out of scope (filed/to-file separately)

- `SECRET_KEY=dev-secret-change-in-production` default in `config.py:23`
- `clerk_publishable_key.split('_')[1]` brittleness in `_get_clerk_jwks`
- Replacing the dev fallback entirely with a Clerk dev tenant
- `/healthz` not asserting auth subsystem readiness