### PR TITLE
docs(#287): tighten new-contributor onboarding path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,13 @@ This project follows the [engineering directives](https://github.com/suniljames/
 
 ## Get running in 10 minutes
 
-**Prerequisite:** [Docker Desktop](https://www.docker.com/products/docker-desktop) installed and running. Everything else (Python, Node, pnpm, uv, git-lfs) is recommended but optional — Docker handles the runtime.
+**Hard requirements:**
+- [Docker Desktop](https://www.docker.com/products/docker-desktop) — runs the local stack.
+- `uv` (Python package manager) — `brew install uv`. Needed by `make api-migrate`, `make api-seed`, and the API half of `make check`, all of which run on the host.
+- `pnpm` and Node 20 — `brew install pnpm node@20`. Needed by the web half of `make check` and any host-side `pnpm dev`.
+
+**Optional:**
+- `git-lfs` — only required if you'll be touching the [v1 UI catalog](docs/legacy/v1-ui-catalog/) WebP binaries.
 
 ```bash
 git clone https://github.com/suniljames/COREcare-v2.git
@@ -35,7 +41,7 @@ make health       # API / Web / DB / Redis health
 make check        # Lint + typecheck + test + build (must pass before PRs)
 ```
 
-If `make setup` warns about missing tools (Node, Python, pnpm, uv), those are only needed for non-Docker workflows — the Docker stack will still come up. See [Troubleshooting](#troubleshooting) below if anything fails.
+If `make setup` warns about missing `uv`, `pnpm`, or Node, install them before running `make api-migrate` / `make api-seed` / `make check` — the Docker stack will come up either way, but those targets execute on the host. See [Troubleshooting](#troubleshooting) below if anything fails.
 
 ## Tech Stack
 
@@ -53,25 +59,25 @@ If `make setup` warns about missing tools (Node, Python, pnpm, uv), those are on
 
 ## Dev/Test Environment
 
-After cloning, install Git LFS once so the [v1 UI catalog](docs/legacy/v1-ui-catalog/) WebP binaries (per [ADR-010](docs/adr/010-v1-ui-catalog-storage.md)) are fetched correctly:
-
-```bash
-git lfs install
-```
+`make setup` runs `git lfs install --local` for you so the [v1 UI catalog](docs/legacy/v1-ui-catalog/) WebP binaries (per [ADR-010](docs/adr/010-v1-ui-catalog-storage.md)) get fetched. The setup script will warn if `git-lfs` itself isn't on your system — install with `brew install git-lfs` and re-run `make setup`.
 
 Local Docker Compose: `docker compose up` starts API (8000), Web (3000), PostgreSQL, Redis.
 
 Test accounts (seeded by `make api-seed`):
 
-| Role | Email | Password |
-|------|-------|----------|
-| Super-Admin | superadmin@test.com | `TestSuper123!` |
-| Agency Admin | admin@test.com | `TestAdmin123!` |
-| Care Manager | manager1@test.com | `TestManager123!` |
-| Caregiver 1 | caregiver1@test.com | `TestCare123!` |
-| Caregiver 2 | caregiver2@test.com | `TestCare123!` |
-| Family 1 | family1@test.com | `TestFamily123!` |
-| Family 2 | family2@test.com | `TestFamily123!` |
+| Role | Email |
+|------|-------|
+| Super-Admin | superadmin@test.com |
+| Agency Admin | admin@test.com |
+| Care Manager | manager1@test.com |
+| Caregiver 1 | caregiver1@test.com |
+| Caregiver 2 | caregiver2@test.com |
+| Family 1 | family1@test.com |
+| Family 2 | family2@test.com |
+
+Auth is Clerk-only — there is no local password column on `User`. Two ways to use these accounts:
+- **API testing (default):** `ENVIRONMENT=development` + empty `CLERK_SECRET_KEY` resolves every request to a mock `super_admin` (see [Local authentication](#local-authentication) below). The seeded rows in the DB are what API endpoints look up by `agency_id` / `role`.
+- **Web sign-in:** create matching users in your own Clerk dev instance with the same emails, then set real `pk_test_…` / `sk_test_…` keys.
 
 ```bash
 make check                # Lint + typecheck + test + build (must pass before PRs)
@@ -103,13 +109,21 @@ When to set real Clerk keys:
 | Run E2E tests against the full stack | Yes |
 | Run any non-development environment (`ENVIRONMENT != development`) | **Yes — the API refuses to boot without it** |
 
-Get keys from [Clerk's dashboard](https://dashboard.clerk.com/) and put them in `web/.env.local` and `api/.env`.
+Get keys from [Clerk's dashboard](https://dashboard.clerk.com/), then place them according to how you're running the stack:
+
+- **Docker Compose (default `make setup` flow):** `docker compose` reads from a project-root `.env` file, *not* `api/.env` or `web/.env.local`. Create `./.env` with:
+  ```
+  CLERK_SECRET_KEY=sk_test_…
+  CLERK_PUBLISHABLE_KEY=pk_test_…
+  ```
+  Then `docker compose up -d --force-recreate web api` to pick them up.
+- **Host workflows (`pnpm dev`, `uv run …` outside Docker):** put `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` + `CLERK_SECRET_KEY` in `web/.env.local`, and `CLERK_SECRET_KEY` + `CLERK_PUBLISHABLE_KEY` in `api/.env`.
 
 ## Branches and commits
 
 Branch names: `<type>/<issue>-<short-desc>` (e.g. `feat/235-onboarding-cleanup`, `docs/106-readme-rewrite`).
 
-Commit messages: `<type>(#<issue>): <subject>` (e.g. `feat(#235): add scripts/setup.sh`). See `git log` for the project's prevailing style. Every change must be associated with a GitHub issue — see [`#213`](https://github.com/suniljames/COREcare-v2/issues/213).
+Commit messages: `<type>(#<issue>): <subject>` (e.g. `feat(#235): add scripts/setup.sh`). See `git log` for the project's prevailing style. Every change must be associated with a GitHub issue (rule established in [#213](https://github.com/suniljames/COREcare-v2/issues/213)).
 
 PRs run `make check` in CI; they're blocked until that passes. Use [`.github/pull_request_template.md`](.github/pull_request_template.md) — the template prompts for the linked issue, summary, and test plan.
 
@@ -137,12 +151,12 @@ Run `make api-migrate` first. If the DB is in an unknown state (created by stray
 
 Slash commands that cut branches must do so from an explicit, freshly-fetched
 named remote ref (e.g., `origin/main`) — never from an implicit local branch.
-See [`#176`](https://github.com/suniljames/COREcare-v2/issues/176) and the
+Invariant established in [#176](https://github.com/suniljames/COREcare-v2/issues/176);
 regression test at `scripts/tests/test_implement_branch_cut.sh`.
 
 Pipeline commands (`/define`, `/design`, `/implement`, `/review`) abort on
 closed issues by default. Pass `--force-on-closed` to override on a single
-run. See [`#213`](https://github.com/suniljames/COREcare-v2/issues/213).
+run. Behavior established in [#213](https://github.com/suniljames/COREcare-v2/issues/213).
 
 ## Domain context (home-care SaaS)
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help: ## Show this help
 
 # --- Bootstrap ---
 
-setup: ## First-run bootstrap: verify tools, seed .env, start stack, seed data
+setup: ## First-run bootstrap: verify tools, seed .env, start Docker stack, wait for /healthz (run api-migrate + api-seed afterwards)
 	bash scripts/setup.sh
 
 # --- Docker ---

--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ Multi-tenant SaaS platform for home care agencies — coordinates clients, careg
 
 ## Get started
 
-New contributor? **Run `scripts/setup.sh`** for a guided bootstrap — checks tool versions, seeds `.env` files from examples, brings up the Docker stack, and waits for `/healthz`. Then read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the development workflow (including the schema-init caveat tracked in [#240](https://github.com/suniljames/COREcare-v2/issues/240)).
+New contributor? **Run `make setup`** for a guided bootstrap — checks tool versions, seeds `.env` files from examples, brings up the Docker stack, and waits for `/healthz`. Then apply migrations, seed test data, and verify the stack:
 
 ```bash
 git clone https://github.com/suniljames/COREcare-v2.git
 cd COREcare-v2
-scripts/setup.sh
+make setup        # bootstrap (or: bash scripts/setup.sh)
+make api-migrate  # alembic upgrade head — creates the schema
+make api-seed     # demo agency + 7 test users
+make health       # API / Web / DB / Redis check
 ```
+
+Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full development workflow, the test-account roster, and `make check` (the pre-PR quality gate).
 
 ## Documentation
 

--- a/api/app/tests/test_migrations_e2e.py
+++ b/api/app/tests/test_migrations_e2e.py
@@ -5,7 +5,7 @@ the empty DB, runs `app.seed.seed()`, and asserts:
 
 - T1 — fresh-DB migrate + seed succeeds with the expected row counts
 - T2 — `SQLModel.metadata` matches migration head (drift guard)
-- T3 — RLS policy parity matches the post-0008 design state
+- T3 — RLS policy parity matches the design state
 - T4 — `messages.recipient_id` is nullable
 
 Tests are marked `integration`. Skipped when Docker is unavailable.
@@ -165,14 +165,14 @@ async def test_t2_no_schema_drift_after_migration(migrated_database_url: str) ->
 
 
 # ---------------------------------------------------------------------------
-# T3 — RLS policy parity (post-0008 state)
+# T3 — RLS policy parity
 # ---------------------------------------------------------------------------
 
 
-# Single-axis tenant_isolation tables (post-0001 + 0002 design state).
+# Single-axis tenant_isolation tables.
 SINGLE_AXIS_TABLES = {"users", "email_events"}
 
-# Dual-axis tenant_and_client_isolation tables (post-0008 design state).
+# Dual-axis tenant_and_client_isolation tables.
 DUAL_AXIS_TABLES = {
     "clients",
     "shifts",
@@ -182,7 +182,7 @@ DUAL_AXIS_TABLES = {
 }
 
 
-async def test_t3_rls_policies_match_post_0008_state(session: AsyncSession) -> None:
+async def test_t3_rls_policies_match_design_state(session: AsyncSession) -> None:
     rows = (
         await session.execute(
             text("SELECT tablename, policyname FROM pg_policies WHERE schemaname='public'")
@@ -220,7 +220,7 @@ async def test_t3_rls_force_enabled_on_all_protected_tables(session: AsyncSessio
 
 
 # ---------------------------------------------------------------------------
-# T4 — messages.recipient_id nullability (preserves 0009 correctness)
+# T4 — messages.recipient_id nullability
 # ---------------------------------------------------------------------------
 
 
@@ -235,4 +235,4 @@ async def test_t4_messages_recipient_id_nullable(session: AsyncSession) -> None:
             )
         )
     ).scalar()
-    assert is_nullable is True, "messages.recipient_id must be nullable (post-0009)"
+    assert is_nullable is True, "messages.recipient_id must be nullable"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,11 @@ services:
       - "3000:3000"
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:8000
-      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY:-}
+      # Defaults to Clerk's publicly-known dummy publishable key so the web
+      # container boots without requiring a project-root .env. Override by
+      # exporting CLERK_PUBLISHABLE_KEY (or setting it in a project-root .env
+      # that docker compose loads) to test live Clerk auth.
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY:-pk_test_Y2xlcmsuaW5jbHVkZWQua2F0eWRpZC05Mi5sY2wuZGV2JA}
       CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
     volumes:
       - ./web:/app

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -10,7 +10,7 @@ Canonical definitions for terms that show up across the COREcare codebase and do
 |------|-----------|
 | **Agency** | A home-care business that employs caregivers and serves clients. Each agency is a tenant. |
 | **Tenant** | An agency and all its associated data, isolated by PostgreSQL Row-Level Security (RLS). One tenant per agency. |
-| **Client** | The person receiving home-care services (often elderly or disabled). In v2, Clients can optionally have a User record and log in (the "Client persona" — see [#125](https://github.com/suniljames/COREcare-v2/issues/125)). |
+| **Client** | The person receiving home-care services (often elderly or disabled). In v2, Clients can optionally have a User record and log in (the "Client persona" — shipped in [#125](https://github.com/suniljames/COREcare-v2/issues/125)). |
 | **Caregiver** | Field worker (RN, CNA, HHA, therapist) who provides direct care in client homes. Highest-volume, lowest-patience user — UX defaults to their mobile experience. |
 | **Care Manager** | Supervising nurse or coordinator who creates care plans and oversees caregiver assignments. |
 | **Family Member** | A client's relative or authorized representative with limited platform visibility. Linked to a Client via `ClientFamilyMember`. |

--- a/docs/adr/006-claude-api-ai-features.md
+++ b/docs/adr/006-claude-api-ai-features.md
@@ -13,7 +13,7 @@ COREcare v2 includes AI-powered features: conversational agent (SMS/WhatsApp), s
 Use the **Claude API (Anthropic)** as the primary AI backend.
 
 ### Integration Pattern
-- **Agent service** — centralized service in `api/app/services/ai/` that manages all Claude API interactions
+- **Agent service** — centralized service in `api/app/services/ai.py` that manages all Claude API interactions
 - **Prompt templates** — versioned templates stored in code, never user-editable
 - **Safety guardrails:**
   - No PHI in prompts (substitute with anonymized placeholders)

--- a/docs/adr/008-shadcn-ui-component-library.md
+++ b/docs/adr/008-shadcn-ui-component-library.md
@@ -20,7 +20,7 @@ Options:
 Use **shadcn/ui** as the component foundation.
 
 ### Why shadcn/ui
-- **Copy-paste, not dependency** — components live in our codebase (`web/src/components/ui/`), fully customizable
+- **Copy-paste, not dependency** — components will live in our codebase under `web/src/components/ui/` (directory created on first component), fully customizable
 - **Radix UI primitives** — accessible by default (ARIA, keyboard nav, focus management)
 - **Tailwind CSS native** — integrates perfectly with our design token system
 - **HSL CSS variables** — theming via CSS custom properties, matching our `TOKENS.md`

--- a/docs/adr/011-email-outbound-boundary.md
+++ b/docs/adr/011-email-outbound-boundary.md
@@ -164,7 +164,7 @@ CI if any imports `sendgrid`, `smtplib`, or
 | Redaction | `api/app/services/email/redaction.py` |
 | Public surface | `api/app/services/email/__init__.py` |
 | Audit row | `api/app/models/email.py` |
-| Schema | `api/alembic/versions/0002_email_events.py` |
+| Schema | `api/alembic/versions/0001_initial_schema.py` (`email_events` table; the original 0002 was folded into 0001 by the squash for #240) |
 | Sender unit tests | `api/app/tests/services/email/test_sender.py` |
 | Feature tests | `api/app/tests/services/test_billing_email.py` |
 | Architecture-fitness | `api/app/tests/architecture/test_email_boundary.py` |

--- a/docs/design-system/COMPONENTS.md
+++ b/docs/design-system/COMPONENTS.md
@@ -1,5 +1,11 @@
 # Component Library
 
+> **Status: forward-looking design spec.** The components and layouts described
+> below are the target shadcn/ui surface for COREcare v2; most do not yet exist
+> in `web/src/components/` (the directory is created when the first component
+> lands). Use this file as the contract for what to build, not as a catalog of
+> what's already importable. Tracked component-by-component as work lands.
+
 Built on shadcn/ui with COREcare theme overrides.
 
 ## shadcn/ui Base Components

--- a/docs/design-system/README.md
+++ b/docs/design-system/README.md
@@ -4,7 +4,7 @@ shadcn/ui + Tailwind CSS token system for COREcare v2. Multi-tenant healthcare c
 
 ## Read first
 
-[`COMPONENTS.md`](COMPONENTS.md) — how to compose shadcn/ui primitives into product components, when to extend the library, naming conventions. Start here when building anything new.
+[`COMPONENTS.md`](COMPONENTS.md) — the target shadcn/ui component surface for COREcare v2 (forward-looking spec; most components are not yet implemented). Use it as the contract when building anything new.
 
 ## Reference (read when the topic comes up)
 
@@ -12,12 +12,11 @@ shadcn/ui + Tailwind CSS token system for COREcare v2. Multi-tenant healthcare c
 |---|---|
 | [`TOKENS.md`](TOKENS.md) | Colors, spacing, typography, shadows, radii. **Always check tokens before hardcoding values.** |
 | [`ACCESSIBILITY.md`](ACCESSIBILITY.md) | WCAG 2.1 AA targets — contrast, focus management, ARIA, keyboard navigation. Caregivers use this on phones in field conditions; a11y is non-optional. |
-| [`RESPONSIVE.md`](RESPONSIVE.md) | Mobile (≤480px), tablet (481–1024px), desktop (>1024px) breakpoints. Caregiver flows are mobile-first. |
+| [`RESPONSIVE.md`](RESPONSIVE.md) | Mobile (<640px), tablet (≥640px), desktop (≥1024px), wide (≥1280px) — Tailwind's default breakpoints. Caregiver flows are mobile-first. |
 | [`BRAND.md`](BRAND.md) | Multi-tenant agency branding — logos, agency-specific colors, tenant-scoped theming. |
 | [`CONTENT_GUIDE.md`](CONTENT_GUIDE.md) | User-facing copy: error messages, button labels, empty states, voice and tone. |
 
 ## Cross-references
 
-- A11y is enforced in tests — see [`../developer/TESTING.md`](../developer/TESTING.md) for the axe-core pattern.
 - Frontend code review uses the [UX Designer lens](../developer/code-review-lenses.md#ux-designer).
 - The shadcn/ui choice is recorded in [ADR-008](../adr/008-shadcn-ui-component-library.md).

--- a/docs/developer/SAFETY.md
+++ b/docs/developer/SAFETY.md
@@ -25,7 +25,7 @@ The dev-mode auth fallback (mock `super_admin` user, JWT signature-skip) is gate
 - Do not introduce new env-blind dev fallbacks.
 - Any new dev-only behavior must route through `settings.is_dev_mode`.
 
-Issue reference: [#241](https://github.com/suniljames/COREcare-v2/issues/241).
+Implemented in [#241](https://github.com/suniljames/COREcare-v2/issues/241).
 
 ## Safe Branch-Switching
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -126,23 +126,20 @@ printf '%b✅ COREcare v2 stack is up.%b\n' "$G$B" "$X"
 echo
 info "Next steps"
 cat <<'EOF'
-  • Open http://localhost:3000 to see the web app.
-  • API docs at http://localhost:8000/docs.
-  • Run quality gates before committing: make check
-  • Run tests:                            make test
-  • Stop containers:                      make down
+  • Apply schema:    make api-migrate   # alembic upgrade head
+  • Seed test data:  make api-seed      # demo agency + 7 test users
+  • Verify health:   make health        # API / Web / DB / Redis
+  • Open the web app: http://localhost:3000
+  • Open API docs:    http://localhost:8000/docs
+  • Pre-PR gate:     make check
+  • Stop the stack:  make down
 
-Database schema and seed data are NOT applied automatically — the schema
-init / migration sequence has a known issue (no migration creates the
-initial tables; SQLModel.metadata.create_all is only used in tests). Once
-that's fixed, the next steps will be:
-
-  make api-migrate    # apply migrations
-  make api-seed       # seed test accounts
+Note: make api-migrate / api-seed / check run on the host (not inside the
+api container) and require uv + pnpm + Node. If the warnings above flagged
+any of those missing, install them with: brew install uv pnpm node@20.
 
 Local auth: by default the API uses a dev fallback — requests sent without
 an Authorization header receive a mock super_admin user (api/app/auth.py).
-That works against an empty schema for endpoints that don't query a table.
 
 See CONTRIBUTING.md for the full contributor workflow.
 EOF


### PR DESCRIPTION
## Summary

Closes #287. Audit of every link, command, and demo on the README "Get started" path before an external contributor lands tomorrow.

- **Web container Clerk wiring fixed** — `docker-compose.yml` now defaults `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` to Clerk's published dummy key, so `localhost:3000` boots out of the box. (Previous default expanded to empty because Compose reads from project-root `.env`, which `setup.sh` doesn't seed.)
- **Stale schema-init / #240 narrative scrubbed** — README + setup.sh now describe the working flow. (`docs/README.md` was already fixed by #284.)
- **CONTRIBUTING.md test accounts** — fictional Password column dropped (auth is Clerk-only); added how-to-actually-use-these-emails block.
- **`uv` / `pnpm` / Node promoted to hard requirements** — they're host tools needed by `make api-migrate` / `api-seed` / `check`, not optional.
- **ADR drift fixed** — ADR-006 path, ADR-008 components-dir framing, ADR-011 migration filename.
- **Design-system docs flagged forward-looking content** — COMPONENTS.md prepended with a spec-not-catalog banner; breakpoints in design-system/README.md aligned with RESPONSIVE.md.
- **Closed-issue framing** — SAFETY.md, GLOSSARY.md, CONTRIBUTING.md now read as historical citations rather than live blockers.
- **Test-file cleanup** — pre-squash "post-0001 / 0002 / 0009" comments and the `test_t3_rls_policies_match_post_0008_state` name removed from `test_migrations_e2e.py`.

13 files, +78/-53. Full breakdown in the commit body and in #287.

## Test plan

- [ ] `make check` green in CI (this PR).
- [ ] On a fresh checkout: `make setup && make api-migrate && make api-seed && make health` should be all-OK with no Clerk error on Web.
- [ ] Spot-check the contributor path: README → Get started → `make setup` → CONTRIBUTING.md → developer / design-system / adr / GLOSSARY links all resolve to current truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)