### PR TITLE
docs(#288): AGENTS.md canonical agent entry point + CLAUDE/GEMINI shims

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,10 @@ repos:
       # would fail on every commit until the very last TODO is replaced).
       # That gate runs in CI only on the final-acceptance PR and on push to
       # main; locally invoke via `make test-v1-captions-authored`.
+
+      - id: agents-md
+        name: AGENTS.md mechanical checks (line budget / internal links / cross-mentions)
+        entry: bash scripts/check-agents-md.sh
+        language: system
+        files: '^(AGENTS|README|CLAUDE|GEMINI)\.md$'
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md — entry point for AI coding assistants
+
+You are an AI agent working on **COREcare v2**, a multi-tenant SaaS for home-care agencies. Stack: FastAPI · Next.js 15 · shadcn/ui · PostgreSQL 16 (RLS) · Clerk · Claude API · Docker Compose. This file is the canonical, tool-agnostic reference for *any* AI assistant. Tool-specific files ([`CLAUDE.md`](CLAUDE.md), [`GEMINI.md`](GEMINI.md)) carry only what is unique to those tools.
+
+## Verify
+
+Run `make check` before committing. It is the canonical pre-PR gate; CI runs the same target — if CI fails, `make check` reproduces it locally.
+
+`make check` executes:
+
+- `uv run ruff check .` — Python linting
+- `uv run ruff format --check .` — Python formatting (line-length 100, **not** 88)
+- `uv run mypy app/` — Python type checking
+- `pytest` — API test suite
+- `eslint + prettier` — web linting
+- `tsc` — web type checking
+- `vitest` — web unit tests
+- `next build` — web production build
+- Several slash-command invariant tests under `scripts/tests/`
+- LFS workflow posture check
+
+If a sub-step fails, the troubleshooting matrix in [`CONTRIBUTING.md`](CONTRIBUTING.md#troubleshooting) lists the fix command (e.g., `cd api && uv run ruff format .`). For runtime health: `make health`.
+
+## Don't touch
+
+Each entry is **path → consequence**. Read the linked issue or ADR before editing.
+
+| Path | Consequence |
+|---|---|
+| `docs/legacy/v1-ui-catalog/` | Git LFS-backed; hand-edits break LFS invariants. See [ADR-010](docs/adr/010-v1-ui-catalog-storage.md). |
+| `api/alembic/versions/` | Schema scaffolding is a known gap — do not fabricate migrations. See [#240](https://github.com/suniljames/COREcare-v2/issues/240). |
+| `api/app/auth.py` | Boot-blocking invariants live here; refuses to start in non-development environments without correct configuration. See [#241](https://github.com/suniljames/COREcare-v2/issues/241). |
+| `web/.env.local.example` | Holds a value required for local boot; removing or "cleaning up" entries breaks `pnpm dev`. See [`CONTRIBUTING.md`](CONTRIBUTING.md). |
+| Files marked `# generated` (or similar) | Regenerate via the documented script — do not hand-edit. |
+| `.pre-commit-config.yaml` v1-* hooks | Gate the v1 catalog migration; alter only with the migration owner. |
+
+Do **not** copy seed credentials, dummy keys, internal hostnames, or environment-variable values into this file or other public docs — link to the existing location instead.
+
+## Repo map (code directories)
+
+Documentation directories are routed by [`docs/README.md`](docs/README.md). For code:
+
+| Path | What lives here |
+|---|---|
+| [`api/app/routers/`](api/app/routers/) | FastAPI route handlers — thin; delegate to services |
+| [`api/app/services/`](api/app/services/) | Business logic |
+| [`api/app/models/`](api/app/models/) | SQLModel definitions |
+| [`api/app/schemas/`](api/app/schemas/) | Pydantic request/response schemas |
+| [`api/app/tests/`](api/app/tests/) | API tests (pytest + httpx) |
+| [`api/alembic/`](api/alembic/) | Migration framework — see don't-touch above |
+| [`web/src/app/`](web/src/app/) | Next.js 15 App Router pages |
+| [`web/src/lib/`](web/src/lib/) | Shared utilities (no React) |
+| [`web/src/__tests__/`](web/src/__tests__/) | Web unit tests (vitest) |
+| [`web/e2e/`](web/e2e/) | E2E tests (Playwright) |
+| [`scripts/`](scripts/) | Bash helpers, pre-commit hooks, coldreader |
+| [`tools/`](tools/) | Long-running tooling (e.g., v1 screenshot catalog) |
+| [`docs/`](docs/) | All documentation — start at [`docs/README.md`](docs/README.md) |
+
+Default to **server components** in `web/src/app/`; switch to client components only for interactivity. API code is **routers → services → models** — no business logic in routers.
+
+## Conventions
+
+- **Branch:** `<type>/<issue>-<short-desc>` (e.g., `docs/288-agents-md`).
+- **Commit:** `<type>(#<issue>): <subject>`.
+- **Every change links to a GitHub issue** ([#213](https://github.com/suniljames/COREcare-v2/issues/213)).
+- **Issue numbers in code, docs, and PRs are intentional anchors.** When in doubt, run `gh issue view <n>` for context — it is cheap and high-signal.
+- **Branch base** must be freshly-fetched `origin/main`, never stale local `main` ([#176](https://github.com/suniljames/COREcare-v2/issues/176)).
+- See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full PR workflow, test-account roster, and `make` target reference.
+
+## Tool routing
+
+- **Claude Code:** read [`CLAUDE.md`](CLAUDE.md) — builder-role assignment plus pipeline commands (`/define`, `/design`, `/implement`, `/review`, `/summarize`).
+- **Gemini-based validators:** read [`GEMINI.md`](GEMINI.md) — validator-role assignment.
+- **All other agents** (OpenAI Codex CLI, Cursor, Aider, Sourcegraph Cody, etc.): this file is your canonical reference. The pipeline slash-commands above are Claude-specific and will not work in your tool — follow the conventions in this file and operate as a regular contributor.
+
+## Domain glossary
+
+This is a healthcare product. Before reasoning about domain terms (*persona*, *tenant*, *agency*, *client*, *caregiver*, *family member*, *RLS*, *PHI*, *ADLs*), consult [`docs/GLOSSARY.md`](docs/GLOSSARY.md) — generic definitions don't carry over. PHI-handling rules live in [`docs/developer/SAFETY.md`](docs/developer/SAFETY.md); architecture and patterns live in [`docs/developer/ARCHITECTURE.md`](docs/developer/ARCHITECTURE.md); past decisions in [`docs/adr/`](docs/adr/).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,16 @@
-# COREcare v2 — Claude Code Agent Config
+# COREcare v2 — Claude Code
 
-> **For Claude Code users.** If you're not using Claude Code as your editor, you can skip this file — start at [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
+> **Read [`AGENTS.md`](AGENTS.md) first.** This file carries only what's unique to Claude Code; shared agent guidance (verify, don't-touch, repo map, conventions, glossary) lives in `AGENTS.md`.
 
-Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first.
+You are the **builder** agent for this repo (per the [engineering team manifest](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) — all roles where `agent: builder`). When operating without an orchestrator, assume validator roles as separate review passes.
 
-Project-specific docs:
-- [`docs/developer/ARCHITECTURE.md`](docs/developer/ARCHITECTURE.md) — codebase patterns
-- [`docs/developer/TESTING.md`](docs/developer/TESTING.md) — test tools and conventions
-- [`docs/developer/SAFETY.md`](docs/developer/SAFETY.md) — project-specific safety rules
-- [`docs/developer/code-review-lenses.md`](docs/developer/code-review-lenses.md) — tech-specific review checklists
-- [`docs/developer/project-context.md`](docs/developer/project-context.md) — project-specific persona knowledge
+## Pipeline commands
+
+The slash-commands in [`.claude/commands/`](.claude/commands/) — `/define`, `/design`, `/implement`, `/review`, `/summarize` — are Claude-specific and will not work in other AI tools.
 
 ## Shared Claude Code magic
 
-This project inherits shared hooks and scripts from [`suniljames/dotfiles`](https://github.com/suniljames/dotfiles). `.claude/settings.json` references hooks at `$HOME/.claude/hooks/*` with graceful no-op fallback if dotfiles isn't installed on the machine.
+This project inherits hooks and scripts from [`suniljames/dotfiles`](https://github.com/suniljames/dotfiles). `.claude/settings.json` references hooks at `$HOME/.claude/hooks/*` with graceful no-op fallback if dotfiles isn't installed on the machine.
 
 To activate hooks locally:
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,39 +1,19 @@
-# COREcare v2 — Gemini Agent Config
+# COREcare v2 — Gemini
 
-> **For Gemini agent users.** If you're not running a Gemini-based validator agent against this repo, you can skip this file — start at [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md).
+> **Read [`AGENTS.md`](AGENTS.md) first.** This file carries only what's unique to Gemini-based validator agents; shared agent guidance (verify, don't-touch, repo map, conventions, glossary) lives in `AGENTS.md`.
 
-You are the **validator** agent. Read [`CONTRIBUTING.md`](CONTRIBUTING.md) first, then the [engineering directives](https://github.com/suniljames/directives).
+You are the **validator** agent for this repo (per the [engineering team manifest](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) — all roles where `agent: validator`). Read each persona file to understand your responsibilities:
 
-Project-specific docs:
-- [`docs/developer/ARCHITECTURE.md`](docs/developer/ARCHITECTURE.md) — codebase patterns
-- [`docs/developer/TESTING.md`](docs/developer/TESTING.md) — test tools and conventions
-- [`docs/developer/SAFETY.md`](docs/developer/SAFETY.md) — project-specific safety rules
-- [`docs/developer/code-review-lenses.md`](docs/developer/code-review-lenses.md) — tech-specific review checklists
-- [`docs/developer/project-context.md`](docs/developer/project-context.md) — project-specific persona knowledge
-
----
-
-## Your Roles
-
-You are the **validator** agent. Your roles are defined in the [engineering team manifest](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) — all roles where `agent: validator`.
-
-Read each persona file to understand your responsibilities:
 - [Security Engineer](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/security-engineer.md)
 - [QA Engineer](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/qa-engineer.md)
 - [Writer](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/writer.md)
 - [PM](https://github.com/suniljames/directives/blob/main/teams/engineering/personas/pm.md)
 
-Roles you do NOT own (builder agent's): all roles where `agent: builder` in the manifest. File findings; don't fix.
+For PRDs, use the [template](https://github.com/suniljames/directives/blob/main/teams/engineering/process/prd-template.md) plus [healthcare addendum](https://github.com/suniljames/directives/blob/main/overlays/healthcare/prd-addendum.md). Use severity levels from the manifest's `vocabularies.severity_levels` when posting review findings.
 
-## What You Produce
-
-See the [pipeline stages](https://github.com/suniljames/directives/blob/main/teams/engineering/manifest.yml) for your responsibilities at each stage. Use severity levels from the manifest's `vocabularies.severity_levels` when posting review findings.
-
-For PRDs, use the [template](https://github.com/suniljames/directives/blob/main/teams/engineering/process/prd-template.md) + [healthcare addendum](https://github.com/suniljames/directives/blob/main/overlays/healthcare/prd-addendum.md).
-
-## What NOT to Do
+## What NOT to do
 
 - Do not write production code.
 - Do not merge PRs.
 - Do not deploy.
-- Do not perform roles you don't own.
+- Do not perform builder-agent roles. File findings; don't fix.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Read [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full development workflow, the
 | Direct link | When to use it |
 |---|---|
 | [`CONTRIBUTING.md`](CONTRIBUTING.md) | First-day setup + branch / commit / PR conventions |
+| [`AGENTS.md`](AGENTS.md) | Canonical entry point for AI coding assistants (verify command, repo map, don't-touch list) |
 | [`docs/developer/`](docs/developer/) | Architecture, testing, safety, code review |
 | [`docs/design-system/`](docs/design-system/) | Frontend tokens, components, accessibility |
 | [`docs/adr/`](docs/adr/) | 11 numbered Architecture Decision Records |

--- a/scripts/check-agents-md.sh
+++ b/scripts/check-agents-md.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Mechanical checks for AGENTS.md (per issue #288 acceptance criteria).
+#
+# Asserts:
+#   1. AGENTS.md exists at repo root.
+#   2. Line count <= 150 (reading-budget guard for AI agents).
+#   3. Every repo-relative link in AGENTS.md resolves to an existing file or
+#      directory. External URLs (http/https/mailto) are not validated here —
+#      they go stale and would flake the hook.
+#   4. README.md, CLAUDE.md, and GEMINI.md each mention AGENTS.md (the
+#      cross-mention discoverability invariant from the design committee).
+#
+# Run manually: bash scripts/check-agents-md.sh
+# Pre-commit:  fires on changes to AGENTS.md, README.md, CLAUDE.md, GEMINI.md.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+FAIL=0
+fail() { echo "FAIL: $*" >&2; FAIL=1; }
+
+# ── 1. AGENTS.md exists ──────────────────────────────────────────────────────
+if [[ ! -f AGENTS.md ]]; then
+  fail "AGENTS.md not found at repo root"
+  exit 1
+fi
+
+# ── 2. Line-count budget ─────────────────────────────────────────────────────
+MAX_LINES=150
+LINES=$(wc -l < AGENTS.md | tr -d ' ')
+if (( LINES > MAX_LINES )); then
+  fail "AGENTS.md is $LINES lines (max $MAX_LINES). Trim before merging."
+fi
+
+# ── 3. Internal-link check ───────────────────────────────────────────────────
+# Match markdown links: [text](target). Capture the target. Skip external,
+# mailto, anchor-only, and image-style links. Check that the file or dir
+# referenced exists relative to the repo root.
+while IFS= read -r target; do
+  # Strip anchor fragment (e.g. "docs/file.md#section" -> "docs/file.md").
+  path="${target%%#*}"
+  [[ -z "$path" ]] && continue                  # pure anchors like (#foo)
+  [[ "$path" =~ ^https?:// ]] && continue       # external URLs
+  [[ "$path" =~ ^mailto: ]] && continue
+  [[ "$path" =~ ^// ]] && continue              # protocol-relative (rare)
+  if [[ ! -e "$path" && ! -d "$path" ]]; then
+    fail "AGENTS.md links to '$path' which does not exist"
+  fi
+done < <(grep -oE '\]\([^)]+\)' AGENTS.md | sed -E 's/^\]\(//; s/\)$//')
+
+# ── 4. Cross-mention discoverability ────────────────────────────────────────
+for f in README.md CLAUDE.md GEMINI.md; do
+  if [[ ! -f "$f" ]]; then
+    fail "$f not found at repo root (cross-mention check skipped)"
+    continue
+  fi
+  if ! grep -q 'AGENTS\.md' "$f"; then
+    fail "$f does not mention AGENTS.md (discoverability invariant)"
+  fi
+done
+
+if (( FAIL == 0 )); then
+  echo "AGENTS.md: $LINES/$MAX_LINES lines, links resolve, cross-mentions present."
+fi
+exit "$FAIL"


### PR DESCRIPTION
Closes #288

## Summary

- Adds `AGENTS.md` at repo root — the cross-tool convention that OpenAI Codex CLI, Cursor, Aider, and Sourcegraph Cody all read first; without it, those agents start cold and burn ~20 exploratory tool calls per session.
- Refactors `CLAUDE.md` (29 → 23 lines) and `GEMINI.md` (40 → 18 lines) to thin shims that retain only tool-specific content and link to `AGENTS.md` for everything universal. Per @System Architect: one source of truth for shared guidance, role-specific overlays for the rest — prevents drift across three agent-config files.
- Adds `scripts/check-agents-md.sh` and a pre-commit hook (`agents-md`) that mechanically enforce the design committee's invariants: line count ≤ 150, every internal link resolves, sibling files cross-mention `AGENTS.md`.
- `README.md` Documentation table picks up an `AGENTS.md` row.

`AGENTS.md` sections (in order, per @Writer's *prevent damage before enabling action*):

1. One-line orientation
2. Verify — `make check` sub-steps + CI-parity callout
3. Don't touch — path → consequence (no sensitive rationale per @Security MUST-FIX)
4. Repo map — code dirs only (docs are routed by `docs/README.md`)
5. Conventions — branch/commit/issue-anchor; `gh issue view <n>` recommendation
6. Tool routing — Claude → `CLAUDE.md`, Gemini → `GEMINI.md`, all others stay here
7. Domain glossary — pointer to `docs/GLOSSARY.md`

## Test Plan

### Mechanical (pre-commit, blocking)

- [x] `agents-md` hook passes: AGENTS.md is 78/150 lines, all internal links resolve, README/CLAUDE/GEMINI all cross-mention `AGENTS.md`.
- [x] `make check` exits 0: API ruff/mypy/pytest (364 passed, 3 skipped), web lint/typecheck/vitest (7 passed)/next build, 30 slash-command invariant tests, 11 LFS posture tests.
- [ ] CI passes (will verify post-push).
- [ ] Docker health check passes (`make health` after `docker compose up --build -d`).

### Behavioral (manual — to capture as PR comment after CI is green)

- [ ] **Codex-style agent** prompted *"Where do API routes live, what command verifies a change, and what's off-limits to edit?"* answers correctly using only `AGENTS.md` — no other file reads. Recommend OpenAI Codex CLI (`npm i -g @openai/codex`); Cursor or Aider acceptable substitutes.
- [ ] **Claude Code regression**: reading `CLAUDE.md` redirects to `AGENTS.md` for shared guidance; pipeline commands `/define`, `/implement` etc. still work.
- [ ] **Gemini regression**: reading `GEMINI.md` redirects to `AGENTS.md`; retains validator role assignment.

### Reviewer-attention items (not CI-testable, per @Security)

- [ ] Don't-touch entries phrased as **path → consequence only** — no sensitive rationale.
- [ ] No seed passwords, dummy keys, internal hostnames, or env-var values duplicated into `AGENTS.md`.

## Out of scope (filed as follow-ups if `AGENTS.md` proves its value)

- Nested `AGENTS.md` files in `api/` and `web/` (Codex directory-merge pattern).
- `STATE.md` / "current focus" file pointing at active milestones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)