### PR TITLE
docs(#280): tighten Agency Admin section-intro paragraph in v1-user-journeys.md

### DIFF
--- a/docs/migration/v1-user-journeys.md
+++ b/docs/migration/v1-user-journeys.md
@@ -25,7 +25,7 @@ Each journey **cites pages-inventory anchors** rather than redefining route fact
 
 _last reconciled: 2026-05-07 against v1 commit `9738412`_
 
-Agency Admin is v1's largest persona surface and v2's highest-volume rebuild target. The first five journeys below cover the operational spine: client onboarding, caregiver onboarding, weekly payroll, billing, and credential expiry handling. Two additional journeys are folded here per #236 — they describe the v1 platform-operator surfaces (capability administration with the View-As kill switch, and the View-As impersonation suite). Those routes are gated on Django's stock `is_staff` flag (and `is_superuser` exclusively for the kill-switch backstop) rather than the Agency Admin role grant; v1 has no separate platform-operator role. v2 design is expected to elevate these to genuinely cross-tenant surfaces with a dedicated platform-operator boundary.
+Agency Admin is v1's largest persona surface and v2's highest-volume rebuild target. The first five journeys below cover the operational spine: client onboarding, caregiver onboarding, weekly payroll, billing, and credential expiry handling. Two additional journeys are folded here per #236 — the v1 platform-operator surfaces: capability administration with the View-As kill switch, and the View-As impersonation suite. v1 has no separate platform-operator role, so those routes are gated on Django's stock `is_staff` flag, with `is_superuser` reserved exclusively for the kill-switch backstop. v2 design is expected to elevate them to genuinely cross-tenant surfaces with a dedicated platform-operator boundary.
 
 ### Client intake — onboarding a new client into operations
 


### PR DESCRIPTION
## Summary

- Tightens the `## Agency Admin` section-intro paragraph at `docs/migration/v1-user-journeys.md:28` per [#280](https://github.com/suniljames/COREcare-v2/issues/280) — Writer-flagged nit deferred from PR #279.
- Reorder leads with the categorical fact (`v1 has no separate platform-operator role`); gating mechanic follows as consequence. Semicolon → 0; mid-clause parens → 0; word count 104 → 97; longest sentence 29 → 25 words.
- All four security invariants preserved verbatim or stronger (verified against `v1-glossary.md:43` and `v1-pages-inventory.md:147`).

## Diff (paragraph)

**Before:**

> Agency Admin is v1's largest persona surface and v2's highest-volume rebuild target. The first five journeys below cover the operational spine: client onboarding, caregiver onboarding, weekly payroll, billing, and credential expiry handling. Two additional journeys are folded here per #236 — they describe the v1 platform-operator surfaces (capability administration with the View-As kill switch, and the View-As impersonation suite). Those routes are gated on Django's stock `is_staff` flag (and `is_superuser` exclusively for the kill-switch backstop) rather than the Agency Admin role grant; v1 has no separate platform-operator role. v2 design is expected to elevate these to genuinely cross-tenant surfaces with a dedicated platform-operator boundary.

**After:**

> Agency Admin is v1's largest persona surface and v2's highest-volume rebuild target. The first five journeys below cover the operational spine: client onboarding, caregiver onboarding, weekly payroll, billing, and credential expiry handling. Two additional journeys are folded here per #236 — the v1 platform-operator surfaces: capability administration with the View-As kill switch, and the View-As impersonation suite. v1 has no separate platform-operator role, so those routes are gated on Django's stock `is_staff` flag, with `is_superuser` reserved exclusively for the kill-switch backstop. v2 design is expected to elevate them to genuinely cross-tenant surfaces with a dedicated platform-operator boundary.

## Verification

| Gate | Status | Evidence |
|---|---|---|
| `make scan-v1-docs` | ✅ exit 0 | hygiene + structure + catalog-coverage all pass |
| Literal-token grep on `v1-user-journeys.md` | ✅ all ≥ 1 | `is_staff` (5), `is_superuser` (6), `kill-switch` (3), `platform-operator` (4), `Agency Admin` (13), `#236` (2) |
| Sentence count | ✅ 5 (target 5) | matches existing structure |
| Word count | ✅ 97 (target ≤ 110) | reduced from 104 |
| Longest sentence | ✅ 25 words (target ≤ 30) | reduced from 29 |
| Semicolons in paragraph | ✅ 0 (target 0) | the run-on signal removed |
| Mid-clause parentheticals | ✅ 0 (target 0) | replaced by trailing comma clause |
| Cross-doc drift vs `v1-glossary.md:43` | ✅ none | all four invariants align |
| Cross-doc drift vs `v1-pages-inventory.md:147` | ✅ none | all four invariants align |

### Security invariants (Security Engineer's lock-down set)

| Invariant | Where in rewrite |
|---|---|
| 1. General View-As gate is `is_staff` | "those routes are gated on Django's stock `is_staff` flag" |
| 2. Kill-switch backstop is `is_superuser` exclusively | "with `is_superuser` reserved exclusively for the kill-switch backstop" — *reserved exclusively* is strict-or-stricter than original *exclusively for* |
| 3. v1 has no separate platform-operator role | sentence 4 leads with this verbatim |
| 4. v2 elevates to cross-tenant surfaces with a dedicated platform-operator boundary | sentence 5, near-verbatim (`these` → `them` for antecedent clarity) |

## Test plan

- [x] `make scan-v1-docs` passes locally
- [x] Literal-token grep — every required token returns ≥ 1
- [x] Structural metrics within bounds (5 sentences / ≤ 110 words / ≤ 30 per sentence / 0 semicolons / 0 mid-clause parens)
- [x] Cross-doc semantic-drift read against `v1-glossary.md:43` and `v1-pages-inventory.md:147`
- [x] CI re-runs the same gate (`V1 Doc Hygiene` workflow)

## Related

- Closes #280
- Source: NIT raised by Writer during PR #279 review; deferred from that PR
- Toward: #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)