### PR TITLE
docs(#282): drop stale #240 blocker in README migrations FAQ

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ A role-based user archetype the product designs for — Caregiver, Family Member
 PostgreSQL Row-Level Security (RLS) at the database layer. Every tenant-scoped table has a policy keyed on `app.current_tenant_id`, set per-request from the authenticated user's `agency_id`. See [ADR-002](adr/002-postgresql-rls-multi-tenancy.md) for the decision and [`developer/ARCHITECTURE.md`](developer/ARCHITECTURE.md) for the implementation pattern.
 
 **How do I add a database migration?**
-*Currently blocked by [#240](https://github.com/suniljames/COREcare-v2/issues/240)* — schema-init is broken (no migration creates the initial tables). Once that's resolved, the workflow will be: create a new revision under `api/alembic/versions/`, run `make api-migrate` against a fresh DB, add a test, ship. Until then, schema lives in `SQLModel.metadata.create_all` in test fixtures.
+Edit models in `api/app/models/`, run `make -C api migration MSG="describe-the-change"` to autogenerate a revision under `api/alembic/versions/`, inspect it, apply with `make api-migrate`, add a test, ship. See [`developer/migrations-runbook.md`](developer/migrations-runbook.md) for the full workflow — autogenerate gotchas (partial indexes, RLS, JSONB), reset, bootstrap, and CI drift recovery.
 
 ## What's *not* here
 


### PR DESCRIPTION
## Summary

- `docs/README.md:40` (the "How do I add a database migration?" FAQ) used to lead with *Currently blocked by #240 — schema-init is broken* and a SQLModel.metadata.create_all caveat. #240 closed 2026-05-08.
- Replaced with a thumbnail of the actual workflow (`make -C api migration MSG=…` → inspect → `make api-migrate` → test → ship) and a pointer to `docs/developer/migrations-runbook.md` for the full flow (autogenerate gotchas, reset, bootstrap, CI drift recovery).

## What I checked

- The runbook target `make -C api migration MSG="…"` exists and calls `alembic revision --autogenerate` (`docs/developer/migrations-runbook.md:46`).
- `make api-migrate` Makefile target exists and runs `alembic upgrade head`.
- `api/alembic/versions/0001_initial_schema.py` exists post-#240, so the workflow as written is the live one.
- Other `#240` references in `docs/`: only `developer/migrations-runbook.md:134` ("This was issue #240. Steps to triage if it ever recurs:") — past-tense triage history, intentionally preserved.

## Out of scope

- Line 33 persona FAQ ambiguity tracked separately in #283 — that's a writer/PM call, not a factual fix.

## Test plan

- [ ] Render `docs/README.md` on GitHub; confirm the migrations FAQ reads cleanly with no "blocked" framing.
- [ ] `grep -rn "#240" docs/` shows only the historical reference in `migrations-runbook.md:134`.

Closes #282.

🤖 Generated with [Claude Code](https://claude.com/claude-code)