### PR TITLE
nit(#257-260): apply 4 NIT fixes from PR #249 review

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -31,8 +31,13 @@ class Settings(BaseSettings):
 
     @property
     def is_dev_mode(self) -> bool:
-        """Single source of truth for dev-mode behavior gates — see #241."""
-        return self.environment == "development"
+        """Single source of truth for dev-mode behavior gates — see #241.
+
+        Case-insensitive (#257): ``ENVIRONMENT=Development`` and similar
+        capitalizations resolve to dev mode rather than tripping the
+        startup guard with no security upside.
+        """
+        return self.environment.lower() == "development"
 
 
 settings = Settings()

--- a/api/app/tests/test_auth.py
+++ b/api/app/tests/test_auth.py
@@ -53,15 +53,6 @@ def _make_protected_app() -> FastAPI:
 
 
 @pytest.mark.asyncio
-async def test_dev_mode_no_auth_returns_mock_user() -> None:
-    """In dev mode (no Clerk secret), missing auth returns dev mock user."""
-    from app.auth import get_current_user
-
-    assert get_current_user is not None
-    assert callable(get_current_user)
-
-
-@pytest.mark.asyncio
 async def test_missing_auth_header_in_prod_mode() -> None:
     """When Clerk is configured, missing auth header returns 401."""
     test_app = _make_protected_app()

--- a/api/app/tests/test_auth.py
+++ b/api/app/tests/test_auth.py
@@ -347,3 +347,28 @@ async def test_dev_fallback_emits_telemetry_event(session: AsyncSession) -> None
     assert len(fallback_events) == 1
     assert fallback_events[0].get("environment") == "development"
     assert fallback_events[0].get("path") == "/protected"
+
+
+# Group 5 — edge cases (#260)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("env_value", ["development", "production"])
+async def test_empty_bearer_token_returns_401(session: AsyncSession, env_value: str) -> None:
+    """``Authorization: Bearer `` (header present, token empty) → 401 in any env — see #260.
+
+    Header non-empty so the dev-mock fallback is skipped, then the empty
+    token fails JWT decode and 401s. Pinning today's behavior so a future
+    refactor can't regress it silently.
+    """
+    test_app = _make_protected_app()
+    _attach_session_override(test_app, session)
+    with (
+        patch.object(settings, "environment", env_value),
+        patch.object(settings, "clerk_secret_key", "sk_test_real"),
+        patch("app.auth._get_clerk_jwks", return_value={}),
+    ):
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/protected", headers={"Authorization": "Bearer "})
+            assert resp.status_code == 401

--- a/api/app/tests/test_config.py
+++ b/api/app/tests/test_config.py
@@ -1,0 +1,21 @@
+"""Tests for application configuration helpers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from app.config import settings
+
+
+@pytest.mark.parametrize("value", ["development", "Development", "DEVELOPMENT", "DeVeLoPmEnT"])
+def test_is_dev_mode_case_insensitive(value: str) -> None:
+    """Settings.is_dev_mode treats any casing of 'development' as dev — see #257."""
+    with patch.object(settings, "environment", value):
+        assert settings.is_dev_mode
+
+
+@pytest.mark.parametrize("value", ["production", "Production", "STAGING", "preview", ""])
+def test_is_dev_mode_false_for_non_development(value: str) -> None:
+    """Anything other than 'development' (any casing) is not dev mode."""
+    with patch.object(settings, "environment", value):
+        assert not settings.is_dev_mode

--- a/docs/developer/TESTING.md
+++ b/docs/developer/TESTING.md
@@ -33,6 +33,8 @@ Write 2-3 service-layer test cases based on the issue description:
 
 ## Running Tests
 
+> The pytest suite assumes `ENVIRONMENT=development` (the project default). If you set `ENVIRONMENT` to anything else **without** also setting `CLERK_SECRET_KEY`, conftest's `from app.main import app` will raise `RuntimeError` at collection time — that's the [#241](https://github.com/suniljames/COREcare-v2/issues/241) startup guard doing its job, not a broken fixture.
+
 ```bash
 # All tests
 make test


### PR DESCRIPTION
Closes #257
Closes #258
Closes #259
Closes #260

Bundled cleanup of the four NITs the eng-committee flagged on PR #249. Each commit is single-issue so the trail stays clean.

## Summary

- **#257** — `Settings.is_dev_mode` now compares case-insensitively (`.lower()`). Boots in `ENVIRONMENT=Development` etc. without tripping the #241 startup guard. Adds parametrized unit tests in a new `test_config.py`.
- **#258** — Removed `test_dev_mode_no_auth_returns_mock_user`; the integration test added in #241 (`test_dev_env_no_secret_no_header_returns_mock_user`) covers the same path with real assertions.
- **#259** — One paragraph in `docs/developer/TESTING.md` noting that conftest's `from app.main import app` triggers the #241 startup guard at collection time, so a non-development `ENVIRONMENT` in the test env will fail collection (correctly — but non-obviously).
- **#260** — Parametrized test covering `Authorization: Bearer ` (empty token after the prefix) → 401, in both dev and production envs.

## Test Plan

- [x] `make check` clean locally (API: ruff/mypy/pytest including 2 new test_config tests + 1 new parametrized test_auth case = 357 passed; Web: lint/test/build all pass; repo invariant scripts: 55 passed)
- [ ] CI passes
- [ ] Squash merge after CI green

## Out of scope

The four follow-up issues from the design committee (#252, #253, #255, #256) are tracked separately — not part of this NIT cleanup.