### PR TITLE
docs(#283): align persona vocabulary across README + GLOSSARY (v1/v2 boundary, Client added, RLS-bypass framing)

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -26,9 +26,9 @@ Canonical definitions for terms that show up across the COREcare codebase and do
 |------|-----------|
 | **PHI** | Protected Health Information — any individually identifiable health data. HIPAA-regulated. Never appears in logs, errors, URLs, or analytics. See [`docs/developer/SAFETY.md`](developer/SAFETY.md). |
 | **RLS** | PostgreSQL Row-Level Security. The mechanism that enforces tenant isolation: queries automatically filter to the calling user's `agency_id` regardless of what the application code asks for. See [ADR-002](adr/002-postgresql-rls-multi-tenancy.md). |
-| **RLS-bypass surface** | Routes that intentionally cross tenant boundaries (e.g., Super-Admin operations). Every such route requires audit logging by design. |
+| <a id="rls-bypass-surface"></a>**RLS-bypass surface** | Routes that intentionally cross tenant boundaries (e.g., Super-Admin operations). Every such route requires audit logging by design. |
 | **ADLs** | Activities of Daily Living — bathing, dressing, eating, mobility, toileting. Standard home-care vocabulary used in care plans and visit documentation. |
-| **Persona** | A role-based user archetype the product designs for: Caregiver, Family Member, Care Manager, Agency Admin, Super-Admin. Distinct from a user's literal `role` enum (which is the implementation), a persona is the *experience* that role gets. |
+| **Persona** | A role-based user archetype the product designs for, distinct from the literal `role` enum (the implementation). The product surface targets five personas: Caregiver, Family Member, Care Manager, Client, and Agency Admin — these are tenant-scoped. v2 design adds a sixth, Super-Admin, the platform-operator role that bypasses tenant Row-Level Security (see [`RLS-bypass surface`](#rls-bypass-surface) and [ADR-002](adr/002-postgresql-rls-multi-tenancy.md)); Super-Admin is forward-looking and has no v1 equivalent. |
 
 ## Process terms
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ You're inside `docs/`. Pick a lane.
 ## Common questions
 
 **What's a "persona" in this product?**
-A role-based user archetype the product designs for — Caregiver, Family Member, Care Manager, Agency Admin, Super-Admin. It's the *experience* that role gets, distinct from the literal `role` enum. Full table in [`GLOSSARY.md`](GLOSSARY.md).
+A role-based user archetype the product designs for — distinct from the literal `role` enum (the implementation). The full enumeration with v1/v2 scope notes lives in [`GLOSSARY.md`](GLOSSARY.md).
 
 **How is multi-tenancy enforced?**
 PostgreSQL Row-Level Security (RLS) at the database layer. Every tenant-scoped table has a policy keyed on `app.current_tenant_id`, set per-request from the authenticated user's `agency_id`. See [ADR-002](adr/002-postgresql-rls-multi-tenancy.md) for the decision and [`developer/ARCHITECTURE.md`](developer/ARCHITECTURE.md) for the implementation pattern.


### PR DESCRIPTION
## Summary

Two commits implementing the locked plan from #283 (committee-reviewed, design-complete):

- **Commit 1** — `docs/README.md:33` FAQ drops the partial enumeration; defers to `GLOSSARY.md` per the "thumbnail + pointer" pattern of the adjacent multi-tenancy FAQ.
- **Commit 2** — `docs/GLOSSARY.md:31` Persona entry rewritten with Writer's locked language: explicit v1/v2 boundary, Client added (resolves the prior self-contradiction with GLOSSARY.md:13), Super-Admin framed as RLS-bypass platform-operator (per Security review). Also adds an inline `<a id="rls-bypass-surface">` anchor to GLOSSARY.md:29 so the new entry's `#rls-bypass-surface` link actually resolves (GitHub auto-anchors only headers, not table cells).

Closes #283.

## What I checked

### Test Specification gates (all green)

- [x] `make scan-v1-docs` — `coverage: 100%`, OK
- [x] `make coldreader-local-dry` — 6 fixtures, 0 errors
- [x] `make check` — exit 0 (API lint/format/mypy/tests, Web lint/tests/build, all script self-tests)
- [x] `git grep "Super-Admin"` audit across `docs/` + `.claude/` — every match is either explicitly v1/v2-framed, an architectural forward-looking reference, or a v1 historical reference noting v1 has no Super-Admin role
- [x] `Client` and `Super-Admin` both present in `docs/GLOSSARY.md:31`
- [x] `docs/README.md:33` no longer carries an enumeration
- [x] `#rls-bypass-surface` anchor resolves (inline `<a id>` added at GLOSSARY.md:29)

### Commit 3 (pm-context audit) — dropped per locked plan

The issue body's Implementation Plan Commit 3 was a verification-only step with explicit "can be omitted from the PR" if no edits needed. After audit:

- `.claude/pm-context.md:7` — Domain prose mentions "caregivers, family members, and agency administrators" + "patient/client record" + "platform-level super-admin"; this is relationship narrative, not a persona enumeration. Acceptable.
- `.claude/pm-context.md:11-24` — Domain Vocabulary table; already includes both Client (line 17) and Super-Admin (line 21). Not a persona enumeration; vocabulary list. Acceptable.
- `.claude/pm-context.md:26-36` — Stakeholders table; locked plan said no row change. Existing footnote at line 36 carries v1/v2 framing.
- No "Personas: …" enumeration prose elsewhere in the file omits Client.

→ No edits needed; Commit 3 dropped, ship 2 commits.

## Observation flagged for follow-up (not in scope)

The `.claude/pm-context.md:26-36` Stakeholders table lists 5 personas (Super-Admin, Agency Admin, Care Manager, Caregiver, Family Member) and **omits Client**. Under the new GLOSSARY.md:31 canonical Persona definition, Client IS one of the five tenant-scoped personas; pm-context's Stakeholders is now technically inconsistent with the canonical definition.

Per the committee-locked plan ("no row change"), this PR does not modify the Stakeholders table. The omission is also explicitly justified at `docs/migration/v1-pages-inventory.md:402` ("v1 has no Client-as-actor surface… `.claude/pm-context.md` `Stakeholders` table aligns with this reality"), which reflects the v1 reality (Client is subject, not actor) — distinct from the v2-eventual reality where Client logs in (#125).

Whether to expand the Stakeholders table to include Client is a writer/PM call about which "now" the table is describing. Worth considering as a separate issue if you want pm-context to align with the post-#283 GLOSSARY.

## Test plan

- [ ] On the GitHub-rendered diff for `docs/GLOSSARY.md`, click the `RLS-bypass surface` link inside the new Persona entry → verify it scrolls to the row at line 29.
- [ ] On the GitHub-rendered `docs/README.md`, confirm the persona FAQ reads as definition + GLOSSARY pointer, no enumeration.
- [ ] CI pipeline: API + Web + script self-tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)