### PR TITLE
docs(#236): cold-reader must_mention coverage for migrated kill-all row (security)

### DIFF
--- a/scripts/coldreader/fixtures/agency-admin.yaml
+++ b/scripts/coldreader/fixtures/agency-admin.yaml
@@ -50,20 +50,34 @@ questions:
     tolerance: 1
 
   - id: q3
-    text: "Which Agency Admin screens display PHI and require special v2 treatment?"
+    text: >-
+      Which Agency Admin screens need bespoke v2 design treatment because
+      they display PHI or sit behind an admin-elevation gate?
     fact_summary: |
-      Rows marked `🔒 PHI · ` and rows with `phi_displayed=true` in the row
-      table — concentrated in `### charting` (clinical surface, 22 routes
-      complete), `### clients` (per-client calendar and events with
-      attachments rendering linked-client data), `### compliance` (the two
-      authenticated PHI file-stream routes mounted at `compliance/files/`),
-      and `### billing` (invoice/payment surfaces). The expense-review routes
-      under top-level admin (`/admin/expenses/review/...`) carry
-      `phi_displayed=true` and surface in the cross-reference index.
+      Two distinct categories surface in this section:
+
+      (a) PHI-displaying rows marked `🔒 PHI · ` or carrying
+      `phi_displayed=true` in the row table — concentrated in `### charting`
+      (clinical surface, 22 routes complete), `### clients` (per-client
+      calendar and events with attachments rendering linked-client data),
+      `### compliance` (the two authenticated PHI file-stream routes mounted
+      at `compliance/files/`), and `### billing` (invoice/payment surfaces).
+      The expense-review routes under top-level admin
+      (`/admin/expenses/review/...`) carry `phi_displayed=true`.
+
+      (b) RLS-bypass / admin-elevation rows folded into Agency Admin per
+      #236 — most notably `/admin/view-as/kill-all/`, the platform-operator
+      kill-switch for runaway impersonation sessions. Gated by
+      `is_superuser` (Django's stock flag) rather than the Agency Admin
+      role grant; audit-logged via the View-As audit trail. v2 must add a
+      comparable platform-operator gate distinct from Agency Admin role
+      authority.
     must_mention:
       - ["phi_displayed", "PHI displayed", "PHI is displayed", "🔒 PHI"]
       - ["charting"]
       - ["clients"]
       - ["compliance"]
       - ["billing"]
+      - ["/admin/view-as/kill-all/", "view-as/kill-all", "kill-all"]
+      - ["is_superuser", "superuser"]
     tolerance: 1


### PR DESCRIPTION
## Summary

- Closes #251 — security-relevant drift coverage gap on `/admin/view-as/kill-all/` after #244 migrated the row from the deleted `## Super-Admin` section into `## Agency Admin` under `is_superuser` gating.
- Extends `scripts/coldreader/fixtures/agency-admin.yaml` q3 with two new `must_mention` groups so the next PR that silently edits the kill-all row's gating clause or audit-log behavior triggers `coldreader-drift`.
- Toward #236.

## Why this matters (security framing)

`/admin/view-as/kill-all/` is the v1 emergency control that terminates all View-As impersonation sessions. The row's load-bearing facts — `is_superuser`-only, audit-logged, RLS-bypass, v2 must add a comparable platform-operator gate distinct from Agency Admin authority — are documented in the inventory under `## Agency Admin`. Without `must_mention` coverage, a future PR could change "is_superuser" to "is_staff" (or similar) and the cold-reader's weekly run would not surface the drift.

The Security Engineer's review on #246 flagged this as the gating concern for closing parent #236.

## Diff shape

| File | Change |
|---|---|
| `scripts/coldreader/fixtures/agency-admin.yaml` q3 `text` | broadened from "screens display PHI **and** require special v2 treatment" → "screens need bespoke v2 design treatment because they display PHI **or** sit behind an admin-elevation gate". |
| q3 `fact_summary` | expanded to document two categories (PHI-displaying + admin-elevation) and the kill-all row's specific facts. |
| q3 `must_mention` | added two groups: `["/admin/view-as/kill-all/", "view-as/kill-all", "kill-all"]` and `["is_superuser", "superuser"]`. |
| q3 `tolerance` | kept at `1`. Total entries now 7, within the README's "4-7 typical" range. |

The kill-all row carries `phi_displayed=false` — it does NOT display PHI — so q3's predicate had to broaden from the conjunctive "PHI **and** special v2" to the disjunctive "PHI **or** admin-elevation". Existing PHI coverage (charting, clients, compliance, billing, phi_displayed) is preserved unchanged.

## Test plan

- [x] `make coldreader-local-dry` — `loaded 6 fixtures; 6 sections above floor; errors: 0`. Anchoring check: every alternate in the 2 new must_mention groups appears as a substring of the post-#244 `## Agency Admin` section ∪ cross-reference index.
- [x] `make coldreader-test` — 129 passed.
- [x] ruff format / ruff check / mypy — all clean.
- [ ] CI passes.

## Anchoring evidence (from post-#244 inventory)

The new must_mention alternates anchor against these substrings in the live `## Agency Admin` section:

- `/admin/view-as/kill-all/` — line 168 row path; also referenced in line 36 (top-level apps row), line 57 (status note).
- `kill-all` — substring of all of the above.
- `is_superuser` — lines 36, 57, 168.
- `superuser` — substring of `is_superuser`.

## Operational impact

- Next Mon 06:00 UTC `v1-inventory-coldreader.yml` workflow will exercise q3 with the broader question and 7 must_mention groups. Expected: PASS.
- Cost: trivially identical — same 6 personas, same 18 questions, same caching pattern.

## Closes
- #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)