### PR TITLE
docs(#254): apply two NIT clarity fixes from PR #248 review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,9 +11,8 @@ You're inside `docs/`. Pick a lane.
 | **Code reviewer** | [`developer/code-review-lenses.md`](developer/code-review-lenses.md) | The persona for your role + [`adr/`](adr/) for past decisions |
 | **On-call / operator** | [`operations/README.md`](operations/README.md) | The runbook matching the alert |
 | **Porting v1 behavior to v2** | [`migration/README.md`](migration/README.md) | The locked conventions inside |
-| **Reading architectural history** | [`adr/README.md`](adr/README.md) | The ADR(s) covering the area you're touching |
-
-> Need a domain term defined? → [`GLOSSARY.md`](GLOSSARY.md). The 30-second answer for *persona*, *tenant*, *RLS*, *PHI*, etc.
+| **Looking up a past decision** | [`adr/README.md`](adr/README.md) | The ADR(s) covering the area you're touching |
+| **Looking up a domain term** | [`GLOSSARY.md`](GLOSSARY.md) | The cross-references in each definition |
 
 ## Directory map
 


### PR DESCRIPTION
## Summary

Two NIT findings from the eng-committee review on [#248](https://github.com/suniljames/COREcare-v2/pull/248), tagged not-blocking at the time. Folding them in:

- **Writer NIT**: rename "Reading architectural history" → "Looking up a past decision" — task-shaped to match the surrounding row labels.
- **UX Designer NIT**: promote `GLOSSARY.md` from a callout below the table to a peer row in the "Start by role" router. Glossary-seekers now see it as an entry-point, not a footnote.

Single-file change in `docs/README.md` — three lines edited (one rename + one row added + one callout removed). No content elsewhere is touched.

## Linked issue

Closes #254

## Test plan

- [x] Diff is the expected 3-line change
- [x] All links in `docs/README.md` still resolve (no path changes)
- [ ] CI passes

## Notes for reviewer

This is the explicit "follow-up the NITs" pattern the project already uses (see `30ad951 test(#191): apply two follow-up NIT fixes from PR #230 review`). Tiny PR; no merge risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)