### PR TITLE
docs(#297): add bespoke-v2-design callout to Agency Admin section (cold-reader q3 drift)

### DIFF
--- a/docs/migration/v1-pages-inventory.md
+++ b/docs/migration/v1-pages-inventory.md
@@ -146,6 +146,11 @@ Agency Admin pages cover scheduling, billing, payroll, credentialing, compliance
 
 A small subset of rows in the `top-level (elitecare/urls.py)` group are gated on Django's stock `is_superuser` boolean rather than the Agency Admin role grant — v1 has no Super-Admin role, so these platform-operator surfaces are folded here with `rls_bypass_by_design=true`. v2 design is expected to introduce a dedicated platform-operator boundary for these routes; the merged rows preserve that intent in their `purpose` cells.
 
+**Screens needing bespoke v2 design treatment.** Two categories in this section warrant deliberate v2 design rather than a mechanical port:
+
+1. **PHI-displaying screens** — rows marked `🔒 PHI ·` (carrying `phi_displayed=true` in the row table), concentrated in [`### charting`](#charting) (the clinical surface — health reports, chart templates, the staff approval queue), [`### clients`](#clients) (per-client calendars and events rendering linked-client data with attachments), [`### compliance`](#compliance) (the two authenticated PHI file-stream routes mounted at `compliance/files/` — physician-order proofs and service-signature images), and [`### billing`](#billing) (invoice lists, single-client billing PDFs, the client billing-email flow, and QuickBooks invoice sends). The `/admin/expenses/review/...` routes in the `top-level (elitecare/urls.py)` group also carry `phi_displayed=true`.
+2. **Admin-elevation / RLS-bypass screens** — `/admin/view-as/kill-all/` is the platform-operator kill-switch that terminates every active impersonation session at once, gated on Django's stock `is_superuser` flag rather than the Agency Admin role grant (folded into this section per [#236](https://github.com/suniljames/COREcare-v2/issues/236) because v1 has no Super-Admin role). v2 must add a comparable platform-operator gate distinct from Agency Admin role authority — see the `rls_bypass_by_design=true` rows in the `top-level (elitecare/urls.py)` group.
+
 <a id="agency-admin-top-level"></a>
 ### top-level (elitecare/urls.py)
 _admin-prefixed routes registered directly in the project root, outside any include()_


### PR DESCRIPTION
## Summary

Closes #297. The weekly cold-reader rotation ([run 25662255854](https://github.com/suniljames/COREcare-v2/actions/runs/25662255854)) flagged drift on `agency-admin/q3` — the model's answer scored 5/7 `must_mention` tokens (tolerance 1), missing `compliance` and `billing`.

**Root cause:** #236/#265 folded the `/admin/view-as/kill-all/` row into the Agency Admin section with heavy `is_superuser`/impersonation framing; #251/#278 then grew the q3 fixture from 5→7 `must_mention` groups (adding `kill-all`, `is_superuser`) without loosening tolerance. q3 now asks the cold-reader to enumerate two distinct categories in one answer, and the model anchored on the newer admin-elevation content at the expense of the older PHI-screen content.

**Fix:** add an explicit "Screens needing bespoke v2 design treatment" callout to the section intro that enumerates both categories — (1) PHI-displaying screens in `charting`/`clients`/`compliance`/`billing` (`🔒 PHI` / `phi_displayed=true`), (2) the admin-elevation `/admin/view-as/kill-all/` row gated on `is_superuser`. A cold reader no longer has to synthesize this by scanning every row's `🔒 PHI` marker — the callout names all seven `must_mention` surfaces directly.

**Fixture left unchanged on purpose.** Bumping `tolerance` to 2 would let this exact regression pass silently next Monday — that defeats the drift detector. The right fix is making the section reliably answerable.

## Test plan

- [ ] CI green (v1 doc hygiene + structure + catalog coverage checks)
- [ ] After merge, re-run `v1-inventory-coldreader.yml` → expect agency-admin/q3 at 7/7 → #297 auto-closes
- [x] Anchors `#charting` / `#clients` / `#compliance` / `#billing` verified to resolve to the Agency Admin H3 subsections (first occurrence in the file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)