### PR TITLE
fix(#292): default CLERK_SECRET_KEY for web to a format-valid dummy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,13 @@ services:
       # exporting CLERK_PUBLISHABLE_KEY (or setting it in a project-root .env
       # that docker compose loads) to test live Clerk auth.
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${CLERK_PUBLISHABLE_KEY:-pk_test_Y2xlcmsuaW5jbHVkZWQua2F0eWRpZC05Mi5sY2wuZGV2JA}
-      CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-}
+      # clerkMiddleware throws "Missing secretKey" at runtime on every request
+      # when CLERK_SECRET_KEY is empty, so localhost:3000 returns 500 on every
+      # route. Provide a format-valid dummy so a fresh checkout is navigable
+      # without a Clerk account. The api service deliberately keeps an empty
+      # CLERK_SECRET_KEY (above) so its dev fallback in app/auth.py keeps
+      # mocking super_admin. Real auth requires real keys for both services.
+      CLERK_SECRET_KEY: ${CLERK_SECRET_KEY:-sk_test_dummylocaldevkey}
     volumes:
       - ./web:/app
       - /app/node_modules


### PR DESCRIPTION
## Summary

Closes #292. Follow-up to #289 (which closed #287). #289 fixed the publishable-key wiring (B1 in #287) but the SK error was masked behind it. With the PK now valid, `clerkMiddleware` throws `"Missing secretKey"` at request time on every route — `localhost:3000` returns 500 on a fresh clone, even on the public `/` route. Hazel still couldn't browse the web UI.

Same pattern as #289's publishable-key default: web service gets a format-valid dummy SK; the api service intentionally keeps `${CLERK_SECRET_KEY:-}` (empty) so the dev fallback in `api/app/auth.py` keeps mocking `super_admin`. When a real `CLERK_SECRET_KEY` is exported, both services pick it up.

## Test plan

Verified on a fresh `/tmp/corecare-smoke` clone of `main` with this branch's compose:

- [x] `curl http://localhost:3000/` → status 200 (was 500)
- [x] `make health` → API/Web/DB/Redis all OK (was Web: FAIL)
- [x] API dev fallback still active (no-Authorization request resolves to `super_admin`)
- [ ] CI green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)